### PR TITLE
Fix ddl parser bugs

### DIFF
--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
@@ -11,6 +11,7 @@ import io.debezium.ddl.parser.mysql.generated.MySqlParser.AlterByAddColumnContex
 import io.debezium.ddl.parser.mysql.generated.MySqlParser.TableNameContext;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNodeImpl;
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -499,17 +500,26 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
         this.query.delete(0, this.query.toString().length()).append(String.format(Constants.ALTER_RENAME_TABLE, originalTableName, newTableName));
 
     }
+
     @Override
     public void enterAlterByAddCheckTableConstraint(MySqlParser.AlterByAddCheckTableConstraintContext alterByAddCheckTableConstraintContext) {
         // log.info("Enter check table constraint: " + alterByAddCheckTableConstraintContext.getText() );
         this.query.append(" ");
         for (ParseTree tree : alterByAddCheckTableConstraintContext.children) {
-            if (tree instanceof MySqlParser.PredicateExpressionContext) {
-                this.query.append(tree.getText());
-            } else if (tree instanceof MySqlParser.UidContext) {
-                this.query.append(tree.getText()).append(" ");
-            } else if (tree instanceof TerminalNodeImpl) {
-                this.query.append(tree.getText()).append(" ");
+            this.parseTreeHelper(tree);
+        }
+    }
+
+    private void parseTreeHelper(ParseTree child) {
+        if (child instanceof MySqlParser.UidContext) {
+            this.query.append(child.getText()).append(" ");
+        } else if (child instanceof MySqlParser.ComparisonOperatorContext) {
+            this.query.append(child.getText());
+        } else if (child instanceof TerminalNodeImpl) {
+            this.query.append(child.getText()).append(" ");
+        } else if (child instanceof ParserRuleContext) {
+            for (ParseTree child2 : ((ParserRuleContext) child).children) {
+                this.parseTreeHelper(child2);
             }
         }
     }

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
@@ -395,16 +395,13 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
                         if (columnDefChild.getChildCount() >= 2) {
                             defaultModifier = "DEFAULT " + columnDefChild.getChild(1).getText();
                         }
-                    } else if (columnDefChild instanceof MySqlParser.DimensionDataTypeContext || columnDefChild instanceof MySqlParser.SimpleDataTypeContext
-                            || columnDefChild instanceof MySqlParser.StringDataTypeContext) {
+                    } else {
                         columnType = (columnDefChild.getText());
                         String chDataType = getClickHouseDataType(columnType, columnChild, columnName);
-                           if (chDataType != null) {
-                                columnType = chDataType;
-                            }
-
+                        if (chDataType != null) {
+                            columnType = chDataType;
                         }
-
+                    }
                 }
             } else if (columnChild instanceof TerminalNodeImpl) {
                 String columnPosition = columnChild.getText();

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/AlterTableAddColumnIT.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/AlterTableAddColumnIT.java
@@ -75,6 +75,8 @@ public class AlterTableAddColumnIT extends DDLBaseIT {
         conn.prepareStatement("alter table add_test add column col4 varchar(255);").execute();
         conn.prepareStatement("alter table add_test rename column col99 to col101;").execute();
         conn.prepareStatement(" alter table add_test drop column col101;").execute();
+        conn.prepareStatement(" alter table add_test add column col5 ENUM ('M','F');").execute();
+        conn.prepareStatement(" alter table add_test add column col6 JSON;").execute();
 
         Thread.sleep(25000);
 
@@ -98,6 +100,8 @@ public class AlterTableAddColumnIT extends DDLBaseIT {
         Assert.assertTrue(addTestColumns.get("col8").equalsIgnoreCase("Nullable(String)"));
         Assert.assertTrue(addTestColumns.get("col2").equalsIgnoreCase("Nullable(Int32)"));
         Assert.assertTrue(addTestColumns.get("col3").equalsIgnoreCase("Nullable(Int32)"));
+        Assert.assertTrue(addTestColumns.get("col5").equalsIgnoreCase("Nullable(String)"));
+        Assert.assertTrue(addTestColumns.get("col6").equalsIgnoreCase("Nullable(String)"));
 
         if(engine.get() != null) {
             engine.get().stop();

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java
@@ -447,8 +447,16 @@ public class MySqlDDLParserListenerImplTest {
 
         String checkConstraintSql = "ALTER TABLE orders ADD CONSTRAINT check_revenue_positive CHECK (revenue >= 0);";
         mySQLDDLParserService.parseSql(checkConstraintSql, " ", clickHouseQuery2);
+    }
 
-
+    @Test
+    public void testAddConstraintsWithAnd() {
+        StringBuffer clickHouseQuery = new StringBuffer();
+        String checkConstraintSql = "ALTER TABLE orders ADD CONSTRAINT check_revenue_positive CHECK ( (revenue>=0 and revenue<1000) or (revenue>=2000) );";
+        String clickhouseExpectedQuery = "ALTER TABLE orders ADD CONSTRAINT check_revenue_positive CHECK ( ( revenue >=0 and revenue <1000 ) or ( revenue >=2000 ) ) ";
+        mySQLDDLParserService.parseSql(checkConstraintSql, " ", clickHouseQuery);
+        log.info("CLICKHOUSE QUERY " + clickHouseQuery.toString());
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(clickhouseExpectedQuery));
     }
 
     @Test

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java
@@ -639,6 +639,32 @@ public class MySqlDDLParserListenerImplTest {
 
     }
 
+    @Test
+    public void testAlterDatabaseAddColumnEnum() {
+        String clickhouseExpectedQuery = "ALTER TABLE employees ADD COLUMN gender String";
+        StringBuffer clickHouseQuery = new StringBuffer();
+        String alterDBAddColumn = "ALTER TABLE employees add column gender ENUM ('M','F') NOT NULL";
+        mySQLDDLParserService.parseSql(alterDBAddColumn, "employees", clickHouseQuery);
+
+        log.info("CLICKHOUSE QUERY " + clickHouseQuery);
+
+        Assert.assertTrue(clickHouseQuery != null && clickHouseQuery.length() != 0);
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(clickhouseExpectedQuery));
+    }
+
+    @Test
+    public void testAlterDatabaseAddColumnJson() {
+        String clickhouseExpectedQuery = "ALTER TABLE employees ADD COLUMN data String";
+        StringBuffer clickHouseQuery = new StringBuffer();
+        String alterDBAddColumn = "ALTER TABLE employees add column data JSON NOT NULL";
+        mySQLDDLParserService.parseSql(alterDBAddColumn, "employees", clickHouseQuery);
+
+        log.info("CLICKHOUSE QUERY " + clickHouseQuery);
+
+        Assert.assertTrue(clickHouseQuery != null && clickHouseQuery.length() != 0);
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(clickhouseExpectedQuery));
+    }
+
 //    @Test
 //    public void deleteData() {
 //        String sql = "DELETE FROM Customers WHERE CustomerName='Alfreds Futterkiste'";


### PR DESCRIPTION
Two fixes here:
1.  `parseAlterTable` used to ignore new columns that were of type JSON or ENUM.
2. `enterAlterByAddCheckTableConstraint` would fail if we have a constraints with logical statements (e.g. "num > 1 and num > 2")
