### PR TITLE
Enable metrics by default for MySQL and postgres

### DIFF
--- a/sink-connector-lightweight/docker/config.yml
+++ b/sink-connector-lightweight/docker/config.yml
@@ -24,7 +24,7 @@ database.server.name: "ER54"
 
 # database.include.list An optional list of regular expressions that match database names to be monitored;
 # any database name not included in the whitelist will be excluded from monitoring. By default all databases will be monitored.
-database.include.list: sbtest
+database.include.list: test
 
 # table.include.list An optional list of regular expressions that match fully-qualified table identifiers for tables to be monitored;
 table.include.list: ""

--- a/sink-connector-lightweight/docker/config.yml
+++ b/sink-connector-lightweight/docker/config.yml
@@ -24,7 +24,7 @@ database.server.name: "ER54"
 
 # database.include.list An optional list of regular expressions that match database names to be monitored;
 # any database name not included in the whitelist will be excluded from monitoring. By default all databases will be monitored.
-database.include.list: test
+database.include.list: sbtest
 
 # table.include.list An optional list of regular expressions that match fully-qualified table identifiers for tables to be monitored;
 table.include.list: ""
@@ -165,6 +165,9 @@ restart.event.loop.timeout.period.secs: "3000"
 
 # Sink Connector maximum queue size
 #sink.connector.max.queue.size: "100000"
+
+#Metrics (Prometheus target), required for Grafana Dashboard
+metrics.enable: "true"
 
 # Skip schema history capturing, use the following configuration
 # to reduce slow startup when replicating dbs with large number of tables

--- a/sink-connector-lightweight/docker/config_postgres.yml
+++ b/sink-connector-lightweight/docker/config_postgres.yml
@@ -115,6 +115,9 @@ database.dbname: "public"
 # ignore_delete: If set to true, the connector will ignore delete events. The default is false.
 #ignore_delete: "true"
 
+#Metrics (Prometheus target), required for Grafana Dashboard
+metrics.enable: "true"
+
 #disable.ddl: If set to true, the connector will ignore DDL events. The default is false.
 #disable.ddl: "false"
 


### PR DESCRIPTION
Enable metrics by default.
closes: #746 