### PR TITLE
When MAX_QUEUE_SIZE is configured, the this.records.add(batch) method may throw an IllegalStateException and terminate the task.

### DIFF
--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/ClickHouseSinkTask.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/ClickHouseSinkTask.java
@@ -113,8 +113,11 @@ public class ClickHouseSinkTask extends SinkTask {
                 //Update the hashmap with the topic name and the list of records.
             }
         }
-        synchronized (this.records) {
-            this.records.add(batch);
+
+        try {
+            this.records.put(batch);
+        } catch (InterruptedException e) {
+            throw new RetriableException(e);
         }
     }
 //

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/common/Utils.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/common/Utils.java
@@ -90,10 +90,10 @@ public class Utils {
 
 
             // topic names is of the following format.
-            // hostname.dbName.tableName
+            // hostname.dbName.tableName or hostname.dbName.schemaName.tableName
             String[] splitName = topicName.split("\\.");
-            if(splitName.length == 3) {
-                tableName = splitName[2];
+            if(splitName.length >= 3) {
+                tableName = splitName[splitName.length - 1];
             }
 
         return tableName;


### PR DESCRIPTION
Changed this.records.add(batch) to this.records.put(batch).
Modified the getTableNameFormTopic method to retrieve table names from topics like hostname.dbName.schemaName.tableName.