### PR TITLE
Fix NullPointerException when config properties are missing

### DIFF
--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumJdbcStorageOperations.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumJdbcStorageOperations.java
@@ -83,14 +83,14 @@ public class DebeziumJdbcStorageOperations {
         String createSchemaHistoryTableQuery = props.getProperty(
                 JdbcOffsetBackingStoreConfig.OFFSET_STORAGE_PREFIX +
                         JdbcSchemaHistoryConfig.PROP_TABLE_DDL.name());
-        String formattedCreateSchemaHistoryTableQuery = String.format(createSchemaHistoryTableQuery, dbName, dbName + "." + tableName);
-
         if (createSchemaHistoryTableQuery == null ||
-                createSchemaHistoryTableQuery.isEmpty() == true) {
+                createSchemaHistoryTableQuery.isEmpty()) {
             log.warn("Skipping creating schema history table as the query " +
                     "was not provided in configuration");
             return;
         }
+        String formattedCreateSchemaHistoryTableQuery = String.format(
+                createSchemaHistoryTableQuery, dbName, dbName + "." + tableName);
         try {
             new DBMetadata(props).executeSystemQuery(conn, formattedCreateSchemaHistoryTableQuery);
         } catch (Exception e) {
@@ -138,9 +138,15 @@ public class DebeziumJdbcStorageOperations {
      *         name as the right element.
      */
     private Pair<String, String> getDebeziumOffsetStorageDatabaseName(Properties props) {
-        String tableName = props.getProperty(
-                JdbcOffsetBackingStoreConfig.OFFSET_STORAGE_PREFIX +
-                        JdbcOffsetBackingStoreConfig.PROP_TABLE_NAME.name());
+        String propKey = JdbcOffsetBackingStoreConfig.OFFSET_STORAGE_PREFIX +
+                JdbcOffsetBackingStoreConfig.PROP_TABLE_NAME.name();
+        String tableName = props.getProperty(propKey);
+        if (tableName == null || tableName.isBlank()) {
+            throw new IllegalArgumentException(
+                    "Required configuration property '" + propKey + "' is not set. "
+                    + "Please add it to your config file (e.g. "
+                    + "offset.storage.jdbc.table.name: \"altinity_sink_connector.replica_source_info\").");
+        }
         return splitTableName(tableName);
     }
 
@@ -399,9 +405,14 @@ public class DebeziumJdbcStorageOperations {
      *         element is the database name.
      */
     private Pair<String, String> getDebeziumSchemaHistoryDatabaseName(Properties props) {
-        String tableName = props.getProperty(
-                SchemaHistory.CONFIGURATION_FIELD_PREFIX_STRING +
-                        JdbcSchemaHistoryConfig.PROP_TABLE_NAME.name());
+        String propKey = SchemaHistory.CONFIGURATION_FIELD_PREFIX_STRING +
+                JdbcSchemaHistoryConfig.PROP_TABLE_NAME.name();
+        String tableName = props.getProperty(propKey);
+        if (tableName == null || tableName.isBlank()) {
+            throw new IllegalArgumentException(
+                    "Required configuration property '" + propKey + "' is not set. "
+                    + "Please add it to your config file.");
+        }
         return splitTableName(tableName);
     }
 

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumJdbcStorageOperationsTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumJdbcStorageOperationsTest.java
@@ -1,0 +1,50 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import io.debezium.storage.jdbc.offset.JdbcOffsetBackingStoreConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DebeziumJdbcStorageOperationsTest {
+
+    @Test
+    @DisplayName("Missing offset.storage.jdbc.table.name throws IllegalArgumentException with property name")
+    void createDatabaseForDebeziumStorage_throwsOnMissingOffsetTableName() {
+        DebeziumJdbcStorageOperations ops = new DebeziumJdbcStorageOperations();
+        Properties emptyProps = new Properties();
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> ops.createDatabaseForDebeziumStorage(null, emptyProps));
+
+        assertTrue(ex.getMessage().contains("offset.storage.jdbc.table.name"),
+                "Error message should name the missing property");
+    }
+
+    @Test
+    @DisplayName("Missing schema history table name throws IllegalArgumentException with property name")
+    void deleteSchemaHistory_throwsOnMissingSchemaHistoryTableName() {
+        DebeziumJdbcStorageOperations ops = new DebeziumJdbcStorageOperations();
+        Properties emptyProps = new Properties();
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> ops.deleteSchemaHistory(null, null, emptyProps));
+
+        assertTrue(ex.getMessage().contains("schema.history.internal"),
+                "Error message should reference the schema history config prefix");
+    }
+
+    @Test
+    @DisplayName("createSchemaHistoryTable returns without NPE when DDL query is absent")
+    void createSchemaHistoryTable_skipsWhenDdlMissing() {
+        DebeziumJdbcStorageOperations ops = new DebeziumJdbcStorageOperations();
+        Properties props = new Properties();
+        String offsetTableKey = JdbcOffsetBackingStoreConfig.OFFSET_STORAGE_PREFIX +
+                JdbcOffsetBackingStoreConfig.PROP_TABLE_NAME.name();
+        props.setProperty(offsetTableKey, "altinity_sink_connector.replica_source_info");
+
+        assertDoesNotThrow(() -> ops.createSchemaHistoryTable(null, props));
+    }
+}


### PR DESCRIPTION
## Summary
closes: #1274

- Fixes #1113
- When `offset.storage.jdbc.table.name` or the schema history table name property is absent from the config file, `splitTableName()` receives `null` and throws a bare `NullPointerException` with no indication of which setting is missing.
- Added null/blank guards in `getDebeziumOffsetStorageDatabaseName()` and `getDebeziumSchemaHistoryDatabaseName()` that throw an `IllegalArgumentException` naming the exact missing property key, with an example of the expected value.
- Moved the null check in `createSchemaHistoryTable()` before the `String.format()` call so it no longer NPEs on a missing DDL query.


