### PR TITLE
Changes to fix grafana datasource

### DIFF
--- a/sink-connector-lightweight/docker/config/grafana/config/datasource.yml
+++ b/sink-connector-lightweight/docker/config/grafana/config/datasource.yml
@@ -1,3 +1,5 @@
+apiVersion: 1
+
 datasources:
   - access: 'proxy'                       # make grafana perform the requests
     editable: true                        # whether it should be editable
@@ -8,18 +10,17 @@ datasources:
     url: 'http://prometheus:9090'       # url of the prom instance
     database: 'prometheus'
     version: 1                            # well, versioning
-  -  name: Clickhouse
-     type: vertamedia-clickhouse-datasource
-     access: 'proxy'
-     url: http://clickhouse:8123
-     basicAuth: true
-     withCredentials: true
-     user: "ch_user"
-     database: ""
-     secureJsonData:
-      password: "root"
+  - name: Clickhouse
+    type: vertamedia-clickhouse-datasource
+    access: proxy
+    url: http://clickhouse:8123
+    basicAuth: true
+    secureJsonData:
       basicAuthPassword: "root"
-     isDefault: false
-     readOnly: false
-     editable: true
-     version: 1
+    basicAuthUser: "root"
+    editable: true
+    jsonData:
+      addCorsHeader: true
+      usePOST: true
+      useCompression: true
+      compressionType: gzip

--- a/sink-connector-lightweight/docker/grafana-service.yml
+++ b/sink-connector-lightweight/docker/grafana-service.yml
@@ -10,4 +10,5 @@ services:
       - DS_PROMETHEUS=prometheus
       - GF_USERS_DEFAULT_THEME=light
       - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=vertamedia-clickhouse-datasource,grafana-clickhouse-datasource
-      - GF_INSTALL_PLUGINS=vertamedia-clickhouse-datasource,grafana-clickhouse-datasource
+      - GF_INSTALL_PLUGINS=vertamedia-clickhouse-datasource
+      - GF_LOG_LEVEL=debug


### PR DESCRIPTION
closes: #518 
Fixed datasource, no manual intervention required.

![image](https://github.com/Altinity/clickhouse-sink-connector/assets/17434846/3854a19d-a8c6-4650-b144-9805cbca5053)
