### PR TITLE
Force RMT to old version for Integration tests

### DIFF
--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java
@@ -1,5 +1,6 @@
 package com.altinity.clickhouse.debezium.embedded.ddl.parser;
 
+import com.altinity.clickhouse.debezium.embedded.cdc.DebeziumChangeEventCapture;
 import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
 import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfigVariables;
 import org.apache.logging.log4j.LogManager;
@@ -24,6 +25,7 @@ public class MySqlDDLParserListenerImplTest {
     static public void init() {
         mySQLDDLParserService = new MySQLDDLParserService(new ClickHouseSinkConnectorConfig(new HashMap<>()),
                 "employees");
+        DebeziumChangeEventCapture.isNewReplacingMergeTreeEngine = true;
     }
     @Test
     public void testCreateTableWithEnum() {


### PR DESCRIPTION
Build server seems to revert to new version of RMT, forcing to use older version for tests to pass.
