### PR TITLE
Various fixes / improvements to python utilities see PR for details

### DIFF
--- a/sink-connector/python/db/mysql.py
+++ b/sink-connector/python/db/mysql.py
@@ -3,6 +3,9 @@ import logging
 import warnings
 import os
 import configparser
+import pymysql
+import pymysql as mysql
+import pandas as pd
 
 binary_datatypes = ('blob', 'varbinary', 'point', 'geometry', 'bit', 'binary', 'linestring',
                     'geomcollection', 'multilinestring', 'multipolygon', 'multipoint', 'polygon')
@@ -58,11 +61,24 @@ def get_partitions_from_regex(conn, mysql_database, include_tables_regex, exclud
     if include_partitions_regex is not None:
          include_regex_clause = f"and partition_name rlike '{include_partitions_regex}'"
          
-    strCommand = f"select TABLE_SCHEMA as table_schema, TABLE_NAME as table_name, PARTITION_NAME as partition_name from information_schema.partitions where table_schema = '{mysql_database}' {include_regex_clause} and (table_schema, table_name) IN ({table_sql}) order by 1,2,3"
+    strCommand = f"select TABLE_SCHEMA as table_schema, TABLE_NAME as table_name, PARTITION_NAME as partition_name, PARTITION_EXPRESSION as partition_expression from information_schema.partitions where table_schema = '{mysql_database}' {include_regex_clause} and (table_schema, table_name) IN ({table_sql}) order by 1,2,3"
     (rowset, rowcount) = execute_mysql(conn, strCommand)
     x = rowset
 
     return x
+
+
+def mysql_execute_df(conn, sql):
+    logging.debug(sql)
+    cursor = conn.connection.cursor()
+    try:
+        cursor.execute( sql )
+        names = [ x[0] for x in cursor.description]
+        rows = cursor.fetchall()
+        return pd.DataFrame( rows, columns=names)
+    finally:
+        if cursor is not None:
+            cursor.close()
 
 
 def execute_mysql(conn, strSql):
@@ -97,3 +113,84 @@ def resolve_credentials_from_config(config_file):
     mysql_password = config['client']['password']
     logging.debug(f"mysql_user {mysql_user} mysql_password ****")
     return (mysql_user, mysql_password)
+
+
+def estimate_table_count(conn, mysql_table, mysql_rows, where, pk, min_pk, max_pk):
+    sql = f"explain select * from {mysql_table} where {where} and {pk} between {min_pk} and {max_pk}"
+    df = mysql_execute_df(conn, sql)
+    head = df.head(1)
+    count = int(head['rows'].iloc[0])
+    return count
+
+
+def get_min_max_pk_value(conn, mysql_table, mysql_rows, pk, where):
+    sql = f"select min({pk}) as min_pk, max({pk}) as max_pk from {mysql_table} where {where}"
+    df = mysql_execute_df(conn, sql)
+    head = df.head(1)
+    if head['max_pk'].isnull().values.any():
+        return (None, None)
+    min_pk = int(head['min_pk'].iloc[0])
+    max_pk = int(head['max_pk'].iloc[0])
+    return (min_pk, max_pk)
+
+
+def mysql_columns(conn, mysql_database, mysql_table, pk, ignore_pk=True):
+    if ignore_pk:
+        not_equal_pk = f"and column_name <> '{pk}'"
+    else:
+        not_equal_pk = ""
+    sql = f"select column_name as COLUMN_NAME from information_schema.columns where table_schema='{mysql_database}' and table_name = '{mysql_table}' {not_equal_pk} order by ORDINAL_POSITION"
+    df = mysql_execute_df(conn, sql)
+    logging.debug('Columns \n' + df.to_string(index=False))
+    list = df['COLUMN_NAME'].to_list()
+    return list
+
+
+def mysql_pk_columns(conn, mysql_database, mysql_table, is_integer=True):
+    where_integer = ""
+    if is_integer:
+        where_integer = " and data_type like '%int%'" 
+    sql = f"select column_name as COLUMN_NAME from information_schema.columns where table_schema='{mysql_database}' and table_name = '{mysql_table}' and column_key='PRI' {where_integer} order by ORDINAL_POSITION"
+    df = mysql_execute_df(conn, sql)
+    logging.debug('PK columns \n' + df.to_string(index=False))
+    list = df['COLUMN_NAME'].to_list()
+    return list
+
+
+def divide_table_into_even_chunks(conn, mysql_table, mysql_rows, pk, where):
+    if not pk:
+         yield {}
+         return 
+    (min_pk_value, max_pk_value) = get_min_max_pk_value(conn, mysql_table, mysql_rows, pk, where)
+    if min_pk_value is None:
+        logging.debug(f"No data in {mysql_table}")
+        return
+    table_rowcount = estimate_table_count(conn, mysql_table, mysql_rows, where, pk, min_pk_value, max_pk_value)
+    lower_bound = int(min_pk_value)
+
+    nb_chunks = int(table_rowcount / mysql_rows)+1
+    logging.debug(f"nb_chunks = {nb_chunks}")
+    logging.debug(f"lower_bound {lower_bound} max_pk_value {max_pk_value}")
+    chunk_step = int((max_pk_value - min_pk_value) / nb_chunks)+1
+
+    upper_bound = lower_bound - 1
+    logging.debug(f"lower_bound {lower_bound} max_pk_value {max_pk_value} chunk_step {chunk_step}")
+ 
+    while lower_bound <= max_pk_value:
+        lower_bound = upper_bound + 1
+        upper_bound = lower_bound + chunk_step
+        chunk = {}
+        chunk['min_pk'] = lower_bound
+        chunk['max_pk'] = upper_bound
+
+        # we need to make sure there is data in the chunk, as CH wants data on insert in a pipe
+        # we can use that to find a better minimum
+        sql = f"select {pk} from {mysql_table} where {where} and {pk} between {lower_bound} and {upper_bound}  order by {pk} limit 1"
+        df = mysql_execute_df(conn, sql)
+        index = df.index
+        number_of_rows = len(index)
+        if number_of_rows > 0 :
+            head = df.head(1)
+            chunk['min_pk'] = int(head[pk].iloc[0])
+            yield chunk
+    logging.debug(f"Estimated table row count {table_rowcount}")

--- a/sink-connector/python/db_compare/clickhouse_table_checksum.py
+++ b/sink-connector/python/db_compare/clickhouse_table_checksum.py
@@ -227,7 +227,7 @@ def select_table_statements(table, query, select_query, order_by, external_colum
 	  ) as t""".format(select_query=select_query, schema=args.clickhouse_database, table=table, where=where, order_by=order_by, limit=limit)
 
     if args.debug_output:
-        sql = """select  {select_query}  as "hash"   from {schema}.{table} final where  {where} {limit} settings do_not_merge_across_partitions_select_final=1, max_memory_usage=100000000000""".format(
+        sql = """select  {select_query}  as "hash"   from {schema}.{table} final where  {where} {limit} settings do_not_merge_across_partitions_select_final=1""".format(
             select_query=select_query, schema=args.clickhouse_database, table=table, where=where, order_by=order_by, limit=limit)
     statements.append(sql)
     return statements

--- a/sink-connector/python/db_compare/clickhouse_table_checksum.py
+++ b/sink-connector/python/db_compare/clickhouse_table_checksum.py
@@ -126,7 +126,7 @@ def get_table_checksum_query(conn, table):
             nullables.append(column_name)
             select += " case when "+column_name+" is null then '' else "
             if first_column:
-                select += " '#' || "
+                select += " "
 
         if not first_column:
             select += "'#'||"
@@ -142,7 +142,7 @@ def get_table_checksum_query(conn, table):
             elif "Decimal" in data_type:
                 # custom function due to https://github.com/ClickHouse/ClickHouse/issues/30934
                 # requires this function : CREATE OR REPLACE FUNCTION format_decimal AS (x, scale) -> if(locate(toString(x),'.')>0,concat(toString(x),repeat('0',toUInt8(scale-(length(toString(x))-locate(toString(x),'.'))))),concat(toString(x),'.',repeat('0',toUInt8(scale))))
-                select += "format_decimal("+column_name + \
+                select += "toDecimalString("+column_name + \
                     ","+str(numeric_scale)+")"
             elif "DateTime64(0" in data_type:
                 select += f"toString({column_name})"
@@ -195,15 +195,15 @@ def get_table_checksum_query(conn, table):
     return (query, select, order_by_columns, external_column_types)
 
 
-def select_table_statements(table, query, select_query, order_by, external_column_types):
+def select_table_statements(table, query, select_query, order_by, external_column_types, _where):
     statements = []
     external_table_name = args.clickhouse_database+"."+table
     limit = ""
     if args.debug_limit:
         limit = " limit "+args.debug_limit
     where = "1=1"
-    if args.where:
-        where = args.where
+    if _where:
+       where = _where
 
     # skip deleted rows
     if args.sign_column != '':
@@ -227,7 +227,7 @@ def select_table_statements(table, query, select_query, order_by, external_colum
 	  ) as t""".format(select_query=select_query, schema=args.clickhouse_database, table=table, where=where, order_by=order_by, limit=limit)
 
     if args.debug_output:
-        sql = """select  {select_query}  as "hash"   from {schema}.{table} final where  {where} order by {order_by} {limit}""".format(
+        sql = """select  {select_query}  as "hash"   from {schema}.{table} final where  {where} {limit} settings do_not_merge_across_partitions_select_final=1, max_memory_usage=100000000000""".format(
             select_query=select_query, schema=args.clickhouse_database, table=table, where=where, order_by=order_by, limit=limit)
     statements.append(sql)
     return statements
@@ -246,7 +246,7 @@ def get_tables_from_regex(conn):
     return x
 
 
-def calculate_checksum(table, clickhouse_user, clickhouse_password):
+def calculate_checksum(table, clickhouse_user, clickhouse_password, where):
     if args.ignore_tables_regex:
         rex_ignore_tables = re.compile(args.ignore_tables_regex, re.IGNORECASE)
         if rex_ignore_tables.match(table):
@@ -262,8 +262,8 @@ def calculate_checksum(table, clickhouse_user, clickhouse_password):
 
     # we need to count the values in CH first
     sql = "select count(*) cnt from "+args.clickhouse_database+"."+table
-    if args.where:
-        sql = sql + " where " + args.where
+    if where:
+        sql = sql + " where " + where
 
     conn = get_connection(clickhouse_user, clickhouse_password)
     (rowset, rowcount) = execute_sql(conn, sql)
@@ -277,7 +277,7 @@ def calculate_checksum(table, clickhouse_user, clickhouse_password):
     (query, select_query, distributed_by,
      external_table_types) = get_table_checksum_query(conn, table)
     statements = select_table_statements(
-        table, query, select_query, distributed_by, external_table_types)
+        table, query, select_query, distributed_by, external_table_types, where)
     compute_checksum(table, clickhouse_user, clickhouse_password, statements)
 
 
@@ -378,7 +378,7 @@ def main():
         with concurrent.futures.ThreadPoolExecutor(max_workers=args.threads) as executor:
             futures = []
             for table in tables:
-              futures.append(executor.submit(calculate_checksum, table[0], clickhouse_user, clickhouse_password))
+              futures.append(executor.submit(calculate_checksum, table[0], clickhouse_user, clickhouse_password, args.where))
             for future in concurrent.futures.as_completed(futures):
               if future.exception() is not None:
                 raise future.exception()

--- a/sink-connector/python/db_compare/clickhouse_table_count.py
+++ b/sink-connector/python/db_compare/clickhouse_table_count.py
@@ -1,0 +1,177 @@
+"""
+#r/ -- ============================================================================
+# -- FileName     : clickhouse_table_count
+# -- Date         : 
+# -- Summary      : calculate a checksum for a clickhouse table 
+# -- Credits      : 
+# --                
+"""
+import logging
+import argparse
+import traceback
+import sys
+from sys import argv
+import datetime
+import warnings
+import re
+import os
+import hashlib
+import concurrent.futures
+from db.clickhouse import *
+
+runTime = datetime.datetime.now().strftime("%Y.%m.%d-%H.%M.%S")
+
+
+def get_connection(clickhouse_user, clickhouse_password):
+
+    conn = clickhouse_connection(args.clickhouse_host, database=args.clickhouse_database,
+                                 user=clickhouse_user, password=clickhouse_password,
+                                 port=args.clickhouse_port,
+                                 secure=args.secure)
+    return conn
+
+
+def get_tables_from_regex(conn):
+    if args.no_wc:
+        return [[args.tables_regex]]
+
+    schema = args.clickhouse_database
+    partition_clause = ""
+    if args.include_partitions_regex:
+        partition_clause = f" and (database, table) in (select distinct database, table from system.parts where database = '{schema}' and match(table,'{args.tables_regex}') and active and match(partition,'{args.include_partitions_regex}'))"
+
+    strCommand = f"select name, partition_key from system.tables where database = '{schema}' and match(name,'{args.tables_regex}') {partition_clause} order by 1"
+    logging.debug(f"REGEX QUERY: {strCommand}")
+    (rowset, rowcount) = execute_sql(conn, strCommand)
+    x = rowset
+    return x
+
+
+def calculate_table_count(table, partition_key, clickhouse_user, clickhouse_password):
+    if args.ignore_tables_regex:
+        rex_ignore_tables = re.compile(args.ignore_tables_regex, re.IGNORECASE)
+        if rex_ignore_tables.match(table):
+            logging.info("Ignoring "+table + " due to ignore_regex_tables")
+            return
+    threads = []
+    threadID = 1
+    # 
+    conn = get_connection(clickhouse_user, clickhouse_password)
+    partition_query = f"select distinct partition from system.parts where database = '{args.clickhouse_database}' and table='{table}' and active and match(partition,'{args.include_partitions_regex}') order by partition"
+    (rowset, rowcount) = execute_sql(conn, partition_query)
+    conn.close()
+    conn = get_connection(clickhouse_user, clickhouse_password)
+    table_count = 0
+    for row in rowset:
+      partition_value = row[0]
+      # 
+      sql = f"select count(*) cnt from {args.clickhouse_database}.{table} final where 1=1"
+      if args.include_partitions_regex and partition_key != '':
+          sql += f" and {partition_key} = '{partition_value}' " 
+      if args.where:
+          sql = sql + " and " + args.where
+      # unsafe due to https://github.com/ClickHouse/ClickHouse/issues/49685
+      #sql += " settings do_not_merge_across_partitions_select_final=1" 
+      (rowset, rowcount) = execute_sql(conn, sql)
+      table_count += rowset[0][0]
+
+    logging.info(f"Count for table {args.clickhouse_database}.{table} = {table_count}")    
+    conn.close()
+
+# hack to add the user to the logger, which needs it apparently
+old_factory = logging.getLogRecordFactory()
+
+
+def record_factory(*args, **kwargs):
+    record = old_factory(*args, **kwargs)
+    record.user = "me"
+    return record
+
+
+logging.setLogRecordFactory(record_factory)
+
+def main():
+
+    parser = argparse.ArgumentParser(description='''
+  Compute the table count using system.tables 
+
+          ''')
+    # Required
+    parser.add_argument('--clickhouse_host',
+                        help='ClickHouse host', required=True)
+    parser.add_argument('--clickhouse_user',
+                        help='ClickHouse user', required=False)
+    parser.add_argument('--clickhouse_password',
+                        help='CH password (discouraged option use a configuration file)', required=False, default=None)
+    parser.add_argument('--clickhouse_config_file',
+                        help='CH config file either xml or yaml, default is ./clickhouse-client.xml', required=False, default='./clickhouse-client.xml')
+    parser.add_argument('--clickhouse_database',
+                        help='ClickHouse database', required=True)
+    parser.add_argument('--clickhouse_port',
+                        help='ClickHouse port', default=9000, required=False)
+    parser.add_argument('--secure',
+                        help='True or False', default=False, required=False)
+    parser.add_argument('--tables_regex', help='table regexp', required=True, default='.')
+    parser.add_argument('--include_partitions_regex', help='partitions regex', required=False, default=None)
+    parser.add_argument('--where', help='where clause', required=False)
+    parser.add_argument('--ignore_tables_regex',
+                        help='Ignore table regexp', required=False)
+    parser.add_argument('--no_wc', action='store_true', default=False,
+                        help='Runs wc first to determine the table names from the regex', required=False)
+    parser.add_argument('--debug', dest='debug',
+                        action='store_true', default=False)
+    parser.add_argument('--threads', type=int,
+                        help='number of parallel threads', default=1)
+    global args
+    args = parser.parse_args()
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.INFO)
+
+    formatter = logging.Formatter(
+        '%(asctime)s - %(levelname)s - %(threadName)s - %(message)s')
+    handler.setFormatter(formatter)
+    root.addHandler(handler)
+
+    if args.debug:
+        root.setLevel(logging.DEBUG)
+        handler.setLevel(logging.DEBUG)
+
+    clickhouse_user = args.clickhouse_user
+    clickhouse_password = args.clickhouse_password
+
+    # check parameters
+    if args.clickhouse_password:
+        logging.warning("Using password on the command line is not secure, please specify a config file ")
+        assert args.clickhouse_user is not None, "--clickhouse_user must be specified"
+    else:
+        config_file = args.clickhouse_config_file
+        (clickhouse_user, clickhouse_password) = resolve_credentials_from_config(config_file)
+    try:
+        conn =  get_connection(clickhouse_user, clickhouse_password)
+        tables = get_tables_from_regex(conn)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=args.threads) as executor:
+            futures = []
+            for table in tables:
+              futures.append(executor.submit(calculate_table_count, table[0], table[1], clickhouse_user, clickhouse_password))
+            for future in concurrent.futures.as_completed(futures):
+              if future.exception() is not None:
+                raise future.exception()
+
+    except (KeyboardInterrupt, SystemExit):
+        logging.info("Received interrupt")
+        os._exit(1)
+    except Exception as e:
+        logging.error("Exception in main thread : " + str(e))
+        logging.error(traceback.format_exc())
+        sys.exit(1)
+    logging.debug("Exiting Main Thread")
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/sink-connector/python/db_compare/mysql_table_count.py
+++ b/sink-connector/python/db_compare/mysql_table_count.py
@@ -36,6 +36,9 @@ def compute_count(table, statements, conn):
     finally:
         conn.close()
 
+@staticmethod
+def fstr(template, partition_expression):
+        return eval(f"f'{template}'")
 
 def select_table_statements(conn, table):
     # TODO adjust the number as a parameter
@@ -60,10 +63,11 @@ def select_table_statements(conn, table):
     if len(partitions) > 0:
         for partition in partitions:
             partition_name = partition['partition_name']
+            partition_expression = partition['partition_expression']
             partition_clause = ""
             if partition_name is not None:
                 partition_clause = f" partition({partition_name})"
-        
+                where = fstr(where, partition_expression) 
             sql = f"select count(*) from {schema}.{table} {partition_clause} {where}"
             statements.append(sql)
     return statements
@@ -132,7 +136,7 @@ def main():
                         help='MySQL database', required=True)
     parser.add_argument('--mysql_port', help='MySQL port',
                         default=3306, required=False)
-    parser.add_argument('--include_tables_regex', help='table regexp', required=False, default=None)
+    parser.add_argument('--include_tables_regex', help='table regexp', required=False, default='.')
     parser.add_argument('--exclude_tables_regex',
                         help='exclude table regexp', required=False)
     parser.add_argument('--include_partitions_regex', help='partitions regex', required=False, default=None)

--- a/sink-connector/python/db_dump/mysql_dumper.py
+++ b/sink-connector/python/db_dump/mysql_dumper.py
@@ -85,9 +85,10 @@ def generate_mysqlsh_dump_tables_clause(dump_dir,
                                         schema_only,
                                         where,
                                         partition_map,
-                                        threads):
+                                        threads,
+                                        bytes_per_chunk):
     table_array_clause = tables_to_dump
-    dump_options = {"dryRun":int(dry_run), "ddlOnly":int(schema_only), "dataOnly":int(data_only), "threads":threads}
+    dump_options = {"dryRun":int(dry_run), "ddlOnly":int(schema_only), "dataOnly":int(data_only), "threads":threads, "bytesPerChunk":bytes_per_chunk}
     if partition_map and not schema_only:
         dump_options['partitions'] = partition_map
     logging.info(f"{dump_options}")
@@ -109,7 +110,9 @@ def generate_mysqlsh_command(dump_dir,
                              schema_only,
                              where,
                              partition_map,
-                             threads, temp_file):
+                             threads, 
+                             bytes_per_chunk,
+                             temp_file):
     mysql_user_clause = ""
     if mysql_user is not None:
         mysql_user_clause = f" --user {mysql_user}"
@@ -131,7 +134,8 @@ def generate_mysqlsh_command(dump_dir,
                                                       schema_only,
                                                       where,
                                                       partition_map,
-                                                      threads)
+                                                      threads,
+                                                      bytes_per_chunk)
     temp_file.write(dump_clause)
     temp_file.flush()
     cmd = f"""mysqlsh {defaults_file_clause} -h {mysql_host} {mysql_user_clause} {mysql_password_clause} {mysql_port_clause} -f {temp_file.name} """
@@ -160,6 +164,7 @@ def main():
     parser.add_argument('--include_partitions_regex', help='partitions regex', required=False, default=None)
     parser.add_argument('--threads', type=int,
                         help='number of parallel threads', default=1)
+    parser.add_argument('--bytes_per_chunk', help='bytesPerChunk mysqlsh variable', required=False, default='64M')
     parser.add_argument('--debug', dest='debug',
                         action='store_true', default=False)
     parser.add_argument('--schema_only', dest='schema_only',
@@ -258,6 +263,7 @@ def main():
                                        args.where,
                                        partition_map,
                                        args.threads,
+                                       args.bytes_per_chunk,
                                        temp_file
                                        )
           rc = run_command(cmd)

--- a/sink-connector/python/db_load/clickhouse_loader.py
+++ b/sink-connector/python/db_load/clickhouse_loader.py
@@ -437,6 +437,9 @@ def load_data(args, timezone, schema_map, clickhouse_user=None, clickhouse_passw
 
 def execute_load(cmd):
     logging.info(cmd)
+    if args.dry_run:
+        logging.info("dry-run not executing")
+        return 
     (rc, result) = run_quick_command(cmd)
     logging.debug(result)
     if rc != '0':
@@ -456,7 +459,6 @@ def load_data_mysqlshell(args, timezone, schema_map, clickhouse_user=None, click
     config_file_option = ""
     if args.clickhouse_config_file is not None:
        config_file_option= f"--config-file '{args.clickhouse_config_file}'"
-
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.threads) as executor:
         futures = []
         for file in glob.glob(schema_files):
@@ -472,6 +474,11 @@ def load_data_mysqlshell(args, timezone, schema_map, clickhouse_user=None, click
                 schema_map, schema, table_name, args.virtual_columns, transform=False, mysqlshell=args.mysqlshell)
             transformed_columns = get_column_list(
                 schema_map, schema, table_name, args.virtual_columns, transform=True, mysqlshell=args.mysqlshell)
+            
+            if args.truncate_tables:
+                if not args.dry_run:
+                    with get_connection(args, clickhouse_user, clickhouse_password) as conn:
+                       clickhouse_execute_conn(conn, f"truncate table {schema}.{table_name}") 
             for data_file in data_files:
                 # double quote escape logic https://github.com/ClickHouse/ClickHouse/issues/10624
                 column_metadata_list = schema_map[schema+"."+table_name]
@@ -497,7 +504,7 @@ def load_data_mysqlshell(args, timezone, schema_map, clickhouse_user=None, click
                         else:
                             structure += " String"
 
-                cmd = f"""export TZ={timezone}; zstd -d --stdout {data_file}  | clickhouse-client {config_file_option} --use_client_time_zone 1 --throw_if_no_data_to_insert=0  -h {clickhouse_host} --query="INSERT INTO {ch_schema}.{table_name}({columns})  SELECT {transformed_columns} FROM input('{structure}') FORMAT TSV" -u{clickhouse_user} {password_option} -mn """
+                cmd = f"""export TZ={timezone}; zstd -d --stdout {data_file}  | clickhouse-client {config_file_option} --use_client_time_zone 1 --throw_if_no_data_to_insert=0  --max_partitions_per_insert_block=1000 -h {clickhouse_host} --query="INSERT INTO {ch_schema}.{table_name}({columns})  SELECT {transformed_columns} FROM input('{structure}') FORMAT TSV" -u{clickhouse_user} {password_option} -mn """
                 futures.append(executor.submit(execute_load, cmd))
 
         for future in concurrent.futures.as_completed(futures):
@@ -553,7 +560,8 @@ def main():
                         action='store_true', default=False)
     parser.add_argument('--use_regexp_parser',
                         action='store_true', default=False)
-
+    parser.add_argument('--truncate_tables', dest='truncate_tables',
+                        action='store_true', default=False)
     parser.add_argument('--dry_run', dest='dry_run',
                         action='store_true', default=False)
     parser.add_argument('--virtual_columns', help='virtual_columns',
@@ -564,6 +572,7 @@ def main():
                         action='store_true', default=False)
     parser.add_argument('--clickhouse_datetime_timezone',
                         help='Timezone for CH date times', required=False, default=None)
+    global args
     args = parser.parse_args()
     schema = not args.data_only
     data = not args.schema_only

--- a/sink-connector/python/db_load/mysql_parser/CreateTableMySQLParserListener.py
+++ b/sink-connector/python/db_load/mysql_parser/CreateTableMySQLParserListener.py
@@ -93,7 +93,7 @@ class CreateTableMySQLParserListener(MySqlParserListener):
                 if isinstance(child, MySqlParser.GeneratedColumnConstraintContext):
                     expression = child.expression()
                     text = self.extract_original_text(expression)
-                    # generated columns are mapped to MATERIALIZED see https://github.com/Altinity/clickhouse-sink-connector/issues/459 
+                    # aliases are translated to MATERIALIZED see https://github.com/Altinity/clickhouse-sink-connector/pull/443
                     # collations may be present before strings like _latin1 or _utf8mb4 
                     generatedExpression =  " MATERIALIZED " + re.sub(r"\b_.*?'","'", text)
                     generated = True

--- a/sink-connector/python/requirements.txt
+++ b/sink-connector/python/requirements.txt
@@ -3,3 +3,4 @@ pymysql
 pyyaml
 sqlalchemy == 1.4
 antlr4-python3-runtime==4.11.1
+pandas


### PR DESCRIPTION
- `mysql_table_checksum.py` can now compute table checksums using multiple threads

if the table has an integer PK, breaks down the table in chunks of `--chunk_size` pulled by  `--threads_per_table` threads

```
$ time python db_compare/mysql_table_checksum.py --mysql_host $MYSQL_HOST --mysql_database $DATABASE --tables_regex "$TABLE" --max_datetime_value "2299-12-31 00:00:00"  --threads 32 --threads_per_table 8 --binary_encoding base64 | grep -i checksum | awk '{print $11" "$13" "$15}' >mysql.txt

real	0m8.443s
user	0m4.714s
sys	0m7.938s

$ time python db_compare/mysql_table_checksum.py --mysql_host $MYSQL_HOST --mysql_database $DATABASE --tables_regex "$TABLE" --max_datetime_value "2299-12-31 00:00:00"  --threads 32 --threads_per_table 1 --binary_encoding base64 | grep -i checksum | awk '{print $11" "$13" "$15}' >mysql.txt

real	0m34.731s
user	0m2.516s
sys	0m7.259s
```
- `mysql_dumper.py` : added the bytesPerChunk variable to control the chunk size   
- `mysql_table_count.py`  fast count per partition are now available, can filter an existing partition with a where clause dependent on the partition key using a f-string

```
python db_compare/mysql_table_count.py --mysql_host $MYSQL_HOST --mysql_database $DATABASE --threads=4   --include_tables_regex . --include_partitions_regex p2024 --where "{partition_expression}=20240411" | awk '{print $11" "$13}' | grep -v " 0$" | sort > mysql.txt
```

- `clickhouse_table_checksum.py` now uses `toDecimalString` to print Decimals
- `clickhouse_table_checksum.py` now uses `settings do_not_merge_across_partitions_select_final=1 to optimize finalized selects` 
- `clickhouse_table_count.py` implements counts similar `mysql_table_count.py`, useful for quick count comparisons
- `clickhouse_loader.py` has an option to truncate existing tables `--truncate_tables`
- `clickhouse_loader.py` now inserts using `max_partitions_per_insert_block=1000`