### PR TITLE
Enable running publish.yml separately

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,19 @@ on:
         required: false
       DOCKERHUB_TOKEN:
         required: false
+  workflow_dispatch:
+    inputs: 
+      release_tag:
+        required: true
+        type: string
+      prerelease:
+        required: true
+        type: boolean
+        default: true
+      draft:
+        required: true
+        type: boolean
+        default: false
 
 env:
   release_tag: ${{ inputs.release_tag }}


### PR DESCRIPTION
Add workflow_dispatch to publish.yml to run it separately. 