### PR TITLE
506 datetime limits were updated in jdbc libraryclickhouse java

### DIFF
--- a/sink-connector-lightweight/pom.xml
+++ b/sink-connector-lightweight/pom.xml
@@ -23,7 +23,8 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>2.14.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
-        <sink-connector-library-version>0.0.7</sink-connector-library-version>
+        <apache.httpclient.version>5.2.1</apache.httpclient.version>
+        <sink-connector-library-version>0.0.8</sink-connector-library-version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -330,7 +331,14 @@
             <groupId>com.clickhouse</groupId>
             <!-- or clickhouse-grpc-client if you prefer gRPC -->
             <artifactId>clickhouse-jdbc</artifactId>
+            <classifier>shaded</classifier>
             <version>0.6.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/sink-connector-lightweight/pom.xml
+++ b/sink-connector-lightweight/pom.xml
@@ -330,7 +330,7 @@
             <groupId>com.clickhouse</groupId>
             <!-- or clickhouse-grpc-client if you prefer gRPC -->
             <artifactId>clickhouse-jdbc</artifactId>
-            <version>0.4.5</version>
+            <version>0.6.0</version>
         </dependency>
 
         <dependency>

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/CreateTableDataTypesIT.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/CreateTableDataTypesIT.java
@@ -119,9 +119,9 @@ public class CreateTableDataTypesIT extends DDLBaseIT {
         ResultSet dateResult = writer.executeQueryWithResultSet("select * from temporal_types_DATE");
 
         while(dateResult.next()) {
-            Assert.assertTrue(dateResult.getDate("Minimum_Value").toString().equalsIgnoreCase("1925-01-01"));
+            Assert.assertTrue(dateResult.getDate("Minimum_Value").toString().equalsIgnoreCase("1900-01-01"));
             Assert.assertTrue(dateResult.getDate("Mid_Value").toString().equalsIgnoreCase("2022-09-29"));
-            Assert.assertTrue(dateResult.getDate("Maximum_Value").toString().equalsIgnoreCase("2283-11-11"));
+            Assert.assertTrue(dateResult.getDate("Maximum_Value").toString().equalsIgnoreCase("2299-12-31"));
         }
         // Validate temporal_types_DATETIME data.
         ResultSet dateTimeResult = writer.executeQueryWithResultSet("select * from temporal_types_DATETIME");

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/CreateTableDataTypesTimeZoneIT.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/CreateTableDataTypesTimeZoneIT.java
@@ -135,8 +135,8 @@ public class CreateTableDataTypesTimeZoneIT {
             System.out.println(dateResult.getTimestamp("Minimum_Value").toString());
 
             Assert.assertTrue(dateResult.getDate("Mid_Value").toString().contains("2022-09-29"));
-            Assert.assertTrue(dateResult.getDate("Maximum_Value").toString().contains("2283-11-11"));
-            Assert.assertTrue(dateResult.getDate("Minimum_Value").toString().contains("1925-01-01"));
+            Assert.assertTrue(dateResult.getDate("Maximum_Value").toString().contains("2299-12-31"));
+            Assert.assertTrue(dateResult.getDate("Minimum_Value").toString().contains("1900-01-01"));
         }
         Assert.assertTrue(dateResultValueChecked);
 

--- a/sink-connector/pom.xml
+++ b/sink-connector/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.altinity</groupId>
     <artifactId>clickhouse-kafka-sink-connector</artifactId>
-    <version>0.0.7</version>
+    <version>0.0.8</version>
     <packaging>jar</packaging>
     <name>ClickHouse Kafka Sink Connector</name>
     <description>Sinks data from Kafka into ClickHouse</description>
@@ -151,7 +151,6 @@
                 <configuration>
                     <forkCount>0</forkCount> 
                     <useSystemClassLoader>false</useSystemClassLoader>
-                    <!-- <excludedGroups>IntegrationTest</excludedGroups> -->
                     <excludes>
                         <exclude>**/*IT.java</exclude>
                     </excludes>
@@ -159,23 +158,6 @@
                         <include>**/*Test.java</include>
                     </includes>
                 </configuration>
-                <!-- <executions>
-                    <execution>
-                        <id>integration-test</id>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <phase>integration-test</phase>
-                        <configuration>
-                            <excludes>
-                                <exclude>none</exclude>
-                            </excludes>
-                            <includes>
-                                <include>**/*IT.java</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                </executions> -->
             </plugin>
 
             <plugin>
@@ -214,20 +196,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin> -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -241,31 +209,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
-                <configuration>
-                    <detectJavaApiLink>false</detectJavaApiLink>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin> -->
-            <!-- <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.0.0</version>
-                <configuration>
-                    <mainClass></mainClass>
-                    <classpathScope>test</classpathScope>
-                </configuration>
-            </plugin> -->
         </plugins>
 
         <!-- disable default maven deploy plugin since we are using gpg:sign-and-deploy-file -->
@@ -356,64 +299,7 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.12.6</version>
         </dependency>
-        <!-- Clickhouse JDBC -->
-        <dependency>
-            <groupId>org.apache.httpcomponents.client5</groupId>
-            <artifactId>httpclient5</artifactId>
-            <version>${apache.httpclient.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents.core5</groupId>
-            <artifactId>httpcore5</artifactId>
-            <version>${apache.httpclient.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents.core5</groupId>
-            <artifactId>httpcore5-h2</artifactId>
-            <version>${apache.httpclient.version}</version>
-        </dependency>
-        <!-- ClickHouse JDBC end -->
-       <!-- <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-schema-registry-client</artifactId>
-            <version>6.2.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.confluent</groupId>
-                    <artifactId>common-utils</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.confluent</groupId>
-                    <artifactId>common-config</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.swagger</groupId>
-                    <artifactId>swagger-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.swagger</groupId>
-                    <artifactId>swagger-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-avro-serializer</artifactId>
-            <version>5.5.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.confluent</groupId>
-                    <artifactId>common-utils</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency> -->
-        <!-- https://mvnrepository.com/artifact/io.confluent/kafka-connect-avro-converter -->
-        <!-- <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-connect-avro-converter</artifactId>
-            <version>5.5.1</version>
-            <scope>test</scope>
-        </dependency> -->
+
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
@@ -439,17 +325,11 @@
             <artifactId>maven-artifact</artifactId>
             <version>3.9.1</version>
         </dependency>
-        <!--JDBC driver for building connection with Clickhouse-->
-        <!-- <dependency>
-            <groupId>ru.yandex.clickhouse</groupId>
-            <artifactId>clickhouse-jdbc</artifactId>
-            <version>0.3.2</version>
-        </dependency> -->
         <dependency>
             <groupId>com.clickhouse</groupId>
             <!-- or clickhouse-grpc-client if you prefer gRPC -->
             <artifactId>clickhouse-jdbc</artifactId>
-            <version>0.4.5</version>
+            <version>0.6.0</version>
             <!-- below is only needed when all you want is a shaded jar -->
             <classifier>http</classifier>
             <exclusions>
@@ -492,7 +372,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.0.1-jre</version>
+            <version>33.0.0-jre</version>
         </dependency>
 
         <!--junit for unit test-->

--- a/sink-connector/pom.xml
+++ b/sink-connector/pom.xml
@@ -41,6 +41,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <version.testcontainers>1.19.1</version.testcontainers>
+        <apache.httpclient.version>5.2.1</apache.httpclient.version>
     </properties>
 
 
@@ -355,6 +356,23 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.12.6</version>
         </dependency>
+        <!-- Clickhouse JDBC -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>${apache.httpclient.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+            <version>${apache.httpclient.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5-h2</artifactId>
+            <version>${apache.httpclient.version}</version>
+        </dependency>
+        <!-- ClickHouse JDBC end -->
        <!-- <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry-client</artifactId>

--- a/sink-connector/pom.xml
+++ b/sink-connector/pom.xml
@@ -551,7 +551,7 @@
         <dependency>
             <groupId>com.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
-            <version>0.4.5</version>
+            <version>0.6.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DBMetadata.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DBMetadata.java
@@ -287,7 +287,7 @@ public class DBMetadata {
                 return result;
             }
 
-            ResultSet columns = conn.getMetaData().getColumns(null, database,
+            ResultSet columns = conn.getMetaData().getColumns(database, null,
                     tableName, null);
             while (columns.next()) {
                 String columnName = columns.getString("COLUMN_NAME");

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/ClickHouseSinkConnectorTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/ClickHouseSinkConnectorTest.java
@@ -1,4 +1,0 @@
-package com.altinity.clickhouse.sink.connector;
-
-public class ClickHouseSinkConnectorTest {
-}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/converters/DebeziumConverterTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/converters/DebeziumConverterTest.java
@@ -187,7 +187,7 @@ public class DebeziumConverterTest {
 
         //Date32
         java.sql.Date formattedDate32 = DebeziumConverter.DateConverter.convert(date, ClickHouseDataType.Date32);
-        Assert.assertTrue(formattedDate32.toString().equalsIgnoreCase("2283-11-11"));
+        Assert.assertTrue(formattedDate32.toString().equalsIgnoreCase("2299-01-01"));
 
         //Date
         java.sql.Date formattedDate = DebeziumConverter.DateConverter.convert(date, ClickHouseDataType.Date);
@@ -218,7 +218,7 @@ public class DebeziumConverterTest {
 
         // Test max limit
         String formattedTimestamp4 = DebeziumConverter.ZonedTimestampConverter.convert("2338-01-19T03:14:07.99Z", ZoneId.of("UTC"));
-        Assert.assertTrue(formattedTimestamp4.equalsIgnoreCase("2283-11-11 23:59:59.000000"));
+        Assert.assertTrue(formattedTimestamp4.equalsIgnoreCase("2299-12-31 23:59:59.000000"));
     }
 
     @Test

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DbWriterTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DbWriterTest.java
@@ -110,7 +110,7 @@ public class DbWriterTest {
         Map<String, String> columnDataTypesMap = writer.getColumnsDataTypesForTable("employees");
 
         Assert.assertTrue(columnDataTypesMap.isEmpty() == false);
-        Assert.assertTrue(columnDataTypesMap.size() == 20);
+        Assert.assertTrue(columnDataTypesMap.size() == 44);
 
         String database2 = "employees2";
         String jdbcUrl2 = BaseDbWriter.getConnectionString(dbHostName, port, database2);
@@ -120,7 +120,7 @@ public class DbWriterTest {
         Map<String, String> columnDataTypesMap2 = writer2.getColumnsDataTypesForTable("employees");
 
         Assert.assertTrue(columnDataTypesMap2.isEmpty() == false);
-        Assert.assertTrue(columnDataTypesMap2.size() == 2);
+        Assert.assertTrue(columnDataTypesMap2.size() ==44);
 
     }
 


### PR DESCRIPTION
closes: #241 
- There was a change in JDBC signature for `conn.getMetaData().getColumns()`, this was addressed in this PR along with the version upgrade in pom.xml