### PR TITLE
[Fix] Export CLICKHOUSE_SINK_CONNECTOR_LT_IMAGE instead of SINK_LIGHTWEIGHT_VERSION

### DIFF
--- a/sink-connector-lightweight/docker/start-docker-compose.sh
+++ b/sink-connector-lightweight/docker/start-docker-compose.sh
@@ -4,9 +4,9 @@
 if [ -z $1 ]
 then
   echo 'Using the latest tag for Sink connector'
-  export SINK_LIGHTWEIGHT_VERSION='latest'
+  export CLICKHOUSE_SINK_CONNECTOR_LT_IMAGE='latest'
 else
-  export SINK_LIGHTWEIGHT_VERSION=$1
+  export CLICKHOUSE_SINK_CONNECTOR_LT_IMAGE=$1
 fi
 
 ./stop-docker-compose.sh


### PR DESCRIPTION
# What
In recent changes, SINK_LIGHTWEIGHT_VERSION is migrated to CLICKHOUSE_SINK_CONNECTOR_LT_IMAGE (#404). Thereby in [sink-connector-lightweight/docker/start-docker-compose.sh](https://github.com/Altinity/clickhouse-sink-connector/blob/develop/sink-connector-lightweight/docker/start-docker-compose.sh) `SINK_LIGHTWEIGHT_VERSION` was getting exported instead of `CLICKHOUSE_SINK_CONNECTOR_LT_IMAGE`.
 
# Why
If `CLICKHOUSE_SINK_CONNECTOR_LT_IMAGE` is not exported then it leads to an empty string in the image ID of `clickhouse-sink-connector-lt`