### PR TITLE
Versioning fix for mysql without gtid enabled

### DIFF
--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/PreparedStatementExecutor.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/PreparedStatementExecutor.java
@@ -494,8 +494,13 @@ public class PreparedStatementExecutor {
                             }
                         } else if (record.getSequenceNumber() != -1) {
                             ps.setLong(columnNameToIndexMap.get(versionColumn),  record.getSequenceNumber());
-                        } else {
+                        } else if (record.getLsn() != -1) {
                             ps.setLong(columnNameToIndexMap.get(versionColumn),  record.getLsn());
+                        } else {
+                            // Fallback when gtid, sequenceNumber, and lsn are all unavailable (-1).
+                            // Use SnowFlakeId with kafka offset to provide sub-millisecond uniqueness.
+                            ps.setLong(columnNameToIndexMap.get(versionColumn), 
+                                SnowFlakeId.generate(record.getTs_ms(), record.getKafkaOffset(), false));
                         }
                 }
             }

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/common/SnowFlakeIdTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/common/SnowFlakeIdTest.java
@@ -20,4 +20,35 @@ public class SnowFlakeIdTest {
 
     }
 
+    /**
+     * Test that SnowFlakeId.generate() with gtid=-1 still produces a valid positive number.
+     * This is important because -1 written directly to a UInt64 column would become
+     * 18446744073709551615 (max UInt64) which causes overflow when read back as signed long.
+     */
+    @Test
+    public void testGenerateWithNegativeGtid() {
+        long timestamp = System.currentTimeMillis();
+        long negativeGtid = -1L;
+        
+        long snowFlakeId = SnowFlakeId.generate(timestamp, negativeGtid, false);
+        
+        // The generated ID should be positive (within signed long range)
+        Assert.assertTrue("SnowFlakeId should be positive", snowFlakeId > 0);
+        // Should not be the max UInt64 value that causes overflow
+        Assert.assertNotEquals("Should not be max UInt64 value", -1L, snowFlakeId);
+    }
+
+    /**
+     * Test that timestamp used as version fallback is always positive and fits in UInt64.
+     * When gtid, sequenceNumber, and lsn are all -1, we use ts_ms as fallback.
+     */
+    @Test
+    public void testTimestampAsVersionFallback() {
+        long timestamp = System.currentTimeMillis();
+        
+        // Timestamp should always be positive and fit in both signed long and UInt64
+        Assert.assertTrue("Timestamp should be positive", timestamp > 0);
+        Assert.assertTrue("Timestamp should fit in signed long", timestamp < Long.MAX_VALUE);
+    }
+
 }


### PR DESCRIPTION
fixes: #1213

fallback mechanism for versioning by using SnowFlakeId for sub-millisecond uniqueness when gtid, sequenceNumber, and lsn are unavailable