### PR TITLE
Update runner labels to more available types

### DIFF
--- a/.github/workflows/sink-connector-kafka-tests.yml
+++ b/.github/workflows/sink-connector-kafka-tests.yml
@@ -19,7 +19,7 @@ env:
         
 jobs:
   java-kafka:
-    runs-on: [ self-hosted, on-demand, type-cpx51, image-x86-app-docker-ce ]
+    runs-on: [ self-hosted, on-demand, type-cx53, image-x86-app-docker-ce ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 17

--- a/.github/workflows/sink-connector-lightweight-tests.yml
+++ b/.github/workflows/sink-connector-lightweight-tests.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   java-lightweight:
-    runs-on: [ self-hosted, on-demand, type-cpx51, image-x86-app-docker-ce ]
+    runs-on: [ self-hosted, on-demand, type-cx53, image-x86-app-docker-ce ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 17

--- a/.github/workflows/testflows-sink-connector-kafka.yml
+++ b/.github/workflows/testflows-sink-connector-kafka.yml
@@ -67,7 +67,7 @@ env:
 
 jobs:
   testflows-kafka:
-    runs-on: [self-hosted, on-demand, type-cpx51, image-x86-app-docker-ce]
+    runs-on: [self-hosted, on-demand, type-cx53, image-x86-app-docker-ce]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/testflows-sink-connector-lightweight.yml
+++ b/.github/workflows/testflows-sink-connector-lightweight.yml
@@ -83,7 +83,7 @@ env:
 
 jobs:
   testflows-lightweight:
-    runs-on: [self-hosted, on-demand, type-cpx51, image-x86-app-docker-ce]
+    runs-on: [self-hosted, on-demand, type-cx53, image-x86-app-docker-ce]
 
     steps:
       - uses: actions/checkout@v2
@@ -161,7 +161,7 @@ jobs:
           if-no-files-found: error
           retention-days: 60
   testflows-lightweight-replicated:
-    runs-on: [self-hosted, on-demand, type-cpx51, image-x86-app-docker-ce]
+    runs-on: [self-hosted, on-demand, type-cx53, image-x86-app-docker-ce]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Changing the cpx51 runners tot cx53, which is cheaper and should be more commonly available, with the same available resources.