### PR TITLE
[Fix] add registry to the clickhouse_debezium_embedded

### DIFF
--- a/sink-connector-lightweight/docker/clickhouse-sink-connector-lt-service.yml
+++ b/sink-connector-lightweight/docker/clickhouse-sink-connector-lt-service.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   clickhouse-sink-connector-lt:
-    image: ${CLICKHOUSE_SINK_CONNECTOR_LT_IMAGE}
+    image: registry.gitlab.com/altinity-public/container-images/clickhouse_debezium_embedded:${CLICKHOUSE_SINK_CONNECTOR_LT_IMAGE}
     entrypoint: ["sh", "-c", "java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Xms4g -Xmx4g -jar /app.jar /config.yml com.altinity.clickhouse.debezium.embedded.ClickHouseDebeziumEmbeddedApplication"]
     restart: "no"
     ports:


### PR DESCRIPTION
# What
Unable to setup clickhouse sink connector light weight version, with the latest branch. Getting repository does not exist.
<img width="1668" alt="Screenshot 2023-12-18 at 11 18 29 AM" src="https://github.com/Altinity/clickhouse-sink-connector/assets/44701159/fbdf8c31-3da0-4291-9ff4-beee3c4f17f1">

# Why
Based on the [docs](https://github.com/Altinity/clickhouse-sink-connector/blob/a59bc4bde4730d054709b041e7b87fb04fffd8c2/doc/quickstart.md?plain=1#L34), the existing `start_docker_compose.sh` just had an image version tag. Due to this it was using `latest` in the image of [clickhouse-sink-connector-lt](https://github.com/Altinity/clickhouse-sink-connector/blob/a59bc4bde4730d054709b041e7b87fb04fffd8c2/sink-connector-lightweight/docker/clickhouse-sink-connector-lt-service.yml#L5)

# Reference
Slack Thread: https://altinitydbworkspace.slack.com/archives/C02K1MWEK2L/p1702878772254419