### PR TITLE
Auto create table: When PK is empty, set ORDER BY to ORDER BY tuple()

### DIFF
--- a/src/main/java/com/altinity/clickhouse/sink/connector/db/operations/ClickHouseAutoCreateTable.java
+++ b/src/main/java/com/altinity/clickhouse/sink/connector/db/operations/ClickHouseAutoCreateTable.java
@@ -79,7 +79,7 @@ public class ClickHouseAutoCreateTable extends ClickHouseTableOperationsBase{
             createTableSyntax.append(")");
         } else {
             // ToDO:
-            createTableSyntax.append("ORDER BY(ver)");
+            createTableSyntax.append("ORDER BY tuple()");
         }
        return createTableSyntax.toString();
     }


### PR DESCRIPTION
https://github.com/ClickHouse/ClickHouse/issues/9521#selecting-the-primary-key