### PR TITLE
794 change logging level of struct empty not a valid cdc record + record to info

### DIFF
--- a/sink-connector-lightweight/docker/log4j2.xml
+++ b/sink-connector-lightweight/docker/log4j2.xml
@@ -20,7 +20,7 @@
             <AppenderRef ref="console"/>
         </Logger>
 
-    <Root level="warn" additivity="false">
+    <Root level="info" additivity="false">
             <AppenderRef ref="console" />
         </Root>
     </Loggers>

--- a/sink-connector-lightweight/docker/log4j2.xml
+++ b/sink-connector-lightweight/docker/log4j2.xml
@@ -11,12 +11,16 @@
                 additivity="false">
         <AppenderRef ref="console"/>
         </Logger>-->
+        <Logger name="io.debezium" level="ERROR"
+                additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
             <Logger name="com.clickhouse" level="ERROR"
                 additivity="false">
             <AppenderRef ref="console"/>
         </Logger>
 
-    <Root level="info" additivity="false">
+    <Root level="warn" additivity="false">
             <AppenderRef ref="console" />
         </Root>
     </Loggers>

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
@@ -193,7 +193,7 @@ public class DebeziumChangeEventCapture {
             Struct struct = (Struct) sr.value();
 
             if (struct == null) {
-                log.info(String.format("STRUCT EMPTY - not a valid CDC record + Record(%s)", record.toString()));
+                log.debug(String.format("STRUCT EMPTY - not a valid CDC record + Record(%s)", record.toString()));
                 return null;
             }
             if (struct.schema() == null) {

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
@@ -193,7 +193,7 @@ public class DebeziumChangeEventCapture {
             Struct struct = (Struct) sr.value();
 
             if (struct == null) {
-                log.warn(String.format("STRUCT EMPTY - not a valid CDC record + Record(%s)", record.toString()));
+                log.info(String.format("STRUCT EMPTY - not a valid CDC record + Record(%s)", record.toString()));
                 return null;
             }
             if (struct.schema() == null) {


### PR DESCRIPTION
closes: #794 