### PR TITLE
Fix COLLAPSING_MERGE_TREE `Update` statement

### DIFF
--- a/src/main/java/com/altinity/clickhouse/sink/connector/db/DbWriter.java
+++ b/src/main/java/com/altinity/clickhouse/sink/connector/db/DbWriter.java
@@ -401,6 +401,7 @@ public class DbWriter extends BaseDbWriter {
             try (PreparedStatement ps = this.conn.prepareStatement(insertQuery)) {
 
                 List<ClickHouseStruct> recordsList = entry.getValue();
+                boolean beforeInserted = false;
                 for (ClickHouseStruct record : recordsList) {
                     try {
                         bmd.update(record);
@@ -418,9 +419,15 @@ public class DbWriter extends BaseDbWriter {
                         insertPreparedStatement(entry.getKey().right, ps, record.getAfterModifiedFields(), record, record.getAfterStruct(), false);
                     } else if(CdcRecordState.CDC_RECORD_STATE_BOTH == getCdcSectionBasedOnOperation(record.getCdcOperation()))  {
                         if(this.engine != null && this.engine.getEngine().equalsIgnoreCase(DBMetadata.TABLE_ENGINE.COLLAPSING_MERGE_TREE.getEngine())) {
-                            insertPreparedStatement(entry.getKey().right, ps, record.getBeforeModifiedFields(), record, record.getBeforeStruct(), true);
+                            if (!beforeInseted) {
+                                insertPreparedStatement(entry.getKey().right, ps, record.getBeforeModifiedFields(), record, record.getBeforeStruct(), true);
+                            } else {
+                                insertPreparedStatement(entry.getKey().right, ps, record.getAfterModifiedFields(), record, record.getAfterStruct(), false);
+                            }
+                            beforeInseted = !beforeInseted;
+                        } else {
+                            insertPreparedStatement(entry.getKey().right, ps, record.getAfterModifiedFields(), record, record.getAfterStruct(), false);
                         }
-                        insertPreparedStatement(entry.getKey().right, ps, record.getAfterModifiedFields(), record, record.getAfterStruct(), false);
                     } else {
                         log.error("INVALID CDC RECORD STATE");
                     }


### PR DESCRIPTION
It would insert an empty statement, which covered the `before` statement. Now I insert a `before` statement first and then insert an `after` statement.