### PR TITLE
Support for partition expression in checksum command lines

### DIFF
--- a/sink-connector/python/db/clickhouse.py
+++ b/sink-connector/python/db/clickhouse.py
@@ -26,6 +26,10 @@ def clickhouse_execute_conn(conn, sql):
     result = cursor.fetchall()
     return result
 
+def get_table_partition_key(conn, database, table):
+   sql = f"SELECT partition_key FROM system.tables WHERE name = '{table}'  AND database = '{database}' FORMAT TabSeparated"
+   res = clickhouse_execute_conn(conn, sql)
+   return res
 
 def execute_sql(conn, strSql):
     """

--- a/sink-connector/python/db_compare/clickhouse_table_checksum.py
+++ b/sink-connector/python/db_compare/clickhouse_table_checksum.py
@@ -198,7 +198,7 @@ def get_table_checksum_query(conn, table):
 def fstr(template, partition_expression):
         return eval(f"f'{template}'")
 
-def select_table_statements(table, query, select_query, order_by, external_column_types, _where, conn):
+def select_table_statements(table, query, select_query, order_by, external_column_types, _where):
     statements = []
     external_table_name = args.clickhouse_database+"."+table
     limit = ""
@@ -286,7 +286,7 @@ def calculate_checksum(table, clickhouse_user, clickhouse_password, where):
     (query, select_query, distributed_by,
      external_table_types) = get_table_checksum_query(conn, table)
     statements = select_table_statements(
-        table, query, select_query, distributed_by, external_table_types, where, conn)
+        table, query, select_query, distributed_by, external_table_types, where)
     compute_checksum(table, clickhouse_user, clickhouse_password, statements)
 
 

--- a/sink-connector/python/db_compare/clickhouse_table_checksum.py
+++ b/sink-connector/python/db_compare/clickhouse_table_checksum.py
@@ -194,8 +194,11 @@ def get_table_checksum_query(conn, table):
     logging.debug("order by columns "+order_by_columns)
     return (query, select, order_by_columns, external_column_types)
 
+@staticmethod
+def fstr(template, partition_expression):
+        return eval(f"f'{template}'")
 
-def select_table_statements(table, query, select_query, order_by, external_column_types, _where):
+def select_table_statements(table, query, select_query, order_by, external_column_types, _where, conn):
     statements = []
     external_table_name = args.clickhouse_database+"."+table
     limit = ""
@@ -259,13 +262,19 @@ def calculate_checksum(table, clickhouse_user, clickhouse_password, where):
     statements = []
     #
     # Create new threads to execute the sync
-
+    conn = get_connection(clickhouse_user, clickhouse_password)
     # we need to count the values in CH first
     sql = "select count(*) cnt from "+args.clickhouse_database+"."+table
     if where:
+        if "{partition_expression}" in where:
+           partition_key = get_table_partition_key(conn, args.clickhouse_database, table)
+           logging.info(partition_key)
+           if len(partition_key) > 0 :
+               partition_key = partition_key[0][0]
+           where = fstr(where, partition_key)
         sql = sql + " where " + where
 
-    conn = get_connection(clickhouse_user, clickhouse_password)
+
     (rowset, rowcount) = execute_sql(conn, sql)
     if rowcount == 0:
         logging.info("No rows in ClickHouse. Nothing to sync.")
@@ -277,7 +286,7 @@ def calculate_checksum(table, clickhouse_user, clickhouse_password, where):
     (query, select_query, distributed_by,
      external_table_types) = get_table_checksum_query(conn, table)
     statements = select_table_statements(
-        table, query, select_query, distributed_by, external_table_types, where)
+        table, query, select_query, distributed_by, external_table_types, where, conn)
     compute_checksum(table, clickhouse_user, clickhouse_password, statements)
 
 

--- a/sink-connector/python/db_compare/mysql_table_checksum.py
+++ b/sink-connector/python/db_compare/mysql_table_checksum.py
@@ -50,7 +50,7 @@ def compute_checksum(table, statements, conn):
     return result
 
 
-def get_table_checksum_query(table, conn, binary_encoding):
+def get_table_checksum_query(table, conn, binary_encoding, where):
 
     (rowset, rowcount) = execute_mysql(conn, "select COLUMN_NAME as column_name, column_type as data_type, IS_NULLABLE as is_nullable from information_schema.columns where table_schema='" +
                                        args.mysql_database+"' and table_name = '"+table+"' order by ordinal_position")
@@ -118,8 +118,8 @@ def get_table_checksum_query(table, conn, binary_encoding):
         order_by_columns = ','.join(primary_key_columns)
 
     query = "select "+select+"  as query from "+args.mysql_database+"."+table
-    if args.where:
-        query += " where "+args.where
+    if where :
+        query += " where "+where
 
     if len(primary_key_columns) > 0:
         query += " order by " + order_by_columns
@@ -131,6 +131,10 @@ def get_table_checksum_query(table, conn, binary_encoding):
     logging.debug("order by columns "+order_by_columns)
     return (query, select, order_by_columns, external_column_types)
 
+
+@staticmethod
+def fstr(template, partition_expression):
+        return eval(f"f'{template}'")
 
 def select_table_statements(table, query, select_query, order_by, external_column_types, _where):
     statements = ['set names utf8mb4']
@@ -187,7 +191,7 @@ def calculate_sql_checksum(conn, table, where):
         statements = []
 
         (query, select_query, distributed_by,
-         external_table_types) = get_table_checksum_query(table, conn, args.binary_encoding)
+         external_table_types) = get_table_checksum_query(table, conn, args.binary_encoding, where)
         statements = select_table_statements(
             table, query, select_query, distributed_by, external_table_types, where)
         result = compute_checksum(table, statements, conn)
@@ -231,7 +235,20 @@ def calculate_checksum(mysql_table, mysql_user, mysql_password):
         threads_per_table = 1
     where = "1=1"
     if args.where:
-       where = args.where
+        where = args.where
+        if "{partition_expression}" in where:
+            partitions = get_partitions_from_regex(conn,
+                                            args.mysql_database,
+                                            '^'+mysql_table+'$')
+            partitions = partitions.fetchall()
+            if len(partitions) > 0:
+                for partition in partitions:
+                    partition_name = partition['partition_name']
+                    partition_expression = partition['partition_expression']
+                    partition_clause = ""
+                    if partition_name is not None:
+                        where = fstr(where, partition_expression)
+                        break
     md5_sum = ""
     cnt = -1
     result = []


### PR DESCRIPTION
This PR is to automate the checksum based on partition dates (without specifying the partitioning key) 

```
python db_compare/mysql_table_checksum.py --min_date_value "1900-01-01" --mysql_host $MYSQL_HOST --mysql_database $DATABASE --tables_regex "$TABLE" --where "{partition_expression}=$DATE_FORMATTED" --max_datetime_value "2299-12-31 00:00:00"  --binary_encoding base64 | grep -i checksum | awk '{print $11" "$13" "$15}' >mysql.txt
python db_compare/clickhouse_table_checksum.py --clickhouse_host $CH_HOST --clickhouse_user dba_aadant  --clickhouse_database $DATABASE --tables_regex "$TABLE" --where "{partition_expression}=\\'$DATE\\'"  --max_datetime_value "2299-12-31 00:00:00" --exclude_columns _version,is_deleted --sign_column "" |grep -i checksum | awk '{print $11" "$13" "$15}' > ch.txt
sort mysql.txt > mysql.sorted.txt
sort ch.txt > ch.sorted.txt
diff mysql.sorted.txt ch.sorted.txt
```