### PR TITLE
Avoid printing error logs when there are no records in the queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ First two are good tutorials on MySQL and PostgreSQL respectively.
 * [Mutable Data Handling](doc/mutable_data.md)
 * [ClickHouse Table Engine Types](doc/clickhouse_engines.md)
 * [Troubleshooting](doc/Troubleshooting.md)
+* [Logging](doc/Logging.md)
 
 ### Operations
 

--- a/doc/logging.md
+++ b/doc/logging.md
@@ -1,0 +1,29 @@
+## Lightweight Sink Connector Logging
+
+Sink connector uses the log4j version 2 directly, however the dependendent libraries like debezium and clickhouse-jdbc
+use different logging frameworks(JUL, slf4j).
+There is logic to use adapters to bridge the logging frameworks.
+
+Logging is controlled by the `log4j2.xml` file in the 'docker' directory.
+This file is mounted into the container and is passed to the JVM as a system property.(-Dlog4j.configurationFile)
+
+### Log Levels
+If you need to change the Logging level , you can modify the rootLogger level in the `log4j2.xml` file.
+By default its set to `info` level.
+
+```xml
+
+    <Root level="info" additivity="false">
+```
+
+## Changing Layout (Example JSON)
+If you want to change the layout of the logs, you can modify the `log4j2.xml` file.
+You can comment out the default `PatternLayout` and enable `JSONLayout`
+
+```
+        <Console name="console" target="SYSTEM_OUT">
+            <!-- <JSONLayout compact="true" eventEol="true" properties="true" stacktraceAsString="true" includeTimeMillis="true" /> -->
+
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level - %msg%n"/>
+        </Console>
+```

--- a/sink-connector-lightweight/docker/clickhouse-sink-connector-lt-service.yml
+++ b/sink-connector-lightweight/docker/clickhouse-sink-connector-lt-service.yml
@@ -3,7 +3,7 @@ version: "3.4"
 services:
   clickhouse-sink-connector-lt:
     image: ${CLICKHOUSE_SINK_CONNECTOR_LT_IMAGE}
-    entrypoint: ["sh", "-c", "java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Xms4g -Xmx4g -jar /app.jar /config.yml com.altinity.clickhouse.debezium.embedded.ClickHouseDebeziumEmbeddedApplication"]
+    entrypoint: ["sh", "-c", "java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Xms4g -Xmx4g -Dlog4j2.configurationFile=log4j2.xml -jar /app.jar /config.yml com.altinity.clickhouse.debezium.embedded.ClickHouseDebeziumEmbeddedApplication"]
     restart: "no"
     ports:
       - "8083:8083"
@@ -12,4 +12,5 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
+      - ./log4j2.xml:/log4j2.xml
       - ./config.yml:/config.yml

--- a/sink-connector-lightweight/pom.xml
+++ b/sink-connector-lightweight/pom.xml
@@ -191,6 +191,18 @@
             <artifactId>log4j-api</artifactId>
             <version>2.17.1</version>
         </dependency>
+       <!-- <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>3.0.0-beta2</version>
+        </dependency> -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>2.23.1</version>
+            <!-- <scope>test</scope>-->
+        </dependency>
+
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
@@ -394,6 +406,13 @@
             <artifactId>log4j-api</artifactId>
             <version>2.23.1</version>
             <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-jul</artifactId>
+            <version>2.23.1</version>
+            <!-- <scope>runtime</scope> -->
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ClickHouseDebeziumEmbeddedApplication.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ClickHouseDebeziumEmbeddedApplication.java
@@ -14,6 +14,7 @@ import com.google.inject.Injector;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.jul.Log4jBridgeHandler;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -49,6 +50,10 @@ public class ClickHouseDebeziumEmbeddedApplication {
 
     public static void main(String[] args) throws Exception {
         //BasicConfigurator.configure();
+
+        Log4jBridgeHandler.install(false, "", true);
+        System.setProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
+
         System.setProperty("log4j.configurationFile", "resources/log4j2.xml");
 
         //org.apache.log4j.Logger root = org.apache.logging.log4j.getRootLogger();

--- a/sink-connector-lightweight/src/main/resources/log4j2.xml
+++ b/sink-connector-lightweight/src/main/resources/log4j2.xml
@@ -2,15 +2,22 @@
 <Configuration status="INFO">
     <Appenders>
         <Console name="console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level - %msg%n"/>
+          <!--  <JSONLayout compact="true" eventEol="true" properties="true" stacktraceAsString="true" includeTimeMillis="true" /> -->
+
+            <!-- <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level - %msg%n"/> -->
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="com.clickhouse" level="ERROR"
+        <!-- <Logger name="org.slf4j" level="DEBUG"
+                additivity="false">
+        <AppenderRef ref="console"/>
+        </Logger>-->
+            <Logger name="com.clickhouse" level="ERROR"
                 additivity="false">
             <AppenderRef ref="console"/>
         </Logger>
-        <Root level="debug" additivity="false">
+
+    <Root level="info" additivity="false">
             <AppenderRef ref="console" />
         </Root>
     </Loggers>

--- a/sink-connector-lightweight/src/main/resources/log4j2.xml
+++ b/sink-connector-lightweight/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="INFO">
     <Appenders>
         <Console name="console" target="SYSTEM_OUT">
-          <!--  <JSONLayout compact="true" eventEol="true" properties="true" stacktraceAsString="true" includeTimeMillis="true" /> -->
+            <!-- <JSONLayout compact="true" eventEol="true" properties="true" stacktraceAsString="true" includeTimeMillis="true" /> -->
 
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level - %msg%n"/>
         </Console>

--- a/sink-connector-lightweight/src/main/resources/log4j2.xml
+++ b/sink-connector-lightweight/src/main/resources/log4j2.xml
@@ -4,7 +4,7 @@
         <Console name="console" target="SYSTEM_OUT">
           <!--  <JSONLayout compact="true" eventEol="true" properties="true" stacktraceAsString="true" includeTimeMillis="true" /> -->
 
-            <!-- <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level - %msg%n"/> -->
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level - %msg%n"/>
         </Console>
     </Appenders>
     <Loggers>

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DBMetadata.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DBMetadata.java
@@ -214,14 +214,14 @@ public class DBMetadata {
                     String response =  rs.getString(1);
                     result = getEngineFromResponse(response);
                 } else {
-                    log.error("Error: Table not found in system tables:" + tableName + " Database:" + database);
+                    log.debug("Error: Table not found in system tables:" + tableName + " Database:" + database);
                 }
                 rs.close();
                 stmt.close();
                 log.info("getTableEngineUsingSystemTables ResultSet" + rs);
             }
         } catch(Exception e) {
-            log.error("getTableEngineUsingSystemTables exception", e);
+            log.debug("getTableEngineUsingSystemTables exception", e);
         }
 
         return result;

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DBMetadata.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DBMetadata.java
@@ -128,7 +128,7 @@ public class DBMetadata {
                 log.info("getTableEngineUsingShowTable ResultSet" + rs);
             }
         } catch(Exception e) {
-            log.error("getTableEngineUsingShowTable exception", e);
+            log.info("getTableEngineUsingShowTable exception", e);
         }
 
         return result;

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchRunnable.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchRunnable.java
@@ -149,10 +149,16 @@ public class ClickHouseBatchRunnable implements Runnable {
 
                 if(currentBatch == null) {
                     currentBatch = records.poll();
+                    if(currentBatch == null) {
+                        // No records in the queue.
+                        continue;
+                    }
                 } else {
                     log.debug("***** RETRYING the same batch again");
-
                 }
+
+
+
                 ///// ***** START PROCESSING BATCH **************************
                 // Step 1: Add to Inflight batches.
                 DebeziumOffsetManagement.addToBatchTimestamps(currentBatch);


### PR DESCRIPTION
This PR includes the changes also for logging.
We include libraries that contain different logging implementation(java.util.logging(JUL) and slf4j).
Included log4j adapter for JUL so that all JUL logs are routed to log4j
Included Slf4j log4j implementation (version 2) so that slf4j logs are routed to log4j

closes: #578 
closes: #642 
closes: #667 
closes: #666