### PR TITLE
Fix version column parsing in ReplicatedReplacingMergeTree

### DIFF
--- a/src/main/java/com/altinity/clickhouse/sink/connector/db/DBMetadata.java
+++ b/src/main/java/com/altinity/clickhouse/sink/connector/db/DBMetadata.java
@@ -21,6 +21,8 @@ public class DBMetadata {
         COLLAPSING_MERGE_TREE("CollapsingMergeTree"),
         REPLACING_MERGE_TREE("ReplacingMergeTree"),
 
+        REPLICATED_REPLACING_MERGE_TREE("ReplicatedReplacingMergeTree"),
+
         MERGE_TREE("MergeTree"),
 
         DEFAULT("default");
@@ -130,6 +132,7 @@ public class DBMetadata {
     public static final String COLLAPSING_MERGE_TREE_SIGN_PREFIX = "CollapsingMergeTree(";
     public static final String REPLACING_MERGE_TREE_VER_PREFIX = "ReplacingMergeTree(";
 
+    public static final String REPLICATED_REPLACING_MERGE_TREE_VER_PREFIX = "ReplicatedReplacingMergeTree(";
     /**
      * Function to extract the sign column for CollapsingMergeTree
      * @param createDML
@@ -155,15 +158,24 @@ public class DBMetadata {
      */
     public String getVersionColumnForReplacingMergeTree(String createDML) {
 
-        String signColumn = "sign";
+        String versionColumn = "ver";
 
-        if(createDML.contains(TABLE_ENGINE.REPLACING_MERGE_TREE.getEngine())) {
-            signColumn = StringUtils.substringBetween(createDML, REPLACING_MERGE_TREE_VER_PREFIX, ")");
+        if(createDML.contains(TABLE_ENGINE.REPLICATED_REPLACING_MERGE_TREE.getEngine())) {
+            String parameters = StringUtils.substringBetween(createDML, REPLICATED_REPLACING_MERGE_TREE_VER_PREFIX, ")");
+            if(parameters != null) {
+                String[] parameterArray = parameters.split(",");
+                if(parameterArray != null && parameterArray.length >= 3) {
+                    versionColumn = parameterArray[2].trim();
+                }
+            }
+        }
+        else if(createDML.contains(TABLE_ENGINE.REPLACING_MERGE_TREE.getEngine())) {
+            versionColumn = StringUtils.substringBetween(createDML, REPLACING_MERGE_TREE_VER_PREFIX, ")").trim();
         } else {
             log.error("Error: Trying to retrieve ver from table that is not ReplacingMergeTree");
         }
 
-        return signColumn;
+        return versionColumn;
     }
     /**
      * Function to get table engine using system tables.
@@ -187,17 +199,7 @@ public class DBMetadata {
                 ResultSet rs = stmt.executeQuery(showSchemaQuery);
                 if(rs.next()) {
                     String response =  rs.getString(1);
-                    if(response.contains(TABLE_ENGINE.COLLAPSING_MERGE_TREE.engine)) {
-                        result.left = TABLE_ENGINE.COLLAPSING_MERGE_TREE;
-                        result.right = getSignColumnForCollapsingMergeTree(response);
-                    } else if(response.contains(TABLE_ENGINE.REPLACING_MERGE_TREE.engine)) {
-                        result.left = TABLE_ENGINE.REPLACING_MERGE_TREE;
-                        result.right = getVersionColumnForReplacingMergeTree(response);
-                    } else if(response.contains(TABLE_ENGINE.MERGE_TREE.engine)) {
-                        result.left = TABLE_ENGINE.MERGE_TREE;
-                    } else {
-                        result.left = TABLE_ENGINE.DEFAULT;
-                    }
+                    result = getEngineFromResponse(response);
                 }
                 rs.close();
                 stmt.close();
@@ -205,6 +207,24 @@ public class DBMetadata {
             }
         } catch(Exception e) {
             log.error("getTableEngineUsingSystemTables exception", e);
+        }
+
+        return result;
+    }
+
+    public MutablePair<TABLE_ENGINE, String> getEngineFromResponse(String response) {
+        MutablePair<TABLE_ENGINE, String> result = new MutablePair<>();
+
+        if(response.contains(TABLE_ENGINE.COLLAPSING_MERGE_TREE.engine)) {
+            result.left = TABLE_ENGINE.COLLAPSING_MERGE_TREE;
+            result.right = getSignColumnForCollapsingMergeTree(response);
+        } else if(response.contains(TABLE_ENGINE.REPLACING_MERGE_TREE.engine)) {
+            result.left = TABLE_ENGINE.REPLACING_MERGE_TREE;
+            result.right = getVersionColumnForReplacingMergeTree(response);
+        } else if(response.contains(TABLE_ENGINE.MERGE_TREE.engine)) {
+            result.left = TABLE_ENGINE.MERGE_TREE;
+        } else {
+            result.left = TABLE_ENGINE.DEFAULT;
         }
 
         return result;

--- a/src/test/java/com/clickhouse/sink/connector/db/DBMetadataTest.java
+++ b/src/test/java/com/clickhouse/sink/connector/db/DBMetadataTest.java
@@ -3,6 +3,7 @@ package com.clickhouse.sink.connector.db;
 import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
 import com.altinity.clickhouse.sink.connector.db.DBMetadata;
 import com.altinity.clickhouse.sink.connector.db.DbWriter;
+import org.apache.commons.lang3.tuple.MutablePair;
 import org.junit.Assert;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -73,6 +74,26 @@ public class DBMetadataTest {
 
         boolean result2 = new DBMetadata().checkIfDatabaseExists(writer.getConnection(), "newdb");
         Assert.assertFalse(result2);
+
+    }
+
+    @Test
+    public void testGetEngineFromResponse() {
+
+        String replacingMergeTree = "ReplacingMergeTree(ver) PRIMARY KEY dept_no ORDER BY dept_no SETTINGS index_granularity = 8192";
+        MutablePair<DBMetadata.TABLE_ENGINE, String> replacingMergeTreeResult = new DBMetadata().getEngineFromResponse(replacingMergeTree);
+
+        Assert.assertTrue(replacingMergeTreeResult.getRight().equalsIgnoreCase("ver"));
+        Assert.assertTrue(replacingMergeTreeResult.getLeft().getEngine().equalsIgnoreCase(DBMetadata.TABLE_ENGINE.REPLACING_MERGE_TREE.getEngine()));
+
+
+        String replicatedReplacingMergeTree = "ReplicatedReplacingMergeTree('/clickhouse/{cluster}/tables/dashboard_mysql_replication/favourite_products', '{replica}', ver) ORDER BY id SETTINGS allow_nullable_key = 1, index_granularity = 8192";
+
+        MutablePair<DBMetadata.TABLE_ENGINE, String> replicatedReplacingMergeTreeResult = new DBMetadata().getEngineFromResponse(replicatedReplacingMergeTree);
+
+        Assert.assertTrue(replicatedReplacingMergeTreeResult.getRight().equalsIgnoreCase("ver"));
+        Assert.assertTrue(replicatedReplacingMergeTreeResult.getLeft().getEngine().equalsIgnoreCase(DBMetadata.TABLE_ENGINE.REPLACING_MERGE_TREE.getEngine()));
+
 
     }
 }


### PR DESCRIPTION
Fix version column parsing in ReplicatedReplacingMergeTree

closes: #164 