### PR TITLE
[1046] Fix NullPointerException and Refactor Connection Pool Initialization Logic

### DIFF
--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/HikariDbSource.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/HikariDbSource.java
@@ -81,7 +81,9 @@ public class HikariDbSource {
         }
         HikariDataSource dbSource = instance.get(databaseName);
         if (dbSource == null) {
-            // No pool exists for the database.
+            throw new SQLException("Database source is null for database: " + databaseName);
+    }
+
         }
         HikariDbSource.printConnectionInfo();
         return dbSource.getConnection();

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/HikariDbSource.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/HikariDbSource.java
@@ -14,6 +14,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 // Singleton class(one per database)
 /**
@@ -29,7 +30,7 @@ public class HikariDbSource {
     /**
      * Map of database name to HikariDataSource instance.
      */
-    private static final Map<String, HikariDataSource> instance = new HashMap<>();
+    private static final Map<String, HikariDataSource> instance = new ConcurrentHashMap<>();
 
     /**
      * Map of database name to Connection.
@@ -107,18 +108,13 @@ public class HikariDbSource {
                 ClickHouseSinkConnectorConfigVariables
                         .CONNECTION_POOL_DISABLE.toString());
 
-        HikariDataSource hikariDataSource = instance.computeIfAbsent(databaseName, dbName -> {
-            log.info("Creating new HikariDataSource for database: {}", dbName);
-            return createConnectionPool(
-                    dataSource, dbName, config);
+        return instance.compute(databaseName, (dbName, existingDataSource) -> {
+            if (existingDataSource == null || existingDataSource.isClosed()) {
+                log.info("Creating new HikariDataSource for database: {}", dbName);
+                return createConnectionPool(dataSource, dbName, config);
+            }
+            return existingDataSource;
         });
-
-        if (hikariDataSource.isClosed()) {
-            instance.remove(databaseName);
-            log.info("Removed closed HikariDataSource for database: {}", databaseName);
-            instance.put(databaseName, createConnectionPool(dataSource, databaseName, config));
-        }
-        return instance.get(databaseName);
     }
 
     /**

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/HikariDbSource.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/HikariDbSource.java
@@ -29,7 +29,7 @@ public class HikariDbSource {
     /**
      * Map of database name to HikariDataSource instance.
      */
-    private static Map<String, HikariDataSource> instance = new HashMap<>();
+    private static final Map<String, HikariDataSource> instance = new HashMap<>();
 
     /**
      * Map of database name to Connection.
@@ -82,9 +82,8 @@ public class HikariDbSource {
         HikariDataSource dbSource = instance.get(databaseName);
         if (dbSource == null) {
             throw new SQLException("Database source is null for database: " + databaseName);
-    }
-
         }
+
         HikariDbSource.printConnectionInfo();
         return dbSource.getConnection();
     }
@@ -107,12 +106,17 @@ public class HikariDbSource {
         disabled = config.getBoolean(
                 ClickHouseSinkConnectorConfigVariables
                         .CONNECTION_POOL_DISABLE.toString());
-        if (instance.containsKey(databaseName)) {
-            return instance.get(databaseName);
-        } else {
-            HikariDataSource hikariDataSource = createConnectionPool(
-                    dataSource, databaseName, config);
-            instance.put(databaseName, hikariDataSource);
+
+        HikariDataSource hikariDataSource = instance.computeIfAbsent(databaseName, dbName -> {
+            log.info("Creating new HikariDataSource for database: {}", dbName);
+            return createConnectionPool(
+                    dataSource, dbName, config);
+        });
+
+        if (hikariDataSource.isClosed()) {
+            instance.remove(databaseName);
+            log.info("Removed closed HikariDataSource for database: {}", databaseName);
+            instance.put(databaseName, createConnectionPool(dataSource, databaseName, config));
         }
         return instance.get(databaseName);
     }


### PR DESCRIPTION
## Description: 
1. Throw `Exception` when `dbSource` is `null`.
2. Refactor `HikariDataSource` initialization logic in `getInstance` method. Ensure that closed `HikariDataSource` instances will be removed to prevent memory leak. 
2. Change `HikariDbSource` from `HashMap` to `ConcurrentHashMap` for more thread safety.
## Benefits:
1. Avoids potential race conditions and redundant synchronization blocks.
2. Ensures correct connection reuse and recreation logic.
3. Clean, thread-safe code using idiomatic ConcurrentHashMap pattern.

