### PR TITLE
Various improvements to checksums

### DIFF
--- a/sink-connector/python/db/mysql.py
+++ b/sink-connector/python/db/mysql.py
@@ -24,7 +24,6 @@ def get_mysql_connection(mysql_host, mysql_user, mysql_passwd, mysql_port, mysql
     conn = engine.connect()
     return conn
 
-
 def get_tables_from_regex_sql(conn, no_wc,  mysql_database, include_tables_regex, exclude_tables_regex=None, non_partitioned_tables_only=False, include_partitions_regex=None):
     schema = mysql_database
     exclude_regex_clause = ""
@@ -116,7 +115,7 @@ def resolve_credentials_from_config(config_file):
 
 
 def estimate_table_count(conn, mysql_table, where, pk, min_pk, max_pk):
-    sql = f"explain select * from {mysql_table} where {where} and {pk} between {min_pk} and {max_pk}"
+    sql = f"explain select * from `{mysql_table}` where {where} and {pk} between {min_pk} and {max_pk}"
     df = mysql_execute_df(conn, sql)
     head = df.head(1)
     count = int(head['rows'].iloc[0])
@@ -124,7 +123,7 @@ def estimate_table_count(conn, mysql_table, where, pk, min_pk, max_pk):
 
 
 def get_min_max_pk_value(conn, mysql_table, pk, where):
-    sql = f"select min({pk}) as min_pk, max({pk}) as max_pk from {mysql_table} where {where}"
+    sql = f"select min({pk}) as min_pk, max({pk}) as max_pk from `{mysql_table}` where {where}"
     df = mysql_execute_df(conn, sql)
     head = df.head(1)
     if head['max_pk'].isnull().values.any():
@@ -185,7 +184,7 @@ def divide_table_into_even_chunks(conn, mysql_table, chunk_size, pk, where):
 
         # we need to make sure there is data in the chunk, as CH wants data on insert in a pipe
         # we can use that to find a better minimum
-        sql = f"select {pk} from {mysql_table} where {where} and {pk} between {lower_bound} and {upper_bound}  order by {pk} limit 1"
+        sql = f"select {pk} from `{mysql_table}` where {where} and {pk} between {lower_bound} and {upper_bound}  order by {pk} limit 1"
         df = mysql_execute_df(conn, sql)
         index = df.index
         number_of_rows = len(index)

--- a/sink-connector/python/db_compare/clickhouse_table_checksum.py
+++ b/sink-connector/python/db_compare/clickhouse_table_checksum.py
@@ -93,22 +93,34 @@ def get_primary_key_columns(conn, table_schema, table_name):
 
 
 def get_table_checksum_query(conn, table):
-    #logging.info(f"Excluded columns before join, {args.exclude_columns}")
     excluded_columns = "','".join(args.exclude_columns)
     excluded_columns = [f'{column}' for column in excluded_columns.split(',')]
-    #excluded_columns = "'"+excluded_columns+"'"
     logging.info(f"Excluded columns, {excluded_columns}")
     excluded_columns_str = ','.join((f"'{col}'" for col in excluded_columns))
-    checksum_query="select name, type, if(match(type,'Nullable'),1,0) is_nullable, numeric_scale from system.columns where database='" + args.clickhouse_database+"' and table = '"+table+"' and name not in ("+ excluded_columns_str +") order by position"
+    checksum_query="select name, type, if(match(type,'Nullable'),1,0) is_nullable, numeric_scale from system.columns where database='" + args.clickhouse_database+"' and table = '"+table+"' order by position"
     (rowset, rowcount) = execute_sql(conn, checksum_query)
-    #logging.info(f"CHECKSUM QUERY: {checksum_query}")
 
     select = ""
     nullables = []
     columns = []
     data_types = {}
     first_column = True
-    for row in rowset:
+    columns_metadata  = []
+    for row in rowset:    
+        columns_metadata.append(row)
+    columns_metadata_map = { r[0]: r for r in columns_metadata }
+    # sometimes we have excluded columns like is_deleted and _is_deleted, we would exclude the one prefixed with _
+    filtered_columns_metadata = []
+    for row in columns_metadata:   
+        prefixed_column = "_"+row[0]
+        if row[0] in excluded_columns and prefixed_column in columns_metadata_map:
+            logging.info(f"Not excluding column {row[0]} as {prefixed_column} is also excluded")
+        elif row[0] in excluded_columns:
+            logging.info(f"Excluding column {row[0]}")
+            continue
+        filtered_columns_metadata.append(row)
+       
+    for row in filtered_columns_metadata:
         column_name = '"'+row[0]+'"'
         data_type = row[1]
         is_nullable = row[2]
@@ -124,9 +136,6 @@ def get_table_checksum_query(conn, table):
             if first_column:
                 select += " "
 
-        if not first_column:
-            select += "'#'||"
-
         if 'timestamp' in data_type:
             select += "replace(to_char("+column_name + \
                 ",'YYYY-MM-DD HH24:MI:SS.US'),'1900-01-01 ','')"
@@ -141,9 +150,9 @@ def get_table_checksum_query(conn, table):
                 select += "toDecimalString("+column_name + \
                     ","+str(numeric_scale)+")"
             elif "DateTime64(0" in data_type:
-                select += f"toString({column_name})"
+                select += f"if(toString({column_name}) >= '{args.max_datetime_value}', '{args.max_datetime_value}', if(toString({column_name}) < '{args.min_datetime_value}', '{args.min_datetime_value}', trim(TRAILING '.' from (trim(TRAILING '0' FROM toString({column_name}))))))"
             elif "DateTime64(6" in data_type:
-                select += f"if(toString({column_name}) > '{args.max_datetime_value}', '{args.max_datetime_value}', toString({column_name}))"
+                select += f"if(toString({column_name}) >= '{args.max_datetime_value}', '{args.max_datetime_value}', if(toString({column_name}) < '{args.min_datetime_value}', '{args.min_datetime_value}', trim(TRAILING '.' from (trim(TRAILING '0' FROM toString({column_name}))))))"
             elif "DateTime" in data_type:
                 select += f"trim(TRAILING '.' from (trim(TRAILING '0' FROM toString({column_name}))))"
             else:
@@ -158,6 +167,9 @@ def get_table_checksum_query(conn, table):
 
         if is_nullable == 1:
             select += " end"
+
+        if not filtered_columns_metadata.index(row) == len(filtered_columns_metadata)-1:
+            select += "||'#'"
         first_column = False
         data_types[row[0]] = data_type
     logging.debug(str(nullables))
@@ -345,6 +357,8 @@ def main():
                         nargs='*', default=['_sign,_version,is_deleted,_is_deleted'])
     parser.add_argument('--threads', type=int,
                         help='number of parallel threads', default=1)
+    parser.add_argument(
+            '--min_datetime_value', help='Min Datetime64 datetime', default='1900-01-01 00:00:00', required=False)
     parser.add_argument(
             '--max_datetime_value', help='Maximum Datetime64 datetime', default='2299-12-31 23:59:59.000000', required=False)
 

--- a/sink-connector/python/db_compare/mysql_table_checksum.py
+++ b/sink-connector/python/db_compare/mysql_table_checksum.py
@@ -50,7 +50,7 @@ def compute_checksum(table, statements, conn):
     return result
 
 
-def get_table_checksum_query(table, conn, binary_encoding, where):
+def get_table_checksum_query(table, conn, binary_encoding, where, excluded_columns):
 
     (rowset, rowcount) = execute_mysql(conn, "select COLUMN_NAME as column_name, column_type as data_type, IS_NULLABLE as is_nullable from information_schema.columns where table_schema='" +
                                        args.mysql_database+"' and table_name = '"+table+"' order by ordinal_position")
@@ -67,25 +67,36 @@ def get_table_checksum_query(table, conn, binary_encoding, where):
         data_type = row['data_type']
         is_nullable = row['is_nullable']
 
+        if row['column_name'] in excluded_columns:
+            logging.info("Excluding column "+row['column_name'])
+            continue
+        
         if not first_column:
             select += ","
-
+            
         if is_nullable == 'YES':
             nullables.append(column_name)
-        if 'datetime' == data_type or 'datetime(1)' == data_type or 'datetime(2)' == data_type or 'datetime(3)' == data_type:
+        
+        select_column = ""
+        if 'json' in data_type :
+            # convert to a compact representation, best effort, it is not perfect and it is advised to ignore those columns
+            # https://bugs.mysql.com/bug.php?id=118990
+            # https://github.com/Altinity/clickhouse-sink-connector/issues/1137
+            select_column += f"""REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(regexp_replace(regexp_replace(regexp_replace(regexp_replace(regexp_replace(convert(json_pretty({column_name}) using utf8mb4),'": "','":"'),'":\\\\s(-*\\\\d|\\\\[|\\\\{{|true|false)','":$1'),'\\\\.0\\\\b',''),'\\\\s+(".*?)\\\\s*','$1'),'\\\\s*\\\\n\\\\\\s*',''), '\\\\\\\\u([0-9A-F]{{3}})a', '\\\\\\\\u$1A'), '\\\\\\\\u([0-9A-F]{{3}})b', '\\\\\\\\u$1B'), '\\\\\\\\u([0-9A-F]{{3}})c', '\\\\\\\\u$1C'), '\\\\\\\\u([0-9A-F]{{3}})d', '\\\\\\\\u$1D'), '\\\\\\\\u([0-9A-F]{{3}})e', '\\\\\\\\u$1E'), '\\\\\\\\u([0-9A-F]{{3}})f', '\\\\\\\\u$1F')"""
+        elif 'datetime' == data_type or 'datetime(1)' == data_type or 'datetime(2)' == data_type or 'datetime(3)' == data_type:
             # CH datetime range is not the same as MySQL https://clickhouse.com/docs/en/sql-reference/data-types/datetime64/
-            select += f"case when {column_name} >=  substr('{max_datetime_value}', 1, length({column_name})) then substr(TRIM(TRAILING '0' FROM CAST('{max_datetime_value}' AS datetime(3))),1,length({column_name})) else case when {column_name} <= '{min_date_value} 00:00:00' then TRIM(TRAILING '.' FROM TRIM(TRAILING '0' FROM CAST('{min_date_value} 00:00:00.000' AS datetime(3)))) else TRIM(TRAILING '.' FROM TRIM(TRAILING '0' FROM {column_name})) end end"
+            select_column += f"case when {column_name} >=  substr('{max_datetime_value}', 1, length({column_name})) then substr(TRIM(TRAILING '0' FROM CAST('{max_datetime_value}' AS datetime(3))),1,length({column_name})) else case when {column_name} <= '{args.min_datetime_value}' then TRIM(TRAILING '.' FROM TRIM(TRAILING '0' FROM CAST('{args.min_datetime_value}' AS datetime(3)))) else substr(TRIM(TRAILING '.' from (TRIM(TRAILING '0' from cast({column_name} as char)))),1,length({column_name})) end end"
         elif 'datetime(4)' == data_type or 'datetime(5)' == data_type or 'datetime(6)' == data_type:
             # CH datetime range is not the same as MySQL https://clickhouse.com/docs/en/sql-reference/data-types/datetime64/ii
-            select += f"case when {column_name} >= substr('{max_datetime_value}', 1, length({column_name})) then substr(TRIM(TRAILING '.' FROM TRIM(TRAILING '0' FROM CAST('{max_datetime_value}' AS datetime(6)))),1,length({column_name})) else case when {column_name} <= '{min_date_value} 00:00:00' then TRIM(TRAILING '.' FROM TRIM(TRAILING '0' FROM CAST('{min_date_value} 00:00:00.000000' AS datetime(6)))) else  {column_name} end end"
+            select_column += f"case when {column_name} >= substr('{max_datetime_value}', 1, length({column_name})) then substr(TRIM(TRAILING '.' FROM TRIM(TRAILING '0' FROM CAST('{max_datetime_value}' AS datetime(6)))),1,length({column_name})) else case when {column_name} <= '{args.min_datetime_value}' then TRIM(TRAILING '.' FROM TRIM(TRAILING '0' FROM CAST('{args.min_datetime_value}' AS datetime(6)))) else  substr(TRIM(TRAILING '.' from (TRIM(TRAILING '0' from cast({column_name} as char)))),1,length({column_name})) end end"
         elif 'time' == data_type or 'time(1)' == data_type or 'time(2)' == data_type or 'time(3)' == data_type or 'time(4)' == data_type or 'time(5)' == data_type or 'time(6)' == data_type:
-            select += f"substr(cast({column_name} as time(6)),1,length({column_name}))"
+            select_column += f"substr(cast({column_name} as time(6)),1,length({column_name}))"
         elif 'timestamp' == data_type or 'timestamp(1)' == data_type or 'timestamp(2)' == data_type or 'timestamp(3)' == data_type or 'timestamp(4)' == data_type or 'timestamp(5)' == data_type or 'timestamp(6)' == data_type:
-            select += f"substr(TRIM(TRAILING '.' from (TRIM(TRAILING '0' from cast({column_name} as char)))),1,length({column_name}))"
+            select_column += f"substr(TRIM(TRAILING '.' from (TRIM(TRAILING '0' from cast({column_name} as char)))),1,length({column_name}))"
         else:
             if 'date' == data_type:  # Date are converted to Date32 in CH
               # CH date range is not the same as MySQL https://clickhouse.com/docs/en/sql-reference/data-types/date
-                select += f"case when {column_name} >='{max_date_value}' then CAST('{max_date_value}' AS {data_type}) else case when {column_name} <= '{min_date_value}' then CAST('{min_date_value}' AS {data_type}) else {column_name} end end"
+                select_column += f"case when {column_name} >='{max_date_value}' then CAST('{max_date_value}' AS {data_type}) else case when {column_name} <= '{min_date_value}' then CAST('{min_date_value}' AS {data_type}) else {column_name} end end"
             else:
                 if is_binary_datatype(data_type):
                     binary_encode = "lower(hex(cast(" + \
@@ -93,9 +104,13 @@ def get_table_checksum_query(table, conn, binary_encoding, where):
                     if binary_encoding == 'base64':
                         binary_encode = "replace(to_base64(cast(" + \
                             column_name+" as binary)),'\\n','')"
-                    select += binary_encode
+                    select_column += binary_encode
                 else:
-                    select += column_name + ""
+                    select_column += f"{column_name}"
+                    
+        if is_nullable == 'YES':
+            select_column = f"ifnull({select_column},'')"
+        select+=select_column
         first_column = False
         data_types[row['column_name']] = data_type
 
@@ -117,7 +132,7 @@ def get_table_checksum_query(table, conn, binary_encoding, where):
     if len(primary_key_columns) > 0:
         order_by_columns = ','.join(primary_key_columns)
 
-    query = "select "+select+"  as query from "+args.mysql_database+"."+table
+    query = "select "+select+"  as query from `"+args.mysql_database+"`.`"+table+"`"
     if where :
         query += " where "+where
 
@@ -135,6 +150,7 @@ def get_table_checksum_query(table, conn, binary_encoding, where):
 @staticmethod
 def fstr(template, partition_expression):
         return eval(f"f'{template}'")
+
 
 def select_table_statements(table, query, select_query, order_by, external_column_types, _where):
     statements = ['set names utf8mb4']
@@ -178,7 +194,7 @@ def get_tables_from_regexp(conn, tables_regexp):
     return get_tables_from_regex(conn, args.no_wc, args.mysql_database, tables_regexp)
 
 
-def calculate_sql_checksum(conn, table, where):
+def calculate_sql_checksum(conn, table, where, excluded_columns):
     result = None
     try:
         if args.ignore_tables_regex:
@@ -191,7 +207,7 @@ def calculate_sql_checksum(conn, table, where):
         statements = []
 
         (query, select_query, distributed_by,
-         external_table_types) = get_table_checksum_query(table, conn, args.binary_encoding, where)
+         external_table_types) = get_table_checksum_query(table, conn, args.binary_encoding, where, excluded_columns)
         statements = select_table_statements(
             table, query, select_query, distributed_by, external_table_types, where)
         result = compute_checksum(table, statements, conn)
@@ -201,7 +217,7 @@ def calculate_sql_checksum(conn, table, where):
     return result
 
 
-def calculate_checksum_single_thread(mysql_table, mysql_user, mysql_password, chunk, pk, where):
+def calculate_checksum_single_thread(mysql_table, mysql_user, mysql_password, chunk, pk, where, excluded_columns):
     conn = get_mysql_connection(args.mysql_host, mysql_user, mysql_password, args.mysql_port, args.mysql_database)
     _where = "1=1"
     if where:
@@ -211,11 +227,11 @@ def calculate_checksum_single_thread(mysql_table, mysql_user, mysql_password, ch
         max_pk = int(chunk['max_pk'])
         _where = f" {_where} and {pk} between {min_pk} and {max_pk}" 
 
-    result = calculate_sql_checksum(conn, mysql_table, _where)
+    result = calculate_sql_checksum(conn, mysql_table, _where, excluded_columns)
     return result
 
 
-def calculate_checksum(mysql_table, mysql_user, mysql_password):
+def calculate_checksum(mysql_table, mysql_user, mysql_password, excluded_columns):
     if args.ignore_tables_regex:
         rex_ignore_tables = re.compile(args.ignore_tables_regex, re.IGNORECASE)
         if rex_ignore_tables.match(mysql_table):
@@ -263,7 +279,7 @@ def calculate_checksum(mysql_table, mysql_user, mysql_password):
             futures = []
             for chunk in divide_table_into_even_chunks(conn, mysql_table, args.chunk_size, pk, where): 
                 futures.append(executor.submit(
-                    calculate_checksum_single_thread, mysql_table, mysql_user, mysql_password, chunk, pk, where))
+                    calculate_checksum_single_thread, mysql_table, mysql_user, mysql_password, chunk, pk, where, excluded_columns))
             for future in concurrent.futures.as_completed(futures):
                 result.append(future.result())
                 if future.exception() is not None:
@@ -334,11 +350,13 @@ def main():
     parser.add_argument(
         '--max_date_value', help='Maximum Date32/Datetime64 date', default='2299-12-31', required=False)
     parser.add_argument(
+            '--min_datetime_value', help='Min Datetime64 datetime', default='1970-01-01 00:00:00', required=False)
+    parser.add_argument(
             '--max_datetime_value', help='Maximum Datetime64 datetime', default='2299-12-31 23:59:59', required=False)
     parser.add_argument('--debug', dest='debug',
                         action='store_true', default=False)
     parser.add_argument('--exclude_columns', help='columns exclude',
-                        nargs='+', default=['_sign', '_version'])
+                        nargs='+', default=[])
     parser.add_argument('--threads_per_table', type=int,
                         help='number of parallel threads per table', default=1)
     parser.add_argument('--chunk_size', type=int, help='Chunk size', default=10000)
@@ -382,7 +400,7 @@ def main():
             future_to_table = {}
             for table in tables.fetchall():
                 future = executor.submit(
-                    calculate_checksum, table['table_name'], mysql_user, mysql_password)
+                    calculate_checksum, table['table_name'], mysql_user, mysql_password, args.exclude_columns)
                 futures.append(future)
                 future_to_table[future] = table['table_name']
             for future in concurrent.futures.as_completed(futures):

--- a/sink-connector/python/db_compare/top_level_table_checksum.py
+++ b/sink-connector/python/db_compare/top_level_table_checksum.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+import yaml
+import sys
+import argparse
+import logging
+from db.mysql import *
+import concurrent.futures
+from datetime import datetime
+from subprocess import Popen, PIPE
+import subprocess
+import time
+
+def parse_config(config_file):
+    """Parse the YAML configuration file."""
+    try:
+        with open(config_file, 'r') as file:
+            config = yaml.safe_load(file)
+        return config
+    except FileNotFoundError:
+        logging.error(f"Error: Configuration file '{config_file}' not found.")
+        sys.exit(1)
+    except yaml.YAMLError as e:
+        logging.error(f"Error parsing YAML file: {e}")
+        sys.exit(1)
+    except Exception as e:
+        logging.error(f"Unexpected error: {e}")
+        sys.exit(1)
+
+
+def validate_config(config):
+    """Validate the configuration structure."""
+    try:
+        # Check source section
+        source = config['source']
+        mysql = source['mysql']
+        host = mysql['host']
+        
+        # Check replicas section
+        replicas = config['replicas']
+        if not isinstance(replicas, list):
+            logging.error("Error: 'replicas' must be a list")
+            return False
+            
+        for i, replica in enumerate(replicas):
+            if 'clickhouse' not in replica:
+                logging.error(f"Error: 'clickhouse' missing in replica {i+1}")
+                return False
+            if 'host' not in replica['clickhouse']:
+                logging.error(f"Error: 'host' missing in replica {i+1}")
+                return False
+                
+        return True
+    except KeyError as e:
+        logging.error(f"Error: Missing required configuration key: {e}")
+        return False
+
+
+def parse_checksum(data, table):
+    # Step 1: Decode the byte string into a regular string
+    decoded_data = data.decode('utf-8').strip()  # Remove the trailing newline with .strip()
+    # Step 2: Split the string into components
+    parts = decoded_data.split()
+    checksum = None
+    row_count = None
+    if len(parts) == 3:
+        # Extract the three values
+        table = parts[0]      
+        checksum = parts[1]   
+        row_count = int(parts[2]) 
+    else:
+        logging.error(f"Invalid checksum output from {data} for table {table}")
+    return (table, checksum, row_count)
+
+
+def run_quick_safe_checksum(cmd, host, table):
+    start = time.perf_counter()    
+    (rc, stdout) = run_quick_safe_command(cmd)
+    duration = time.perf_counter() - start
+    if rc == '0':
+        (table, checksum, count) = parse_checksum(stdout, table)
+        logging.info(f"{( host, table, checksum, count)} in {duration:0.3f} seconds" )
+        return ( host, table, checksum, count)
+    else:
+        logging.error(f"{cmd}. failed")
+        return None
+    
+
+def compute_checksum (database, table, mysql_user, mysql_password, mysql_host, replica_hosts, pk, max_pk, where, ignored_columns=[], debug_output=False):
+    table_name = f"{database}.{table}"
+    logging.info(f"Checksumming {table_name}")
+    commands = []
+    cmd = get_mysql_checksum_command(mysql_host, database, table, pk, max_pk, where=where, ignored_columns=ignored_columns, debug_output=debug_output)
+    
+    commands.append((mysql_host,cmd))
+    
+    for ch_host in replica_hosts:
+         cmd = get_clickhouse_checksum_command(ch_host, database, table, pk, max_pk, where=where, ignored_columns=ignored_columns, debug_output=debug_output)
+         commands.append((ch_host, cmd))
+    results = []    
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(commands)) as executor:
+            futures = []
+            for (host, cmd) in commands:
+                future = executor.submit(
+                    run_quick_safe_checksum, cmd, host, table)
+                futures.append(future)
+            for future in concurrent.futures.as_completed(futures):
+                if future.exception() is not None:
+                    raise future.exception()
+                else:
+                    results.append(future.result())
+    return results
+
+
+def get_tables_from_regexp(conn, database, tables_regexp):
+    return get_tables_from_regex(conn, args.no_wc, database, tables_regexp, include_partitions_regex=args.include_partitions_regex, exclude_tables_regex=args.exclude_tables_regex, non_partitioned_tables_only=args.non_partitioned_tables_only)
+
+
+def get_mysql_checksum_command(mysql_host, database, table, pk, max_pk, where, ignored_columns=[], debug_output=False):
+    partition_date = args.partition_date
+    where_argument = '--where " 1=1 '
+    if where:
+        where_argument += f" and {where} "
+    if partition_date:
+      where_argument += f""" and {{partition_expression}}={partition_date:%Y%m%d}"""
+    where_argument += '"'
+    
+    ignored_columns_clause = ""
+    if len(ignored_columns) > 0:
+        logging.info(f"Ignoring columns {ignored_columns} for table {table}")
+        ignored_columns_clause = "--exclude_columns "+",".join(ignored_columns)
+        
+    debug_output_clause = ""
+    if debug_output:
+        debug_output_clause = "--debug_output"
+        
+    cmd = f"""set -e pipefail;python db_compare/mysql_table_checksum.py --threads_per_table {args.threads_per_table} --threads={args.threads} --min_date_value "1900-01-01" --mysql_host {mysql_host} --mysql_database {database} --tables_regex "^{table}$" {where_argument} --min_datetime_value "1969-12-31 18:00:00"  --max_datetime_value "2299-12-31 00:00:00"  --binary_encoding base64 {ignored_columns_clause} {debug_output_clause} | grep -i checksum | awk '{{print $11" "$13" "$15}}' """ 
+    logging.debug(f"MySQL command: {cmd}")
+    return cmd 
+
+
+def get_clickhouse_checksum_command(ch_host, database, table, pk, max_pk, where=None, ignored_columns=[], debug_output=False):
+    partition_date = args.partition_date   
+    where_argument = '--where " 1=1 '
+    if where:
+        where_argument += f" and {where} "
+    if partition_date:
+      where_argument += f""" and {{partition_expression}}="""+f"""toDate(\\\\'{partition_date:%Y-%m-%d}\\\\') """
+    where_argument += '"'
+    
+    ignored_columns_clause = "--exclude_columns _version,is_deleted,_is_deleted"
+    if len(ignored_columns) > 0:
+        logging.info(f"Ignoring columns {ignored_columns} for table {table}")
+        ignored_columns_clause += ","+",".join(ignored_columns)
+    
+    debug_output_clause = ""
+    if debug_output:
+        debug_output_clause = "--debug_output"
+        
+    cmd = f"""set -e pipefail;python db_compare/clickhouse_table_checksum.py --max_memory_usage 80000000000 --threads={args.threads} --clickhouse_host {ch_host} --clickhouse_database  {database}  --tables_regex "^{table}$" {where_argument}  --min_datetime_value "1969-12-31 18:00:00"  --max_datetime_value "2299-12-31 00:00:00" {ignored_columns_clause} --sign_column "" {debug_output_clause} |grep -i checksum | awk '{{print $11" "$13" "$15}}' """ 
+    return cmd 
+
+
+def analyze_differences(results, mysql_host, replica_hosts):
+    source_results = [result for result in results if result[0] == mysql_host]
+    replica_results = [result for result in results if result[0] in replica_hosts]
+    if len(source_results) == 1:
+        (mysql_checksum, mysql_count) = (source_results[0][2], source_results[0][3])
+        is_difference = False
+        for replica_result in replica_results:
+            (checksum, count) = (replica_result[2], replica_result[3])
+            if  (checksum, count) !=  (mysql_checksum, mysql_count):
+                logging.warning(f"Checksum difference : {replica_result} to {source_results[0]}")
+                is_difference = True
+        if not is_difference:
+            logging.info(f"No difference for {source_results[0][1]}")
+    
+    
+def lock_tables(conn, table):
+    lock_stmt = f"FLUSH TABLE {table} WITH READ LOCK"
+    logging.info(f"Locking table with statement {lock_stmt}")
+    execute_mysql(conn, lock_stmt)
+    
+    
+def unlock_tables(conn, table):
+    unlock_stmt = "UNLOCK TABLES"
+    logging.info(f"Unlocking table {table} with statement {unlock_stmt}")
+    execute_mysql(conn, unlock_stmt)
+    
+def run_config(config):
+    """Display the parsed configuration."""
+    logging.info("\nConfiguration Details:")
+    
+    mysql_host = config['source']['mysql']['host']
+    logging.info(f"Source MySQL Host: {mysql_host}")
+    
+    replica_hosts = []
+    for i, replica in enumerate(config['replicas']):
+        replica_hosts.append(replica['clickhouse']['host'])
+    
+    logging.info(f"\nFound {len( config['replicas'])} ClickHouse replicas: {replica_hosts}")
+    
+    
+    mysql_user = args.mysql_user
+    config_file = args.defaults_file
+    (mysql_user, mysql_password) = resolve_credentials_from_config(config_file)
+
+    database = args.mysql_database
+    databases = []
+    if not database:    
+        databases = config['source']['mysql']['databases'] if 'databases' in config['source']['mysql'] else []
+        if len(databases) == 0:
+            logging.error("If not specifying --mysql_database, there must at least one database in the config file under mysql:databases")
+            sys.exit(1)
+        logging.info(f"Using MySQL databases: {databases}") 
+    else:
+        databases = [database]  
+    
+    ignored_columns = config['source']['mysql']['ignored_columns'] if 'ignored_columns' in config['source']['mysql'] else []
+    ignored_columns_map = {}
+    for ignored_column in ignored_columns:
+        logging.info(f"Ignoring column {ignored_column}")
+        ignored_columns_split = ignored_column.split('.')  
+        db = ignored_columns_split[0]
+        table = ignored_columns_split[1]
+        col = ignored_columns_split[2]
+        if len(ignored_columns_split) == 3:
+            if db not in ignored_columns_map:
+                ignored_columns_map[db] = {}
+            if table not in ignored_columns_map[db]:
+                ignored_columns_map[db][table] = {}
+            ignored_columns_map[db][table][col] = True
+       
+    for database in databases:
+        logging.info(f"Using MySQL database: {database}")
+        try:
+            conn = get_mysql_connection(mysql_host, mysql_user,
+                                    mysql_password, args.mysql_port, database)
+            tables = get_tables_from_regexp(conn, database, args.tables_regex)
+            with concurrent.futures.ThreadPoolExecutor(max_workers=args.threads) as executor:
+                futures = []
+                future_to_table = {}
+                future_to_conn = {}
+                for table in tables.fetchall():
+                    if args.lock_tables_on_source:
+                        # we need a new connection for each table since the lock is per connection
+                        conn = get_mysql_connection(mysql_host, mysql_user,
+                                    mysql_password, args.mysql_port, database)
+                        logging.info(f"Locking table {table['table_name']} on source {mysql_host}")
+                        lock_tables(conn, table['table_name'])
+                        time.sleep(args.sleep_after_lock)  # slight delay for the sink-connector to catch up
+                        future_to_conn[table['table_name']] = conn
+                        
+                    pk = mysql_pk_columns(conn, database, table['table_name'])
+                    pk_column = pk[0] if len(pk) > 0 else 'NULL'
+                    (min_pk, max_pk) = get_min_max_pk_value(conn, table['table_name'], pk_column, '1=1')
+                    table_name = f"{database}.{table['table_name']}"
+                    ignored_columns = []
+                    if database in ignored_columns_map and table['table_name'] in ignored_columns_map[database]:
+                        ignored_columns = list(ignored_columns_map[database][table['table_name']].keys())
+                    future = executor.submit(
+                        compute_checksum, database, table['table_name'], mysql_user, mysql_password, mysql_host, replica_hosts, pk_column, max_pk, args.where, ignored_columns = ignored_columns, debug_output = args.debug_output)
+                    futures.append(future)
+                    future_to_table[future] = table['table_name']
+                for future in concurrent.futures.as_completed(futures):
+                    conn =  future_to_conn.get(future_to_table[future], None)
+                    table = future_to_table[future]
+                    if future.exception() is not None:
+                        logging.error("Exception in table " + table)
+                        logging.error(future.exception())
+                        if conn:
+                            unlock_tables(conn, table)
+                        raise future.exception()
+                    else:
+                        if conn:
+                            unlock_tables(conn, table)
+                        analyze_differences(future.result(), mysql_host, replica_hosts)      
+
+        except (KeyboardInterrupt, SystemExit):
+            logging.info("Received interrupt")
+            os._exit(1)
+        except Exception as e:
+            logging.error("Exception in main thread : " + str(e))
+            logging.error(traceback.format_exc())
+            sys.exit(1)
+
+    logging.debug("Exiting Main Thread")
+    sys.exit(0)
+
+def run_quick_safe_command(cmd):
+    logging.debug("cmd " + cmd)
+    process = subprocess.Popen(cmd,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.STDOUT,
+                               shell=True)
+    stdout, stderr = process.communicate()
+    rc = str(process.poll())
+    if stdout:
+        logging.debug(str(stdout).strip())
+    logging.debug("return code = " + rc)
+    if rc != "0":
+        logging.error("command failed : terminating")
+    return rc, stdout
+
+
+def valid_date(s, format= "%Y-%m-%d"):
+    try:
+        try :
+            return datetime.strptime(s, format)
+        except:
+            return datetime.strptime(s, "%Y/%m/%d")
+    except ValueError:
+        msg = "Not a valid date: '{0}'.".format(s)
+        raise argparse.ArgumentTypeError(msg)
+
+# hack to add the user to the logger, which needs it apparently
+old_factory = logging.getLogRecordFactory()
+
+
+def record_factory(*args, **kwargs):
+    record = old_factory(*args, **kwargs)
+    record.user = "me"
+    return record
+
+
+logging.setLogRecordFactory(record_factory)
+
+def main():
+    parser = argparse.ArgumentParser(description='Parse and display a database configuration file')
+    parser.add_argument('--config_file', help='Path to the YAML configuration file', required=True)
+    # it can be useful to specify a date to checksum a subset of the date based on a partition by date
+    parser.add_argument('--partition_date', help='date of partition - format yyyy/mm/dd', type=valid_date, required=False, default=None)
+    parser.add_argument('--mysql_user', help='MySQL user', required=False)
+    parser.add_argument('--defaults_file',
+                        help='MySQL config file default is ~/.my.cnf', required=False, default='~/.my.cnf')
+    parser.add_argument('--mysql_database',
+                        help='MySQL database', required=False)
+    parser.add_argument('--mysql_port', help='MySQL port',
+                        default=3306, required=False)
+    parser.add_argument('--tables_regex', help='table regexp', required=False, default='.')
+    parser.add_argument('--exclude_tables_regex',
+                        help='exclude table regexp', required=False)
+    parser.add_argument('--include_partitions_regex', help='partitions regex', required=False, default=None)
+    parser.add_argument('--non_partitioned_tables_only', dest='non_partitioned_tables_only', action='store_true', default=False)
+    parser.add_argument('--clickhouse_user',
+                        help='ClickHouse user', required=False)
+    parser.add_argument('--clickhouse_config_file',
+                        help='CH config file either xml or yaml, default is ./clickhouse-client.xml', required=False, default='./clickhouse-client.xml')
+    parser.add_argument('--clickhouse_database',
+                        help='ClickHouse database', required=False, default=None)
+    parser.add_argument('--clickhouse_port',
+                        help='ClickHouse port', default=9000, required=False)
+    parser.add_argument('--secure',
+                        help='True or False', default=False, required=False)
+    parser.add_argument('--threads_per_table', type=int,
+                        help='number of parallel threads per table', default=1)
+    parser.add_argument('--chunk_size', type=int, help='Chunk size', default=10000)
+    parser.add_argument('--threads', type=int,
+                        help='number of tables in parallel to compute', default=1)
+    parser.add_argument('--debug', dest='debug',
+                        action='store_true', default=False)
+    parser.add_argument('--debug_output', dest='debug_output',
+                        action='store_true', default=False)
+    parser.add_argument('--no_wc', action='store_true', default=False,
+                        help='Use --tables_regex as the table', required=False)
+    parser.add_argument('--where', help='where clause', required=False)
+    parser.add_argument('--lock_tables_on_source', action='store_true', default=False,
+                        help='Lock the table on the source so that source and target are in sync ...', required=False)
+    parser.add_argument('--sleep_after_lock', type=int, help='When locking, sleeping n seconds', default=3)
+    global args
+    args = parser.parse_args()
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.INFO)
+
+    formatter = logging.Formatter(
+        '%(asctime)s - %(levelname)s - %(threadName)s - %(message)s')
+    handler.setFormatter(formatter)
+    root.addHandler(handler)
+
+    if args.debug:
+        root.setLevel(logging.DEBUG)
+        handler.setLevel(logging.DEBUG)
+        
+    # Parse the configuration file
+    config = parse_config(args.config_file)
+    
+    # Validate the configuration
+    if validate_config(config):
+        logging.info("Configuration is valid.")
+        run_config(config)
+    else:
+        print("Invalid configuration. Please check your YAML file.")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduced a new features and many bug fixes  : 

`top_level_table_checksum.py` 

- support for multiple databases

```
source:
    mysql:
        host: mysql1
        databases:
          - test
        ignored_columns:
            # https://github.com/Altinity/clickhouse-sink-connector/issues/1136
            - test.bit_table.bit1_column
           # https://github.com/Altinity/clickhouse-sink-connector/issues/1137
            - test.json_table.json_column

replicas:
    - clickhouse:
        host: clickhouse1
    - clickhouse:
        host: clickhouse2

```
- `--lock_tables_on_source` locks tables on the source (it should be a replica not to block writes but only replication)
- `--sleep_after_lock` sleeps after lock to wait for data to replicate

`mysql_table_checksum.py`

- escapes table names
- ability to exclude columns
- attempts to format JSON columns (compact format)

`clickhouse_table_checksum.py`

- fix checksums with NULL values in the first column
- trim the trailing zeroes in DateTimes similar to MySQL checksums
- support for `is_deleted` in the source table (previously it was ignored, leading to different checksums