### PR TITLE
Adding scripts to test classic databases

### DIFF
--- a/deploy/configure_airport-db.sh
+++ b/deploy/configure_airport-db.sh
@@ -1,0 +1,5 @@
+DATABASE=airportdb
+./debezium-delete.sh &&  ./debezium-connector-setup-database.sh $DATABASE && ./sink-delete.sh && ./sink-connector-setup-database.sh $DATABASE
+./debezium-delete.sh &&  ./debezium-connector-setup-database.sh $DATABASE && ./sink-delete.sh && ./sink-connector-setup-database.sh $DATABASE
+docker exec -it clickhouse clickhouse-client -uroot --password root -mn --query "drop database if exists $DATABASE;create database $DATABASE;"
+docker exec -it mysql-master mysql -uroot -proot -e ""

--- a/deploy/configure_employees.sh
+++ b/deploy/configure_employees.sh
@@ -1,0 +1,15 @@
+DATABASE=employees
+./debezium-delete.sh &&  ./debezium-connector-setup-database.sh $DATABASE && ./sink-delete.sh && ./sink-connector-setup-database.sh $DATABASE
+./debezium-delete.sh &&  ./debezium-connector-setup-database.sh $DATABASE && ./sink-delete.sh && ./sink-connector-setup-database.sh $DATABASE
+docker exec -it clickhouse clickhouse-client -uroot --password root -mn --query "drop database if exists $DATABASE;create database $DATABASE;"
+docker cp  $HOME/test_db/employees.sql mysql-master:/
+docker cp  $HOME/test_db/show_elapsed.sql mysql-master:/
+docker cp  $HOME/test_db/load_departments.dump mysql-master:/
+docker cp  $HOME/test_db/load_dept_emp.dump mysql-master:/
+docker cp  $HOME/test_db/load_dept_manager.dump mysql-master:/
+docker cp  $HOME/test_db/load_employees.dump mysql-master:/
+docker cp  $HOME/test_db/load_salaries1.dump mysql-master:/
+docker cp  $HOME/test_db/load_salaries2.dump mysql-master:/
+docker cp  $HOME/test_db/load_salaries3.dump mysql-master:/
+docker cp  $HOME/test_db/load_titles.dump mysql-master:/
+docker exec -it mysql-master mysql -uroot -proot -e "source /employees.sql"

--- a/deploy/configure_menagerie.sh
+++ b/deploy/configure_menagerie.sh
@@ -1,0 +1,13 @@
+DATABASE=menagerie
+./debezium-delete.sh &&  ./debezium-connector-setup-database.sh $DATABASE && ./sink-delete.sh && ./sink-connector-setup-database.sh $DATABASE
+./debezium-delete.sh &&  ./debezium-connector-setup-database.sh $DATABASE && ./sink-delete.sh && ./sink-connector-setup-database.sh $DATABASE
+docker exec -it clickhouse clickhouse-client -uroot --password root -mn --query "drop database if exists $DATABASE;create database $DATABASE;"
+docker cp  menagerie-db/cr_pet_tbl.sql mysql-master:/
+docker cp  menagerie-db/pet.txt mysql-master:/
+docker cp  menagerie-db/ins_puff_rec.sql mysql-master:/
+docker cp  menagerie-db/cr_event_tbl.sql mysql-master:/
+docker cp  menagerie-db/event.txt mysql-master:/
+docker exec -it mysql-master mysql -uroot -proot -e "DROP DATABASE IF EXISTS $DATABASE;CREATE DATABASE $DATABASE;"
+docker exec -it mysql-master mysql -uroot -proot -e "use $DATABASE;SOURCE cr_pet_tbl.sql;SOURCE ins_puff_rec.sql;SOURCE cr_event_tbl.sql;"
+docker exec -it mysql-master mysqlimport -uroot -proot --local menagerie pet.txt
+docker exec -it mysql-master mysqlimport -uroot -proot --local menagerie event.txt

--- a/deploy/configure_sakila.sh
+++ b/deploy/configure_sakila.sh
@@ -1,0 +1,7 @@
+DATABASE=sakila
+./debezium-delete.sh &&  ./debezium-connector-setup-database.sh $DATABASE && ./sink-delete.sh && ./sink-connector-setup-database.sh $DATABASE
+./debezium-delete.sh &&  ./debezium-connector-setup-database.sh $DATABASE && ./sink-delete.sh && ./sink-connector-setup-database.sh $DATABASE
+docker exec -it clickhouse clickhouse-client -uroot --password root -mn --query "drop database if exists $DATABASE;create database $DATABASE;"
+docker cp  sakila-db/sakila-schema.sql mysql-master:/tmp
+docker cp  sakila-db/sakila-data.sql mysql-master:/tmp
+docker exec -it mysql-master mysql -uroot -proot -e "source /tmp/sakila-schema.sql;source /tmp/sakila-data.sql;"

--- a/deploy/configure_sysbench.sh
+++ b/deploy/configure_sysbench.sh
@@ -1,0 +1,4 @@
+DATABASE=sbtest
+./debezium-delete.sh &&  ./debezium-connector-setup-database.sh $DATABASE && ./sink-delete.sh && ./sink-connector-setup-database.sh $DATABASE
+./debezium-delete.sh &&  ./debezium-connector-setup-database.sh $DATABASE && ./sink-delete.sh && ./sink-connector-setup-database.sh $DATABASE
+docker exec -it clickhouse clickhouse-client -uroot --password root -mn --query "drop database if exists $DATABASE;create database $DATABASE;"

--- a/deploy/configure_world-db.sh
+++ b/deploy/configure_world-db.sh
@@ -1,0 +1,6 @@
+DATABASE=world
+./debezium-delete.sh &&  ./debezium-connector-setup-database.sh $DATABASE && ./sink-delete.sh && ./sink-connector-setup-database.sh $DATABASE
+./debezium-delete.sh &&  ./debezium-connector-setup-database.sh $DATABASE && ./sink-delete.sh && ./sink-connector-setup-database.sh $DATABASE
+docker exec -it clickhouse clickhouse-client -uroot --password root -mn --query "drop database if exists $DATABASE;create database $DATABASE;"
+docker cp  world-db/world.sql mysql-master:/
+docker exec -it mysql-master mysql -uroot -proot -e "source /world.sql"

--- a/deploy/configure_world_x-db.sh
+++ b/deploy/configure_world_x-db.sh
@@ -1,0 +1,6 @@
+DATABASE=world
+./debezium-delete.sh &&  ./debezium-connector-setup-database.sh $DATABASE && ./sink-delete.sh && ./sink-connector-setup-database.sh $DATABASE
+./debezium-delete.sh &&  ./debezium-connector-setup-database.sh $DATABASE && ./sink-delete.sh && ./sink-connector-setup-database.sh $DATABASE
+docker exec -it clickhouse clickhouse-client -uroot --password root -mn --query "drop database if exists $DATABASE;create database $DATABASE;"
+docker cp  world_x-db/world_x.sql mysql-master:/
+docker exec -it mysql-master mysql -uroot -proot -e "source /world_x.sql"

--- a/deploy/configure_world_x-db.sh
+++ b/deploy/configure_world_x-db.sh
@@ -1,4 +1,4 @@
-DATABASE=world
+DATABASE=world_x
 ./debezium-delete.sh &&  ./debezium-connector-setup-database.sh $DATABASE && ./sink-delete.sh && ./sink-connector-setup-database.sh $DATABASE
 ./debezium-delete.sh &&  ./debezium-connector-setup-database.sh $DATABASE && ./sink-delete.sh && ./sink-connector-setup-database.sh $DATABASE
 docker exec -it clickhouse clickhouse-client -uroot --password root -mn --query "drop database if exists $DATABASE;create database $DATABASE;"

--- a/deploy/debezium-connector-setup-database.sh
+++ b/deploy/debezium-connector-setup-database.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# Source configuration
+CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+source "${CUR_DIR}/debezium-connector-config.sh"
+
+# Debezium parameters. Check
+# https://debezium.io/documentation/reference/stable/connectors/mysql.html#_required_debezium_mysql_connector_configuration_properties
+# for the full list of available properties
+
+MYSQL_HOST="mysql-master"
+MYSQL_PORT="3306"
+MYSQL_USER="root"
+MYSQL_PASSWORD="root"
+# Comma-separated list of regular expressions that match the databases for which to capture changes
+DATABASE=$1
+MYSQL_DBS="${DATABASE}"
+# Comma-separated list of regular expressions that match fully-qualified table identifiers of tables
+MYSQL_TABLES=""
+#KAFKA_BOOTSTRAP_SERVERS="one-node-cluster-0.one-node-cluster.redpanda.svc.cluster.local:9092"
+KAFKA_BOOTSTRAP_SERVERS="kafka:9092"
+KAFKA_TOPIC="schema-changes.${DATABASE}"
+
+# Connector joins the MySQL database cluster as another server (with this unique ID) so it can read the binlog.
+# By default, a random number between 5400 and 6400 is generated, though the recommendation is to explicitly set a value.
+DATABASE_SERVER_ID="5432"
+# Unique across all other connectors, used as a prefix for Kafka topic names for events emitted by this connector.
+# Alphanumeric characters, hyphens, dots and underscores only.
+DATABASE_SERVER_NAME="SERVER5432"
+
+if [[ $2 == "apicurio" ]]; then
+  echo "APICURIO SCHEMA REGISTRY"
+  A
+  ######       Connector  registration ######
+  cat <<EOF | curl --request POST --url "${CONNECTORS_MANAGEMENT_URL}" --header 'Content-Type: application/json' --data @-
+  {
+    "name": "${CONNECTOR_NAME}",
+    "config": {
+      "connector.class": "io.debezium.connector.mysql.MySqlConnector",
+      "tasks.max": "1",
+      "snapshot.mode": "initial",
+      "snapshot.locking.mode": "minimal",
+      "snapshot.delay.ms": 10000,
+      "include.schema.changes":"true",
+      "database.hostname": "${MYSQL_HOST}",
+      "database.port": "${MYSQL_PORT}",
+      "database.user": "${MYSQL_USER}",
+      "database.password": "${MYSQL_PASSWORD}",
+      "database.server.id": "${DATABASE_SERVER_ID}",
+      "database.server.name": "${DATABASE_SERVER_NAME}",
+      "database.whitelist": "${MYSQL_DBS}",
+      "database.allowPublicKeyRetrieval":"true",
+
+A
+      "database.history.kafka.bootstrap.servers": "${KAFKA_BOOTSTRAP_SERVERS}",
+      "database.history.kafka.topic": "${KAFKA_TOPIC}",
+
+      "key.converter": "io.apicurio.registry.utils.converter.AvroConverter",
+      "value.converter": "io.apicurio.registry.utils.converter.AvroConverter",
+
+      "key.converter.apicurio.registry.url": "http://schemaregistry:8080/apis/registry/v2",
+      "key.converter.apicurio.registry.auto-register": "true",
+      "key.converter.apicurio.registry.find-latest": "true",
+
+      "value.converter.apicurio.registry.url": "http://schemaregistry:8080/apis/registry/v2",
+      "value.converter.apicurio.registry.auto-register": "true",
+      "value.converter.apicurio.registry.find-latest": "true",
+
+      "topic.creation.$alias.partitions": 1,
+      "topic.creation.default.replication.factor": 1,
+      "topic.creation.default.partitions": 1,
+
+      "provide.transaction.metadata": "true"
+    }
+  }
+EOF
+else
+ echo "Using confluent schema registry"
+#https://debezium.io/documentation/reference/stable/configuration/avro.html
+      cat <<EOF | curl --request POST --url "${CONNECTORS_MANAGEMENT_URL}" --header 'Content-Type: application/json' --data @-
+      {
+        "name": "${CONNECTOR_NAME}",
+        "config": {
+          "connector.class": "io.debezium.connector.mysql.MySqlConnector",
+          "tasks.max": "1",
+          "snapshot.mode": "initial",
+          "snapshot.locking.mode": "minimal",
+          "snapshot.delay.ms": 10000,
+          "include.schema.changes":"true",
+          "include.schema.comments": "true",
+          "database.hostname": "${MYSQL_HOST}",
+          "database.port": "${MYSQL_PORT}",
+          "database.user": "${MYSQL_USER}",
+          "database.password": "${MYSQL_PASSWORD}",
+          "database.server.id": "${DATABASE_SERVER_ID}",
+          "database.server.name": "${DATABASE_SERVER_NAME}",
+          "database.whitelist": "${MYSQL_DBS}",
+          "database.allowPublicKeyRetrieval":"true",
+          "database.history.kafka.bootstrap.servers": "${KAFKA_BOOTSTRAP_SERVERS}",
+          "database.history.kafka.topic": "${KAFKA_TOPIC}",
+
+          "key.converter": "io.confluent.connect.avro.AvroConverter",
+          "value.converter": "io.confluent.connect.avro.AvroConverter",
+
+          "key.converter.schema.registry.url": "http://schemaregistry:8081",
+          "value.converter.schema.registry.url":"http://schemaregistry:8081",
+
+          "topic.creation.$alias.partitions": 6,
+          "topic.creation.default.replication.factor": 1,
+          "topic.creation.default.partitions": 6,
+
+          "provide.transaction.metadata": "true"
+        }
+      }
+EOF
+fi
+#binary.handling.mode

--- a/deploy/sink-connector-setup-database.sh
+++ b/deploy/sink-connector-setup-database.sh
@@ -10,19 +10,11 @@ CLICKHOUSE_HOST="clickhouse"
 CLICKHOUSE_PORT=8123
 CLICKHOUSE_USER="root"
 CLICKHOUSE_PASSWORD="root"
-CLICKHOUSE_TABLE="employees"
-CLICKHOUSE_DATABASE="test"
-
+CLICKHOUSE_TABLE="dummy"
+DATABASE=$1
+CLICKHOUSE_DATABASE="${DATABASE}"
+TOPICS_TABLE_MAP=""
 BUFFER_COUNT=10000
-
-#SERVER5432.transaction
-TOPICS="SERVER5432.sbtest.sbtest1"
-TOPICS_TABLE_MAP="SERVER5432.test.employees_predated:employees, SERVER5432.test.products:products"
-#TOPICS="SERVER5432"
-
-#"topics.regex": "SERVER5432.sbtest.(.*), SERVER5432.test.(.*)",
-
-#"topics": "${TOPICS}",
 
 if [[ $1 == "apicurio" ]]; then
       echo "APICURIO SCHEMA REGISTRY"
@@ -32,13 +24,14 @@ if [[ $1 == "apicurio" ]]; then
       "config": {
         "connector.class": "com.altinity.clickhouse.sink.connector.ClickHouseSinkConnector",
         "tasks.max": "10",
-        "topics": "${TOPICS}",
+        "topics.regex": "SERVER5432.${DATABASE}.(.*)", 
         "clickhouse.topic2table.map": "${TOPICS_TABLE_MAP}",
         "clickhouse.server.url": "${CLICKHOUSE_HOST}",
         "clickhouse.server.user": "${CLICKHOUSE_USER}",
         "clickhouse.server.pass": "${CLICKHOUSE_PASSWORD}",
         "clickhouse.server.database": "${CLICKHOUSE_DATABASE}",
         "clickhouse.server.port": ${CLICKHOUSE_PORT},
+#        "clickhouse.table.name": "${CLICKHOUSE_TABLE}",
         "key.converter": "io.apicurio.registry.utils.converter.AvroConverter",
         "value.converter": "io.apicurio.registry.utils.converter.AvroConverter",
 
@@ -80,13 +73,14 @@ else
     "config": {
       "connector.class": "com.altinity.clickhouse.sink.connector.ClickHouseSinkConnector",
       "tasks.max": "100",
-      "topics": "${TOPICS}",
+      "topics.regex": "SERVER5432.${DATABASE}.(.*)", 
       "clickhouse.topic2table.map": "${TOPICS_TABLE_MAP}",
       "clickhouse.server.url": "${CLICKHOUSE_HOST}",
       "clickhouse.server.user": "${CLICKHOUSE_USER}",
       "clickhouse.server.pass": "${CLICKHOUSE_PASSWORD}",
       "clickhouse.server.database": "${CLICKHOUSE_DATABASE}",
       "clickhouse.server.port": ${CLICKHOUSE_PORT},
+      "clickhouse.table.name": "${CLICKHOUSE_TABLE}",
       "key.converter": "io.confluent.connect.avro.AvroConverter",
       "value.converter": "io.confluent.connect.avro.AvroConverter",
       "key.converter.schema.registry.url": "http://schemaregistry:8081",

--- a/deploy/sink-connector-setup-schema-registry.sh
+++ b/deploy/sink-connector-setup-schema-registry.sh
@@ -45,6 +45,7 @@ if [[ $2 == "apicurio" ]]; then
         "clickhouse.server.pass": "${CLICKHOUSE_PASSWORD}",
         "clickhouse.server.database": "${CLICKHOUSE_DATABASE}",
         "clickhouse.server.port": ${CLICKHOUSE_PORT},
+        "clickhouse.table.name": "${CLICKHOUSE_TABLE}",
         "key.converter": "io.apicurio.registry.utils.converter.AvroConverter",
         "value.converter": "io.apicurio.registry.utils.converter.AvroConverter",
 
@@ -93,6 +94,7 @@ else
       "clickhouse.server.pass": "${CLICKHOUSE_PASSWORD}",
       "clickhouse.server.database": "${CLICKHOUSE_DATABASE}",
       "clickhouse.server.port": ${CLICKHOUSE_PORT},
+      "clickhouse.table.name": "${CLICKHOUSE_TABLE}",
       "key.converter": "io.confluent.connect.avro.AvroConverter",
       "value.converter": "io.confluent.connect.avro.AvroConverter",
       "key.converter.schema.registry.url": "http://schemaregistry:8081",

--- a/deploy/sink-connector-setup.sh
+++ b/deploy/sink-connector-setup.sh
@@ -30,6 +30,7 @@ cat <<EOF | curl --request POST --url "${CONNECTORS_MANAGEMENT_URL}" --header 'C
     "clickhouse.server.pass": "${CLICKHOUSE_PASSWORD}",
     "clickhouse.server.database": "${CLICKHOUSE_DATABASE}",
     "clickhouse.server.port": ${CLICKHOUSE_PORT},
+    "clickhouse.table.name": "${CLICKHOUSE_TABLE}",
     "key.converter": "org.apache.kafka.connect.json.JsonConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",
     "store.kafka.metadata": true


### PR DESCRIPTION
Work in progress. It assumes that the database files have been downloaded.

For airportdb, 

from the mysql-shell (docker call would be nice) :
```
MySQL>JS> util.loadDump("airport-db", {threads: 16, deferTableIndexes: "all",  ignoreVersion: true})
```