### PR TITLE
Fix double database prefix in DDL replication for TRUNCATE, DROP, and RENAME

### DIFF
--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
@@ -2,139 +2,259 @@ package com.altinity.clickhouse.debezium.embedded.ddl.parser;
 
 import com.altinity.clickhouse.debezium.embedded.cdc.DebeziumChangeEventCapture;
 import com.altinity.clickhouse.debezium.embedded.parser.DataTypeConverter;
+
+import static com.altinity.clickhouse.sink.connector.config.DefaultColumnDataTypeMappingConfig.loadDefaultColumnDataTypeMapping;
 import static com.altinity.clickhouse.sink.connector.db.ClickHouseDbConstants.*;
 import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
 
 import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
 import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfigVariables;
 import com.altinity.clickhouse.sink.connector.common.Utils;
+import com.altinity.clickhouse.sink.connector.config.SchemaOverrideConfig;
+import com.altinity.clickhouse.sink.connector.db.BaseDbWriter;
+import com.altinity.clickhouse.sink.connector.db.DBMetadata;
+import com.altinity.clickhouse.sink.connector.metadata.DataTypeRange;
+import com.clickhouse.data.ClickHouseDataType;
 import io.debezium.ddl.parser.mysql.generated.MySqlParser;
 import io.debezium.ddl.parser.mysql.generated.MySqlParser.AlterByAddColumnContext;
 import io.debezium.ddl.parser.mysql.generated.MySqlParser.TableNameContext;
+import io.debezium.relational.ddl.DataType;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNodeImpl;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.sql.SQLException;
 import java.time.ZoneId;
 import java.util.*;
-
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
- * This class contains the only overridden functions from the generated parser.
+ * This class is an implementation of the MySQL DDL parser listener. It overrides specific methods from the generated
+ * parser to transform and customize the SQL queries for ClickHouse.
  */
 public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
+
+    /**
+     * Logger instance for logging purposes.
+     * This logger is used throughout the class to log messages related to DDL operations.
+     */
     private static final Logger log = LogManager.getLogger(MySqlDDLParserListenerImpl.class);
+
+    /**
+     * The query string that will be transformed.
+     */
     StringBuffer query;
+
+    /**
+     * The name of the table that is part of the DDL operation.
+     */
     String tableName;
+
+    /**
+     * The configuration object that contains connector settings for ClickHouse.
+     */
     ClickHouseSinkConnectorConfig config;
+
+    /**
+     * The time zone provided by the user for handling time-related operations.
+     */
     ZoneId userProvidedTimeZone;
 
+    /**
+     * A map that holds source to destination database mappings.
+     */
+    Map<String, String> sourceToDestinationMap = new HashMap<>();
+
+    /**
+     * The name of the database in the DDL operation.
+     */
     String databaseName;
 
-    public MySqlDDLParserListenerImpl(StringBuffer transformedQuery, String tableName,
-                                      String databaseName,
-                                      ClickHouseSinkConnectorConfig config) {
-        this.databaseName = databaseName;
+    /**
+     * Writer used for database operations.
+     */
+    BaseDbWriter writer;
+
+    /**
+     * Database metadata used for operations.
+     */
+    DBMetadata dbMetadata;
+
+    /**
+     * The original SQL string for regex fallback parsing.
+     */
+    String originalSql;
+
+    /**
+     * Constructor for initializing the MySqlDDLParserListenerImpl instance.
+     *
+     * @param writer         The database writer instance.
+     * @param transformedQuery The transformed SQL query.
+     * @param tableName      The name of the table involved in the operation.
+     * @param databaseName   The name of the database.
+     * @param config         The configuration object containing connector settings.
+     * @param originalSql    The original SQL string for regex fallback parsing.
+     */
+    public MySqlDDLParserListenerImpl(BaseDbWriter writer, StringBuffer transformedQuery, String tableName,
+                                      String databaseName, ClickHouseSinkConnectorConfig config, String originalSql) {
+        this.config = config;
+        try {
+            if (this.config.getString(ClickHouseSinkConnectorConfigVariables.CLICKHOUSE_DATABASE_OVERRIDE_MAP.toString()) != null)
+                sourceToDestinationMap = Utils.parseSourceToDestinationDatabaseMap(this.config.
+                        getString(ClickHouseSinkConnectorConfigVariables.CLICKHOUSE_DATABASE_OVERRIDE_MAP.toString()));
+        } catch(Exception e) {
+            log.error("enterCreateDatabase: Error parsing source to destination database map:" + e.toString());
+        }
+
+        // Override the database name based on the provided configuration.
+        this.databaseName = overrideDatabaseName(databaseName);
+
         this.query = transformedQuery;
         this.tableName = tableName;
-        this.config = config;
 
+        this.config = config;
+        this.dbMetadata = new DBMetadata(config);
+        this.writer = writer;
         this.userProvidedTimeZone = parseTimeZone();
+        this.originalSql = originalSql;
     }
 
+    /**
+     * Function to override the database name based on the source-to-destination map.
+     *
+     * @param databaseName The original database name from the DDL operation.
+     * @return The overridden database name if present in the source-to-destination map.
+     */
+    private String overrideDatabaseName(String databaseName) {
+        // Remove backticks from the database name if present.
+        if(databaseName.contains("`")) {
+            databaseName = databaseName.replace("`", "");
+        }
 
+        // If the source database name is present in the map, override it.
+        if(sourceToDestinationMap.containsKey(databaseName)) {
+            return sourceToDestinationMap.get(databaseName);
+        }
+        return databaseName;
+    }
+
+    /**
+     * Parse the user-provided time zone string and return a ZoneId object.
+     *
+     * @return The ZoneId object representing the user-provided time zone, or null if not provided.
+     */
     public ZoneId parseTimeZone() {
         String userProvidedTimeZone = config.getString(ClickHouseSinkConnectorConfigVariables
                 .CLICKHOUSE_DATETIME_TIMEZONE.toString());
-        // Validate if timezone string is valid.
         ZoneId userProvidedTimeZoneId = null;
         try {
-            if(!userProvidedTimeZone.isEmpty()) {
-
+            if(userProvidedTimeZone != null && !userProvidedTimeZone.isEmpty()) {
                 userProvidedTimeZoneId = ZoneId.of(userProvidedTimeZone);
-                if(userProvidedTimeZoneId != null) {
-                    //log.info("**** OVERRIDE TIMEZONE for DateTime:" + userProvidedTimeZone);
-                }
             }
         } catch (Exception e){
             log.error("**** Error parsing user provided timezone:"+ userProvidedTimeZone + e.toString());
         }
-
         return userProvidedTimeZoneId;
     }
 
+    /**
+     * Override the enterCreateDatabase method from the parser listener to handle CREATE DATABASE statements.
+     * This method transforms the original CREATE DATABASE query.
+     *
+     * @param createDatabaseContext The context for the CREATE DATABASE statement.
+     */
     @Override
     public void enterCreateDatabase(MySqlParser.CreateDatabaseContext createDatabaseContext) {
         for (ParseTree tree : createDatabaseContext.children) {
             if (tree instanceof MySqlParser.UidContext) {
-
                 String databaseName = tree.getText();
                 if(!databaseName.isEmpty()) {
-                    // Check if the database is overridden
-                    Map<String, String> sourceToDestinationMap = new HashMap<>();
+                    String overrideDatabaseName = overrideDatabaseName(tree.getText());
+                    this.query.append(String.format(Constants.CREATE_DATABASE, overrideDatabaseName));
 
-                    try {
-                        if (this.config.getString(ClickHouseSinkConnectorConfigVariables.CLICKHOUSE_DATABASE_OVERRIDE_MAP.toString()) != null)
-                            sourceToDestinationMap = Utils.parseSourceToDestinationDatabaseMap(this.config.
-                                    getString(ClickHouseSinkConnectorConfigVariables.CLICKHOUSE_DATABASE_OVERRIDE_MAP.toString()));
-                    } catch(Exception e) {
-                        log.error("enterCreateDatabase: Error parsing source to destination database map:" + e.toString());
-                    }
-
-                    if(sourceToDestinationMap.containsKey(databaseName)) {
-                        this.query.append(String.format(Constants.CREATE_DATABASE, sourceToDestinationMap.get(databaseName)));
-                    } else {
-                        this.query.append(String.format(Constants.CREATE_DATABASE, databaseName));
+                    boolean isReplicatedReplacingMergeTree = config.getBoolean(ClickHouseSinkConnectorConfigVariables
+                            .AUTO_CREATE_TABLES_REPLICATED.toString());
+                    if(isReplicatedReplacingMergeTree) {
+                        this.query.append(" ON CLUSTER `{cluster}`");
                     }
                 }
             }
         }
     }
 
+    /**
+     * Override the enterDropDatabase method from the parser listener to handle DROP DATABASE statements.
+     * This method transforms the original DROP DATABASE query.
+     *
+     * @param dropDatabaseContext The context for the DROP DATABASE statement.
+     */
+    @Override
+    public void enterDropDatabase(MySqlParser.DropDatabaseContext dropDatabaseContext) {
+        for (ParseTree child : dropDatabaseContext.children) {
+            if (child instanceof MySqlParser.UidContext) {
+                String databaseName = child.getText();
+                String overrideDatabaseName = overrideDatabaseName(databaseName);
+                this.query.append(String.format(Constants.DROP_DATABASE, overrideDatabaseName));
+            }
+        }
+    }
+
+    /**
+     * Override the enterCopyCreateTable method from the parser listener to handle CREATE TABLE LIKE statements.
+     * This method transforms the original CREATE TABLE LIKE query.
+     *
+     * @param copyCreateTableContext The context for the CREATE TABLE LIKE statement.
+     */
     @Override
     public void enterCopyCreateTable(MySqlParser.CopyCreateTableContext copyCreateTableContext) {
         ListIterator<ParseTree> it = copyCreateTableContext.children.listIterator();
-
         String originalTableName = "";
         String newTableName = "";
 
-
-        while(it.hasNext()) {
+        while (it.hasNext()) {
             ParseTree tree = it.next();
-            if(tree instanceof MySqlParser.TableNameContext) {
+            if (tree instanceof MySqlParser.TableNameContext) {
                 originalTableName = tree.getText();
-                if(it.next().getText().equalsIgnoreCase(Constants.LIKE)) {
+                if (it.next().getText().equalsIgnoreCase(Constants.LIKE)) {
                     newTableName = it.next().getText();
                 }
             }
         }
-        // if the table name already includes the datbase name dont include it in the query.
-        if(originalTableName.contains(".")) {
+
+        // Handle the case where the table name includes the database name.
+        if (originalTableName.contains(".")) {
             this.query.append(Constants.CREATE_TABLE).append(" ").append(originalTableName).append(" ")
                     .append(Constants.AS).append(" ").append(newTableName);
-        } else
+        } else {
             this.query.append(Constants.CREATE_TABLE).append(" ").append(databaseName).append(".").append(originalTableName).append(" ")
-                .append(Constants.AS).append(" ").append(databaseName).append(".").append(newTableName);
+                    .append(Constants.AS).append(" ").append(databaseName).append(".").append(newTableName);
+        }
     }
 
+    /**
+     * Override the enterColumnCreateTable method from the parser listener to handle column definitions
+     * for CREATE TABLE statements. It also handles the engine type and versioning for ReplacingMergeTree.
+     *
+     * @param columnCreateTableContext The context for the column definitions in CREATE TABLE.
+     */
     @Override
     public void enterColumnCreateTable(MySqlParser.ColumnCreateTableContext columnCreateTableContext) {
         StringBuilder orderByColumns = new StringBuilder();
         StringBuilder partitionByColumn = new StringBuilder();
         Set<String> columnNames = parseCreateTable(columnCreateTableContext, orderByColumns, partitionByColumn);
-        //this.query.append(" Engine=")
+
         String isDeletedColumn = IS_DELETED_COLUMN;
+
         // Iterate through columnNames and match isDeletedColumn with elements in columnNames.
-        // remove the backticks from elements in columnNames.
-        for(String columnName: columnNames) {
-            if(columnName.contains("`")) {
-               // replace backticks with empty string.
+        for (String columnName: columnNames) {
+            if (columnName.contains("`")) {
                 columnName = columnName.replace("`", "");
             }
-            if(columnName.equalsIgnoreCase(isDeletedColumn)) {
-                isDeletedColumn = "__" + IS_DELETED_COLUMN;
+            if (columnName.equalsIgnoreCase(isDeletedColumn)) {
+                isDeletedColumn = "_" + IS_DELETED_COLUMN;
                 break;
             }
         }
@@ -143,7 +263,28 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
         boolean isReplicatedReplacingMergeTree = config.getBoolean(ClickHouseSinkConnectorConfigVariables
                 .AUTO_CREATE_TABLES_REPLICATED.toString());
 
-        if(DebeziumChangeEventCapture.isNewReplacingMergeTreeEngine == true) {
+        String chDataTypeWithTimeZone = DataTypeConverter.addTimeZoneToDateTimeType(ClickHouseDataType.DateTime, 0, userProvidedTimeZone);
+        // append this to the chDataTypeWithTimeZone
+        chDataTypeWithTimeZone = chDataTypeWithTimeZone + " DEFAULT " + "'" + DataTypeRange.epochSecondsToDateString(DataTypeRange.DATETIME32_MAX_TTL) + "'";
+        // If Replication history is enabled, add the
+        // deleted_time DateTime DEFAULT '2149-06-06',
+        if (config.getBoolean(ClickHouseSinkConnectorConfigVariables.REPLICATION_HISTORY_ENABLE.toString())) {
+
+            this.query.append("`").append(DELETED_FROM_TIME_COLUMN)
+                    .append("` ").append(chDataTypeWithTimeZone)
+                    .append(",");
+
+            this.query.append("`").append(DELETED_TIME_COLUMN)
+                    .append("` ").append(chDataTypeWithTimeZone)
+                    .append(",");
+
+            this.query.append("`").append(OPERATION_COLUMN)
+                    .append("` ").append(OPERATION_COLUMN_DATA_TYPE)
+                    .append(",");
+        }
+
+
+        if (DebeziumChangeEventCapture.isNewReplacingMergeTreeEngine) {
             this.query.append("`").append(VERSION_COLUMN).append("` ").append(VERSION_COLUMN_DATA_TYPE).append(",");
             this.query.append("`").append(isDeletedColumn).append("` ").append(IS_DELETED_COLUMN_DATA_TYPE);
         } else {
@@ -152,30 +293,178 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
         }
 
         this.query.append(")");
-        if(DebeziumChangeEventCapture.isNewReplacingMergeTreeEngine == true) {
-            if(isReplicatedReplacingMergeTree == true) {
-                this.query.append(String.format("Engine=ReplicatedReplacingMergeTree(%s, %s)", VERSION_COLUMN, isDeletedColumn));
-            } else
+
+        // Retrieve table from configuration setting
+        SchemaOverrideConfig.Table tableConfig = SchemaOverrideConfig.getTableConfig(this.databaseName, this.tableName, this.config.originalsStrings());
+
+        // Add engine type based on table configuration.
+        if (DebeziumChangeEventCapture.isNewReplacingMergeTreeEngine) {
+            if (isReplicatedReplacingMergeTree) {
+                this.query.append(String.format(" Engine=ReplicatedReplacingMergeTree(%s, %s)", VERSION_COLUMN, isDeletedColumn));
+            } else {
                 this.query.append(" Engine=ReplacingMergeTree(").append(VERSION_COLUMN).append(",").append(isDeletedColumn).append(")");
+            }
         } else {
-            if (isReplicatedReplacingMergeTree == true) {
-                this.query.append(String.format("Engine=ReplicatedReplacingMergeTree(%s)",  VERSION_COLUMN));
-            } else
+            if (isReplicatedReplacingMergeTree) {
+                this.query.append(String.format(" Engine=ReplicatedReplacingMergeTree(%s)", VERSION_COLUMN));
+            } else {
                 this.query.append(" Engine=ReplacingMergeTree(").append(VERSION_COLUMN).append(")");
+            }
         }
-        if(partitionByColumn.length() > 0) {
+
+        // Append partitioning and ordering clauses, using values from tableConfig if they exist
+
+        if (config.getBoolean(ClickHouseSinkConnectorConfigVariables.REPLICATION_HISTORY_ENABLE.toString())) {
+            String deletedTimeColumnToDate = String.format(DELETED_TIME_COLUMN_TO_DATE, DELETED_TIME_COLUMN);
+            this.query.append(" PARTITION BY ").append(deletedTimeColumnToDate);
+        } else if (tableConfig.getPartitionBy() != null && !tableConfig.getPartitionBy().isEmpty()) {
+            // Use the partition_by from tableConfig if it exists
+            this.query.append(Constants.PARTITION_BY).append(" ").append(tableConfig.getPartitionBy());
+        } else if (partitionByColumn.length() > 0) {
+            // Fallback to partitionByColumn if tableConfig does not provide a partition_by value
             this.query.append(Constants.PARTITION_BY).append(" ").append(partitionByColumn);
         }
-        if(orderByColumns.length() == 0) {
-        this.query.append(Constants.ORDER_BY_TUPLE);
-        } else {
-            this.query.append(Constants.ORDER_BY).append(orderByColumns.toString());
+
+        if (tableConfig.getPrimaryKey() != null && !tableConfig.getPrimaryKey().isEmpty()) {
+            // Use the primary_key from tableConfig if it exists
+            this.query.append(Constants.ORDER_BY).append(tableConfig.getPrimaryKey());
+        }else if (orderByColumns.length() == 0) {
+            this.query.append(Constants.ORDER_BY_TUPLE);
+        } else{
+            // Convert the orderByColumns object to a string
+            String orderByStr = orderByColumns.toString();
+
+            // Regex pattern to detect invalid column suffix like id_registro(10)
+            String regex = "\\b(\\w+)\\(\\d+\\)";
+
+            if (orderByStr.matches(".*" + regex + ".*")) {
+                // If pattern is matched: clean up suffix and append ORDER BY
+                String fixedOrderBy = orderByStr.replaceAll(regex, "$1");
+
+                // Append the sanitized ORDER BY clause to the query
+                this.query.append(Constants.ORDER_BY).append(fixedOrderBy);
+            } else {
+                // Otherwise, use the orderByColumns for ordering
+
+                if (config.getBoolean(ClickHouseSinkConnectorConfigVariables.REPLICATION_HISTORY_ENABLE.toString())) {
+                    this.query.append(Constants.ORDER_BY);
+                    this.query.append("(");
+                    this.query.append(orderByColumns.toString());
+                    this.query.append(",`").append(DELETED_TIME_COLUMN).append("`");
+
+                    this.query.append(")");
+                }
+                else {
+                    this.query.append(Constants.ORDER_BY).append(orderByStr);
+                }
+            }
         }
 
+        if(config.getBoolean(ClickHouseSinkConnectorConfigVariables.REPLICATION_HISTORY_ENABLE.toString())) {
+            this.query.append(" TTL `").append(DELETED_TIME_COLUMN).append("` + toIntervalDay(30)");
+        }
+        
+
+        if (tableConfig.getSettings() != null && !tableConfig.getSettings().isEmpty()) {
+            // Use the settings from tableConfig if it exists
+            this.query.append(Constants.SETTINGS).append(tableConfig.getSettings());
+        }
     }
 
+    /**
+     * Finds partitioning options using regex when ANTLR parser fails to identify partitions.
+     * This method provides a fallback mechanism to extract partition columns from the raw DDL text.
+     *
+     * @param source The raw DDL source string to search for partitioning patterns.
+     * @return The partitioning options string, or empty string if no partitioning is found.
+     */
+    private String findPartitioningOptions(String source) {
+        // First try to match PARTITION BY RANGE COLUMNS(...)
+        Pattern pattern = Pattern.compile("PARTITION\\s+BY\\s+RANGE\\s+COLUMNS\\((.*?)\\)", Pattern.CASE_INSENSITIVE);
+        Matcher matcher = pattern.matcher(source);
+        String partitioningKeys = null;
+        if (matcher.find()) {
+            partitioningKeys = matcher.group(1);
+            log.info("Partitioning key (RANGE COLUMNS): " + partitioningKeys);
+        }
+        
+        // If not found, try to match function-based partitioning like PARTITION BY RANGE( YEAR(...) )
+        if (partitioningKeys == null) {
+            // Match PARTITION BY RANGE( <function_or_expression> ) but stop before the partition definitions
+            Pattern functionPattern = Pattern.compile("PARTITION\\s+BY\\s+RANGE\\s*\\(\\s*([^)]+)\\s*\\)\\s*\\(", Pattern.CASE_INSENSITIVE);
+            Matcher functionMatcher = functionPattern.matcher(source);
+            if (functionMatcher.find()) {
+                String functionExpression = functionMatcher.group(1).trim();
+                log.info("Found function-based partitioning: " + functionExpression);
+                // Convert MySQL function to ClickHouse equivalent
+                partitioningKeys = convertMySQLPartitionFunctionToClickHouse(functionExpression);
+                if (partitioningKeys != null) {
+                    log.info("Converted to ClickHouse partition: " + partitioningKeys);
+                }
+            }
+        }
+        
+        String partitioningOptions = "";
+        if (partitioningKeys != null) {
+            partitioningOptions = "PARTITION BY " + partitioningKeys;
+        }
+        return partitioningOptions;
+    }
+    
+    /**
+     * Convert MySQL partition function expressions to ClickHouse equivalents
+     * @param mysqlFunction MySQL partition function expression (e.g., "YEAR(order_date)")
+     * @return ClickHouse partition expression or null if conversion not supported
+     */
+    private String convertMySQLPartitionFunctionToClickHouse(String mysqlFunction) {
+        if (mysqlFunction == null || mysqlFunction.isEmpty()) {
+            return null;
+        }
+        
+        // Extract column name from function like YEAR(column_name) or TO_DAYS(column_name)
+        Pattern columnPattern = Pattern.compile("(\\w+)\\s*\\(\\s*([\\w`]+)\\s*\\)", Pattern.CASE_INSENSITIVE);
+        Matcher columnMatcher = columnPattern.matcher(mysqlFunction);
+        
+        if (columnMatcher.find()) {
+            String function = columnMatcher.group(1).toUpperCase();
+            String columnName = columnMatcher.group(2).replaceAll("`", "");
+            
+            // Convert MySQL functions to ClickHouse equivalents
+            switch (function) {
+                case "YEAR":
+                    return "toYear(" + columnName + ")";
+                case "MONTH":
+                    return "toMonth(" + columnName + ")";
+                case "DAY":
+                case "DAYOFMONTH":
+                    return "toDayOfMonth(" + columnName + ")";
+                case "TO_DAYS":
+                    // ClickHouse doesn't have exact TO_DAYS equivalent, use date directly
+                    return columnName;
+                case "UNIX_TIMESTAMP":
+                    return "toUnixTimestamp(" + columnName + ")";
+                default:
+                    log.warn("Unsupported MySQL partition function: " + function + ". Using column directly.");
+                    return columnName;
+            }
+        }
+        
+        // If no function pattern matches, return the expression as-is
+        log.info("Could not parse partition function, using expression as-is: " + mysqlFunction);
+        return mysqlFunction;
+    }
+
+    /**
+     * This function parses the CREATE TABLE statement and processes the columns,
+     * order by clauses, and partitioning specifications.
+     *
+     * @param ctx The context of the CREATE TABLE statement.
+     * @param orderByColumns A StringBuilder to store the ORDER BY columns.
+     * @param partitionByColumns A StringBuilder to store the PARTITION BY columns.
+     * @return A set of column names defined in the CREATE TABLE statement.
+     */
     private Set<String> parseCreateTable(MySqlParser.CreateTableContext ctx, StringBuilder orderByColumns,
-                                  StringBuilder partitionByColumns) {
+                                         StringBuilder partitionByColumns) {
         List<ParseTree> pt = ctx.children;
         Set<String> columnNames = new HashSet<>();
 
@@ -184,63 +473,89 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
 
             if (tree instanceof TableNameContext) {
                 this.tableName = tree.getText();
-                // If tableName already includes the database name don't include database name in this.query
-                if(tableName.contains(".")) {
-                    this.query.append(tableName);
-                } else
+                // If tableName already includes the database name, don't include database name in the query.
+                if (tableName.contains(".")) {
+                    // Split tableName into databaseName and tableName
+                    String[] tableNameSplit = tableName.split("\\.");
+                    this.query.append(this.databaseName).append(".").append(tableNameSplit[1]);
+                } else {
                     this.query.append(databaseName).append(".").append(tree.getText());
+                }
 
-                // If its RRMT add on CLUSTER {cluster} to QUERY.
+                // If it's ReplicatedReplacingMergeTree, add ON CLUSTER {cluster} to the query.
                 boolean isReplicatedReplacingMergeTree = config.getBoolean(ClickHouseSinkConnectorConfigVariables
                         .AUTO_CREATE_TABLES_REPLICATED.toString());
-                if(isReplicatedReplacingMergeTree) {
+                if (isReplicatedReplacingMergeTree) {
                     this.query.append(" ON CLUSTER `{cluster}`");
                 }
                 this.query.append("(");
-            }else if(tree instanceof MySqlParser.IfNotExistsContext) {
+            } else if (tree instanceof MySqlParser.IfNotExistsContext) {
                 this.query.append(Constants.IF_NOT_EXISTS);
-            }else if (tree instanceof MySqlParser.CreateDefinitionsContext) {
+            } else if (tree instanceof MySqlParser.CreateDefinitionsContext) {
                 for (ParseTree subtree : ((MySqlParser.CreateDefinitionsContext) tree).children) {
                     if (subtree instanceof TerminalNodeImpl) {
-                       // this.query.append(subtree.getText());
+                        // Do nothing for TerminalNodeImpl, just skip it
                     } else if (subtree instanceof MySqlParser.ColumnDeclarationContext) {
+                        // Parse column definitions
                         parseColumnDefinitions(subtree, orderByColumns, columnNames);
                     } else if(subtree instanceof MySqlParser.ConstraintDeclarationContext) {
-                        for(ParseTree constraintTree: ((MySqlParser.ConstraintDeclarationContext) subtree).children) {
-                            if(constraintTree instanceof MySqlParser.PrimaryKeyTableConstraintContext) {
-                                for(ParseTree primaryKeyTree: ((MySqlParser.PrimaryKeyTableConstraintContext) constraintTree).children) {
-                                    if(primaryKeyTree instanceof MySqlParser.IndexColumnNamesContext) {
+                        for (ParseTree constraintTree: ((MySqlParser.ConstraintDeclarationContext) subtree).children) {
+                            if (constraintTree instanceof MySqlParser.PrimaryKeyTableConstraintContext) {
+                                for (ParseTree primaryKeyTree: ((MySqlParser.PrimaryKeyTableConstraintContext) constraintTree).children) {
+                                    if (primaryKeyTree instanceof MySqlParser.IndexColumnNamesContext) {
                                         String primaryKeyColumns = primaryKeyTree.getText();
-                                        if(primaryKeyColumns != null && !primaryKeyColumns.isEmpty()) {
+                                        if (primaryKeyColumns != null && !primaryKeyColumns.isEmpty()) {
                                             orderByColumns.append(primaryKeyColumns);
                                         }
-                                        //log.info("PRIMARY KEY");
                                     }
-
                                 }
                             }
                         }
                     }
                 }
-            } else if(tree instanceof MySqlParser.PartitionDefinitionsContext) {
-                for(ParseTree partitionTree: ((MySqlParser.PartitionDefinitionsContext) tree).children) {
-                    if(partitionTree instanceof MySqlParser.PartitionFunctionKeyContext) {
-                        for(ParseTree partitionKeyTree: ((MySqlParser.PartitionFunctionKeyContext) partitionTree).children) {
-                            if(partitionKeyTree instanceof MySqlParser.UidListContext) {
+            } else if (tree instanceof MySqlParser.PartitionDefinitionsContext) {
+                for (ParseTree partitionTree: ((MySqlParser.PartitionDefinitionsContext) tree).children) {
+                    if (partitionTree instanceof MySqlParser.PartitionFunctionKeyContext) {
+                        for (ParseTree partitionKeyTree: ((MySqlParser.PartitionFunctionKeyContext) partitionTree).children) {
+                            if (partitionKeyTree instanceof MySqlParser.UidListContext) {
                                 String partitionColumn = partitionKeyTree.getText();
                                 partitionByColumns.append(partitionColumn);
                             }
                         }
-
-                    } else if(partitionTree instanceof MySqlParser.PartitionFunctionRangeContext) {
-                        for(ParseTree partitionFunctionRangeTree: ((MySqlParser.PartitionFunctionRangeContext) partitionTree).children) {
-                            if(partitionFunctionRangeTree instanceof MySqlParser.UidListContext) {
+                    } else if (partitionTree instanceof MySqlParser.PartitionFunctionRangeContext) {
+                        for (ParseTree partitionFunctionRangeTree: ((MySqlParser.PartitionFunctionRangeContext) partitionTree).children) {
+                            if (partitionFunctionRangeTree instanceof MySqlParser.UidListContext) {
                                 partitionByColumns.append("(").append(partitionFunctionRangeTree.getText()).append(")");
+                            } else if (partitionFunctionRangeTree instanceof MySqlParser.PredicateExpressionContext) {
+                                // Handle function-based partitioning like PARTITION BY RANGE( YEAR(order_date) )
+                                String functionExpression = partitionFunctionRangeTree.getText();
+                                log.info("Found partition function expression: " + functionExpression);
+                                // Convert MySQL function to ClickHouse equivalent
+                                String clickhousePartition = convertMySQLPartitionFunctionToClickHouse(functionExpression);
+                                if (clickhousePartition != null && !clickhousePartition.isEmpty()) {
+                                    partitionByColumns.append(clickhousePartition);
+                                    log.info("Converted partition to ClickHouse format: " + clickhousePartition);
+                                }
                             }
                         }
-
                     }
                 }
+            }
+        }
+
+        // If ANTLR parser didn't find partition columns, try regex as fallback
+        if (partitionByColumns.length() == 0 && originalSql != null) {
+            try {
+                // Use the original DDL text for regex parsing (handles MySQL comments)
+                String regexPartitioning = findPartitioningOptions(originalSql);
+                if (!regexPartitioning.isEmpty()) {
+                    // Extract only the partition columns part (remove "PARTITION BY " prefix)
+                    String partitionColumns = regexPartitioning.substring("PARTITION BY ".length());
+                    partitionByColumns.append(partitionColumns);
+                    log.info("Regex fallback found partitioning: " + partitionColumns);
+                }
+            } catch (Exception e) {
+                log.warn("Regex fallback for partition parsing failed: " + e.getMessage());
             }
         }
 
@@ -248,11 +563,12 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
     }
 
     /**
-     * Function to parse column definitions.
-     * @param subtree
-     * @param orderByColumns
+     * Function to parse the column definitions in a CREATE TABLE statement.
+     * It processes column names, data types, and constraints like NOT NULL, PRIMARY KEY, and GENERATED columns.
      *
-     * @return list of column names
+     * @param subtree The subtree representing the column definition in the DDL.
+     * @param orderByColumns A StringBuilder to append order by columns for indexing.
+     * @param columnNames A set to hold the column names parsed from the statement.
      */
     private void parseColumnDefinitions(ParseTree subtree, StringBuilder orderByColumns, Set<String> columnNames) {
         String columnName = null;
@@ -268,60 +584,80 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
             } else if (colDefTree instanceof MySqlParser.ColumnDefinitionContext) {
                 String colDataTypeDefinition = colDefTree.getText();
 
+                // Get the corresponding ClickHouse data type for the column.
                 colDataType = getClickHouseDataType(colDataTypeDefinition, colDefTree, columnName);
-                // Null Column and DimensionDataType are children of ColumnDefinition
-                for(ParseTree colDefinitionChildTree: ((MySqlParser.ColumnDefinitionContext) colDefTree).children) {
-                    if (colDefinitionChildTree instanceof MySqlParser.NullColumnConstraintContext) {
-                        if (colDefinitionChildTree.getText().equalsIgnoreCase(Constants.NOT_NULL))
-                            isNullColumn = false;
-                    } else if(colDefinitionChildTree instanceof MySqlParser.DimensionDataTypeContext) {
-                        if (colDefinitionChildTree.getText() != null) {
 
+                // Handle constraints such as NOT NULL, PRIMARY KEY, and GENERATED column.
+                for (ParseTree colDefinitionChildTree: ((MySqlParser.ColumnDefinitionContext) colDefTree).children) {
+                    if (colDefinitionChildTree instanceof MySqlParser.NullColumnConstraintContext) {
+                        if (colDefinitionChildTree.getText().equalsIgnoreCase(Constants.NOT_NULL)) {
+                            isNullColumn = false;
                         }
                     } else if (colDefinitionChildTree instanceof MySqlParser.PrimaryKeyColumnConstraintContext) {
-                        for(ParseTree primaryKeyTree: ((MySqlParser.PrimaryKeyColumnConstraintContext) colDefinitionChildTree).children) {
-                            System.out.println(primaryKeyTree.getText());
+                        for (ParseTree primaryKeyTree: ((MySqlParser.PrimaryKeyColumnConstraintContext) colDefinitionChildTree).children) {
+                            isNullColumn = false;
                             orderByColumns.append(columnName);
                             break;
                         }
                     } else if (colDefinitionChildTree instanceof MySqlParser.GeneratedColumnConstraintContext) {
-                        for(ParseTree generatedColumnTree: ((MySqlParser.GeneratedColumnConstraintContext) colDefinitionChildTree).children) {
-                            if(generatedColumnTree instanceof MySqlParser.ExpressionContext) {
+                        for (ParseTree generatedColumnTree: ((MySqlParser.GeneratedColumnConstraintContext) colDefinitionChildTree).children) {
+                            if (generatedColumnTree instanceof MySqlParser.ExpressionContext) {
+                                for(ParseTree generatedColumnTreeChildren: ((MySqlParser.ExpressionContext) generatedColumnTree).children) {
+                                    //System.out.println(generatedColumnTreeChildren.getText().trim());
+                                    // iterate over the children of the generatedColumnTreeChildren
+                                    if(generatedColumnTreeChildren instanceof MySqlParser.IsNullPredicateContext) {
+                                        for (ParseTree generatedColumnTreeChildrenChildren : ((MySqlParser.IsNullPredicateContext) generatedColumnTreeChildren).children) {
+                                            if (generatedColumnTreeChildrenChildren instanceof MySqlParser.ExpressionAtomPredicateContext) {
+                                                //System.out.println(generatedColumnTreeChildrenChildren.getText().trim());
+                                                generatedColumn = generatedColumnTreeChildrenChildren.getText();
+                                            }
+                                        }
+                                    } else {
+                                        generatedColumn = generatedColumnTreeChildren.getText();
+                                    }
+                                }
                                 isGeneratedColumn = true;
-                                generatedColumn = generatedColumnTree.getText();
-                                //this.query.append(Constants.AS).append(" ").append(expression);
+                                //generatedColumn = generatedColumnTree.getText();
                             }
                         }
-
                     }
                 }
-                if(isGeneratedColumn) {
-                    if(isNullColumn){
-                        this.query.append(Constants.NULLABLE).append("(").append(colDataType)
-                                .append(")");
-                    } else
+
+                if (isGeneratedColumn) {
+                    // For generated columns, handle NULL and NOT NULL constraints.
+                    if (isNullColumn) {
+                        this.query.append(Constants.NULLABLE).append("(").append(colDataType).append(")");
+                    } else {
                         this.query.append(colDataType);
+                    }
 
                     this.query.append(" ").append(Constants.ALIAS).append(" ").append(generatedColumn).append(",");
                     continue;
                 }
 
-                if(isNullColumn) {
+                // For non-generated columns, apply nullable constraints if applicable.
+                String lowerCaseDataType = colDataType.toLowerCase();
+                if (!Constants.NULLABLE_NOT_SUPPORTED_DATA_TYPES.contains(lowerCaseDataType) && isNullColumn) {
                     this.query.append(Constants.NULLABLE).append("(").append(colDataType)
                             .append(")").append(",");
-                }
-                else {
+                } else {
                     this.query.append(colDataType).append(" ").append(Constants.NOT_NULLABLE).append(" ").append(",");
                 }
+
+                // Add column name to the set of column names.
                 columnNames.add(columnName);
             }
         }
     }
 
     /**
-     * Function to get the ClickHouse Data type from DDL Datatype.
-     * @param parsedDataType
-     * @return
+     * Function to get the ClickHouse data type based on the MySQL data type in the CREATE TABLE statement.
+     * It handles precision and scale for data types such as numeric and datetime.
+     *
+     * @param parsedDataType The parsed data type from the MySQL statement.
+     * @param colDefTree The column definition context for retrieving the data type.
+     * @param columnName The name of the column.
+     * @return The corresponding ClickHouse data type as a string.
      */
     private String getClickHouseDataType(String parsedDataType, ParseTree colDefTree, String columnName) {
         int precision = 0;
@@ -329,71 +665,96 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
 
         String chDataType = null;
         MySqlParser.DataTypeContext dtc = ((MySqlParser.ColumnDefinitionContext) colDefTree).dataType();
+        DataType dt = DataTypeConverter.getDataType(dtc);
 
-        if(parsedDataType.contains("(") && parsedDataType.contains(")") && parsedDataType.contains(",")) {
+        if (dt.name().equalsIgnoreCase("ENUM") || dt.name().equalsIgnoreCase("SET")) {
+            // Skip precision and scale for ENUM and SET types
+        } else if (parsedDataType.contains("(") && parsedDataType.contains(")") && parsedDataType.contains(",")) {
+            String sanitizedDataType = parsedDataType.split("COMMENT")[0].trim();
             try {
-                precision = Integer.parseInt(parsedDataType.substring(parsedDataType.indexOf("(") + 1, parsedDataType.indexOf(",")));
-                scale = Integer.parseInt(parsedDataType.substring(parsedDataType.indexOf(",") + 1, parsedDataType.indexOf(")")));
-            } catch(Exception e) {
+                precision = Integer.parseInt(sanitizedDataType.substring(sanitizedDataType.indexOf("(") + 1, sanitizedDataType.indexOf(",")));
+                scale = Integer.parseInt(sanitizedDataType.substring(sanitizedDataType.indexOf(",") + 1, sanitizedDataType.indexOf(")")));
+            } catch (Exception e) {
                 log.error("Error parsing precision, scale : columnName" + columnName);
             }
-        }  // datetime(6)
-        else if(parsedDataType.contains("(") && parsedDataType.contains(")") &&
-                (containsIgnoreCase(parsedDataType, "datetime") || containsIgnoreCase(parsedDataType, "timestamp"))){
+        } else if (parsedDataType.contains("(") && parsedDataType.contains(")") &&
+                (containsIgnoreCase(parsedDataType, "datetime") || containsIgnoreCase(parsedDataType, "timestamp"))) {
             try {
                 precision = Integer.parseInt(parsedDataType.substring(parsedDataType.indexOf("(") + 1, parsedDataType.indexOf(")")));
-            } catch(Exception e) {
+            } catch (Exception e) {
                 log.error("Error parsing precision:ColumnName:" + columnName);
             }
         }
 
-        chDataType = DataTypeConverter.convertToString(columnName,
+        // Convert MySQL data type to the equivalent ClickHouse data type.
+        chDataType = DataTypeConverter.convertToString(this.config, columnName,
                 scale, precision, dtc, this.userProvidedTimeZone);
 
-        return chDataType;
+        Map<String, String> defaultColumnDataTypeMap = loadDefaultColumnDataTypeMapping(this.config.originalsStrings());
 
+        // Use a single null check with optional.
+        if (defaultColumnDataTypeMap != null) {
+            chDataType = defaultColumnDataTypeMap.getOrDefault(columnName, chDataType);
+        }
+
+        return chDataType;
     }
 
-
+    /**
+     * This function processes the addition of an index in the ALTER TABLE statement.
+     * It parses the index name, type, columns, and options like the granularity of the index.
+     *
+     * @param tree The parse tree representing the ALTER TABLE ADD INDEX clause.
+     */
     private void parseAddIndex(ParseTree tree) {
 
-        // add index col3_index(col3) TYPE minmax GRANULARITY 4;
+        // Add index col3_index(col3) TYPE minmax GRANULARITY 4;
         for (ParseTree columnChild : ((MySqlParser.AlterByAddIndexContext) tree).children) {
 
             if (columnChild instanceof MySqlParser.IfNotExistsContext) {
-
+                // Ignore if "IF NOT EXISTS" is present, as it's not relevant for the query.
             } else if (columnChild instanceof MySqlParser.UidContext) {
-                // Name of index.
-
+                // The name of the index.
             } else if (columnChild instanceof MySqlParser.IndexTypeContext) {
-                // Index type
-
+                // The type of the index.
             } else if (columnChild instanceof MySqlParser.IndexColumnNamesContext) {
+                // Process the column names in the index.
                 for (ParseTree columnNameChild : ((MySqlParser.IndexColumnNamesContext) (columnChild)).children) {
                     // Column Name
                 }
-
             } else if (columnChild instanceof MySqlParser.IndexOptionContext) {
-                // Index option
-                // comment
+                // Index options like comment, type, granularity, etc.
             }
         }
     }
 
+    /**
+     * This function handles the renaming of a column in the ALTER TABLE statement.
+     * It appends the new column name to the query.
+     *
+     * @param tree The parse tree representing the ALTER TABLE RENAME COLUMN clause.
+     */
     private void parseRenameColumn(ParseTree tree) {
         ListIterator<ParseTree> it = ((MySqlParser.AlterSpecificationContext) tree).children.listIterator();
         // this.query.append(" ").append(Constants.RENAME_COLUMN);
-        //for (ParseTree columnChild : ((MySqlParser.AlterSpecificationContext) tree).children) {
         while (it.hasNext()) {
             ParseTree child = it.next();
             if (child instanceof MySqlParser.UidContext) {
+                // Append the column name to the query
                 this.query.append(" ").append(child.getText());
             } else if (child instanceof TerminalNodeImpl) {
+                // Append the terminal node text to the query
                 this.query.append(" ").append(child.getText());
             }
         }
     }
 
+    /**
+     * This function processes an ALTER TABLE statement, handling column addition, modification, renaming,
+     * and other operations like index creation and constraints.
+     *
+     * @param tree The parse tree representing the ALTER TABLE statement.
+     */
     private void parseAlterTable(ParseTree tree) {
 
         String columnName = null;
@@ -409,6 +770,9 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
 
         boolean isNullColumn = false;
         boolean isAlterChangeColumn = false;
+        boolean nullExplicitlySet = false;
+
+        // Determine the type of alter operation (Add, Modify, Rename, etc.)
         if (tree instanceof AlterByAddColumnContext) {
             modifier = Constants.ADD_COLUMN;
             modifierWithNull = Constants.ADD_COLUMN_NULLABLE;
@@ -428,16 +792,15 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
         } else if (tree instanceof MySqlParser.AlterByAddIndexContext) {
             modifier = Constants.ADD_INDEX;
         } else {
-            //log.error("Not support Alter specification context");
             return;
         }
+
         ListIterator<ParseTree> it = ((MySqlParser.AlterSpecificationContext) tree).children.listIterator();
 
-        //for (ParseTree columnChild : ((MySqlParser.AlterSpecificationContext) tree).children) {
         while (it.hasNext()) {
             ParseTree columnChild = it.next();
             if (columnChild instanceof MySqlParser.UidContext) {
-                columnName = (columnChild).getText();
+                columnName = columnChild.getText();
                 if (isAlterChangeColumn) {
                     // Change column comes in this format ALTER TABLE change column oldcol newcol.
                     ParseTree newColumnChild = it.next();
@@ -447,17 +810,24 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
 
                 for (ParseTree columnDefChild : ((MySqlParser.ColumnDefinitionContext) columnChild).children) {
                     if (columnDefChild instanceof MySqlParser.NullColumnConstraintContext) {
+                        nullExplicitlySet = true;
                         if (columnDefChild.getText().equalsIgnoreCase(Constants.NULL))
                             isNullColumn = true;
                         else if(columnDefChild.getText().equalsIgnoreCase(Constants.NOT_NULL)) {
-                            isNullColumn = false;
+                            // if (!modifier.equalsIgnoreCase(Constants.ADD_COLUMN))
+                            {
+                                isNullColumn = false;
+                            }
                         }
                     } else if (columnDefChild instanceof MySqlParser.DefaultColumnConstraintContext) {
                         if (columnDefChild.getChildCount() >= 2) {
                             defaultModifier = "DEFAULT " + columnDefChild.getChild(1).getText();
                         }
-                    } else {
-                        columnType = (columnDefChild.getText());
+                    } else if (columnDefChild instanceof MySqlParser.CommentColumnConstraintContext) {
+                        // Ignore comment for now.
+                    }
+                    else {
+                        columnType = columnDefChild.getText();
                         String chDataType = getClickHouseDataType(columnType, columnChild, columnName);
                         if (chDataType != null) {
                             columnType = chDataType;
@@ -467,26 +837,50 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
             } else if (columnChild instanceof TerminalNodeImpl) {
                 String columnPosition = columnChild.getText();
                 if (columnPosition.equalsIgnoreCase(Constants.AFTER)) {
-                    // The next element in the tree will be the column
                     if (it.hasNext()) {
                         columnPositionModifier.append(columnPosition).append(" ").append(it.next().getText());
                     }
                 } else if (columnPosition.equalsIgnoreCase(Constants.FIRST)) {
                     columnPositionModifier.append(columnPosition);
                 }
-                // columnName = columnName + " " + columnChild.getText();
-
             }
         }
 
+        // If null is not explicitly set, determine if the column is nullable.
+        if (!nullExplicitlySet) {
+            try {
+                if (writer == null) {
+                    log.error("Error with DB connection");
+                    throw new SQLException("Error with DB connection");
+                }
+                else {
+                    Map<String, Boolean> isNullableList = dbMetadata.getColumnsIsNullableForTable(tableName, writer.getConnection(), databaseName);
+                    if (isNullableList.get(columnName) != null && isNullableList.get(columnName)) {
+                        isNullColumn = true;
+                    } else if (isNullableList.get(columnName) == null) {
+                        isNullColumn = true;
+                    } else {
+                        isNullColumn = false;
+                    }
+                }
+            } catch (Exception e) {
+                log.error("Error retrieving NULL column schema from ClickHouse", e);
+            }
+        }
+
+        // If column name and column type are defined, append them to the query.
         if (columnName != null && columnType != null)
             if (isNullColumn) {
                 this.query.append(" ").append(String.format(modifierWithNull, columnName, columnType)).append(" ");
-            } else
+            }
+            else {
                 this.query.append(" ").append(String.format(modifier, columnName, columnType));
+            }
+
         if (defaultModifier != null && defaultModifier.isEmpty() == false) {
             this.query.append(" ").append(defaultModifier);
         }
+
         if (columnPositionModifier.length() != 0) {
             this.query.append(" ").append(columnPositionModifier);
         }
@@ -500,42 +894,51 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
     }
 
     /**
-     * Function to create MODIFY column to rename the column name
+     * Function to create MODIFY column to rename the column name.
      *
-     * @param tableName
-     * @param oldCol
-     * @param newCol
-     * @param dataType
+     * @param tableName The name of the table being modified.
+     * @param oldCol The old column name.
+     * @param newCol The new column name.
+     * @param dataType The data type of the column.
      */
     public void postProcessModifyColumn(String tableName, String oldCol, String newCol, String dataType) {
         this.query.append("\n");
-        // If the tableName already includes the databaseName dont include databaseName in this.query
-        if(tableName.contains(".")) {
+        // If the tableName already includes the databaseName don't include databaseName in the query.
+        if (tableName.contains(".")) {
             this.query.append(String.format("ALTER TABLE %s RENAME COLUMN %s to %s", tableName, oldCol, newCol));
-        } else
+        } else {
             this.query.append(String.format("ALTER TABLE %s RENAME COLUMN %s to %s", databaseName + "." + tableName, oldCol, newCol));
-
+        }
     }
 
     @Override
     public void enterAlterTable(MySqlParser.AlterTableContext alterTableContext) {
-
-
         List<ParseTree> pt = alterTableContext.children;
         for (ParseTree tree : pt) {
 
             if (tree instanceof TableNameContext) {
                 this.tableName = tree.getText();
-                // If the table name already include the database name dont include it in the query.
-                if(this.tableName.contains(".")) {
-                    this.query.append(String.format(Constants.ALTER_TABLE, this.tableName));
-                } else
+                // If the table name already includes the database name don't include database name in the query.
+                if (this.tableName.contains(".")) {
+                    // Split database and table name.
+                    String[] tableNameSplit = this.tableName.split("\\.");
+                    this.query.append(String.format(Constants.ALTER_TABLE, databaseName+ "." + tableNameSplit[1]));
+                } else {
                     this.query.append(String.format(Constants.ALTER_TABLE, databaseName + "." + this.tableName));
+                }
             }
 
             if (tree instanceof AlterByAddColumnContext) {
                 parseAlterTable(tree);
 
+            } else if (tree instanceof MySqlParser.AlterByDropConstraintCheckContext) {
+                // Drop Constraint.
+                this.query.append(" ");
+                for (ParseTree dropConstraintTree : ((MySqlParser.AlterByDropConstraintCheckContext) (tree)).children) {
+                    if (dropConstraintTree instanceof MySqlParser.UidContext) {
+                        this.query.append(String.format(Constants.DROP_CONSTRAINT, dropConstraintTree.getText()));
+                    }
+                }
             } else if (tree instanceof MySqlParser.AlterByModifyColumnContext) {
                 parseAlterTable(tree);
             } else if (tree instanceof MySqlParser.AlterByDropColumnContext) {
@@ -543,12 +946,11 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
                 this.query.append(" ");
                 for (ParseTree dropColumnTree : ((MySqlParser.AlterByDropColumnContext) (tree)).children) {
                     if (dropColumnTree instanceof MySqlParser.UidContext) {
-                        for(ParseTree dropColumnChild: ((MySqlParser.UidContext) dropColumnTree).children) {
-                            if(dropColumnChild instanceof MySqlParser.SimpleIdContext || dropColumnChild instanceof TerminalNodeImpl) {
+                        for (ParseTree dropColumnChild: ((MySqlParser.UidContext) dropColumnTree).children) {
+                            if (dropColumnChild instanceof MySqlParser.SimpleIdContext || dropColumnChild instanceof TerminalNodeImpl) {
                                 this.query.append(String.format(Constants.DROP_COLUMN, dropColumnChild.getText()));
                             }
                         }
-                       // this.query.append(String.format(Constants.DROP_COLUMN, ((MySqlParser.AlterByDropColumnContext) tree).uid()));
                     }
                 }
             } else if (tree instanceof MySqlParser.AlterByRenameColumnContext) {
@@ -559,6 +961,12 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
                 parseAlterTable(tree);
             } else if (tree instanceof MySqlParser.AlterByAddIndexContext) {
                 parseAddIndex(tree);
+            } else if (tree instanceof MySqlParser.AlterBySetAlgorithmContext) {
+                log.info("INSTANT ALGORITHM not supported in ClickHouse");
+                // Remove any terminating commas and break out of the parser loop.
+                if(this.query.charAt(this.query.length() - 1) == ',')
+                    this.query.deleteCharAt(this.query.length() - 1);
+                break;
             } else if (tree instanceof TerminalNodeImpl) {
                 if (((TerminalNodeImpl) tree).symbol.getType() == MySqlParser.COMMA) {
                     this.query.append(",");
@@ -569,33 +977,54 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
         }
     }
 
+    /**
+     * This function processes the renaming of a table in the ALTER TABLE statement.
+     * It appends the necessary SQL query to rename the table.
+     *
+     * @param originalTableName The original name of the table.
+     * @param tree The parse tree representing the ALTER TABLE RENAME TABLE clause.
+     */
     private void parseAlterTableByRename(String originalTableName, MySqlParser.AlterByRenameContext tree) {
         String newTableName = null;
-        for(ParseTree alterByRenameChildren: tree.children) {
-            if(alterByRenameChildren instanceof MySqlParser.UidContext) {
+        // Iterate over the children of the parse tree to find the new table name
+        for (ParseTree alterByRenameChildren: tree.children) {
+            if (alterByRenameChildren instanceof MySqlParser.UidContext) {
+                newTableName = alterByRenameChildren.getText();
+            } else if(alterByRenameChildren instanceof MySqlParser.FullIdContext) {
                 newTableName = alterByRenameChildren.getText();
             }
         }
 
-        // If the databasename already includes the table name dont include it in the query.
-        if(originalTableName.contains(".")) {
+        // If the database name already includes the table name, don't include it in the query.
+        if (originalTableName.contains(".")) {
             this.query.delete(0, this.query.toString().length()).append(String.format
                     (Constants.ALTER_RENAME_TABLE, originalTableName, newTableName));
-        } else
+        } else {
             this.query.delete(0, this.query.toString().length()).append(String.format
-                (Constants.ALTER_RENAME_TABLE, databaseName + "." + originalTableName, databaseName + "." + newTableName));
-
+                    (Constants.ALTER_RENAME_TABLE, databaseName + "." + originalTableName, databaseName + "." + newTableName));
+        }
     }
 
+    /**
+     * This function processes the addition of a check table constraint in the ALTER TABLE statement.
+     * It appends the corresponding SQL query to add the check constraint.
+     *
+     * @param alterByAddCheckTableConstraintContext The context representing the ALTER TABLE ADD CHECK CONSTRAINT clause.
+     */
     @Override
     public void enterAlterByAddCheckTableConstraint(MySqlParser.AlterByAddCheckTableConstraintContext alterByAddCheckTableConstraintContext) {
-        // log.info("Enter check table constraint: " + alterByAddCheckTableConstraintContext.getText() );
+        // Append the relevant part of the query for the check constraint
         this.query.append(" ");
         for (ParseTree tree : alterByAddCheckTableConstraintContext.children) {
             this.parseTreeHelper(tree);
         }
     }
 
+    /**
+     * A helper function to recursively process each tree node in the ALTER TABLE statement.
+     *
+     * @param child The parse tree node to be processed.
+     */
     private void parseTreeHelper(ParseTree child) {
         if (child instanceof MySqlParser.UidContext) {
             this.query.append(child.getText()).append(" ");
@@ -604,22 +1033,19 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
         } else if (child instanceof TerminalNodeImpl) {
             this.query.append(child.getText()).append(" ");
         } else if (child instanceof ParserRuleContext) {
+            // Recursively process child nodes
             for (ParseTree child2 : ((ParserRuleContext) child).children) {
                 this.parseTreeHelper(child2);
             }
         }
     }
 
-//    @Override
-//    public void enterAlterByDropColumn(MySqlParser.AlterByDropColumnContext alterByDropColumnContext) {
-//        this.query.append(" ");
-//        for (ParseTree tree : alterByDropColumnContext.children) {
-//            if (tree instanceof MySqlParser.UidContext) {
-//                this.query.append(String.format(Constants.DROP_COLUMN, tree.getText()));
-//            }
-//        }
-//    }
-
+    /**
+     * This function processes the DROP TABLE statement.
+     * It appends the necessary SQL query to drop the specified table.
+     *
+     * @param dropTableContext The context representing the DROP TABLE clause.
+     */
     @Override
     public void enterDropTable(MySqlParser.DropTableContext dropTableContext) {
         log.debug("DROP TABLE enter");
@@ -628,18 +1054,29 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
             if (child instanceof MySqlParser.TablesContext) {
                 for (ParseTree tableNameChild : ((MySqlParser.TablesContext) child).children) {
                     if (tableNameChild instanceof MySqlParser.TableNameContext) {
-                        this.query.append(tableNameChild.getText());
+                        String tableName = tableNameChild.getText();
+                        if (tableName.contains(".")) {
+                            String[] parts = tableName.split("\\.");
+                            this.query.append(databaseName).append(".").append(parts[1]);
+                        } else {
+                            this.query.append(databaseName).append(".").append(tableName);
+                        }
                     } else if (tableNameChild instanceof TerminalNodeImpl) {
                         this.query.append(tableNameChild.getText());
                     }
                 }
-            } else if(child instanceof MySqlParser.IfExistsContext) {
+            } else if (child instanceof MySqlParser.IfExistsContext) {
                 this.query.append(Constants.IF_EXISTS);
             }
         }
     }
 
-
+    /**
+     * This function processes the RENAME TABLE statement.
+     * It appends the corresponding SQL query to rename the table.
+     *
+     * @param renameTableContext The context representing the RENAME TABLE clause.
+     */
     @Override
     public void enterRenameTable(MySqlParser.RenameTableContext renameTableContext) {
         this.query.append(Constants.RENAME_TABLE).append(" ");
@@ -652,12 +1089,19 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
                 if (renameTableContextChildren.size() >= 3) {
                     originalTableName = renameTableContextChildren.get(0).getText();
                     newTableName = renameTableContextChildren.get(2).getText();
-                    // If the table name already includes the database name dont include it in the query.
-                    if(originalTableName.contains(".")) {
-                        this.query.append(originalTableName).append(" to ").append(newTableName);
-                    } else
-                        this.query.append(databaseName).append(".").append(originalTableName).append(" to ").
-                                append(databaseName).append(".").append(newTableName);
+                    // If the table name already includes the database name don't include it in the query.
+                    if (originalTableName.contains(".") || newTableName.contains(".")) {
+                        // Split database and table name.
+                        String origTable = originalTableName.contains(".")
+                                ? originalTableName.split("\\.")[1] : originalTableName;
+                        String newTable = newTableName.contains(".")
+                                ? newTableName.split("\\.")[1] : newTableName;
+                        this.query.append(this.databaseName).append(".").append(origTable).append(" to ").append(this.databaseName)
+                                .append(".").append(newTable);
+                    } else {
+                        this.query.append(databaseName).append(".").append(originalTableName).append(" to ").append(databaseName)
+                                .append(".").append(newTableName);
+                    }
                 }
             } else if(child instanceof TerminalNodeImpl) {
                 if (((TerminalNodeImpl) child).symbol.getType() == MySqlParser.COMMA) {
@@ -667,11 +1111,23 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
         }
     }
 
+    /**
+     * This function processes the TRUNCATE TABLE statement.
+     * It appends the necessary SQL query to truncate the specified table.
+     *
+     * @param truncateTableContext The context representing the TRUNCATE TABLE clause.
+     */
     @Override
     public void enterTruncateTable(MySqlParser.TruncateTableContext truncateTableContext) {
         for (ParseTree child : truncateTableContext.children) {
             if (child instanceof MySqlParser.TableNameContext) {
-                this.query.append(String.format(Constants.TRUNCATE_TABLE, databaseName + "." + child.getText()));
+                String tableName = child.getText();
+                if (tableName.contains(".")) {
+                    String[] parts = tableName.split("\\.");
+                    this.query.append(String.format(Constants.TRUNCATE_TABLE, databaseName + "." + parts[1]));
+                } else {
+                    this.query.append(String.format(Constants.TRUNCATE_TABLE, databaseName + "." + tableName));
+                }
             }
         }
     }

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java
@@ -7,13 +7,17 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfigVariables.CLICKHOUSE_DATABASE_OVERRIDE_MAP;
 
 
 public class MySqlDDLParserListenerImplTest {
@@ -26,6 +30,17 @@ public class MySqlDDLParserListenerImplTest {
         mySQLDDLParserService = new MySQLDDLParserService(new ClickHouseSinkConnectorConfig(new HashMap<>()),
                 "employees");
         DebeziumChangeEventCapture.isNewReplacingMergeTreeEngine = true;
+    }
+
+    @Test
+    public void testCreateTableWithSetDataType() {
+
+        String createQuery = "CREATE TABLE example(options SET('a', 'b', 'c', 'd'))";
+        StringBuffer clickHouseQuery = new StringBuffer();
+
+        mySQLDDLParserService.parseSql(createQuery, "test", clickHouseQuery);
+        Assert.assertTrue("CREATE TABLE employees.example(options Nullable(String),`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) ORDER BY tuple()".equalsIgnoreCase(clickHouseQuery.toString()));
+        ;
     }
     @Test
     public void testCreateTableWithEnum() {
@@ -45,9 +60,10 @@ public class MySqlDDLParserListenerImplTest {
         StringBuffer clickHouseQuery = new StringBuffer();
 
         mySQLDDLParserService.parseSql(createQuery, "Persons",  clickHouseQuery);
-        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("CREATE TABLE employees.employees_predated(emp_no Int32 NOT NULL ,birth_date Date32 NOT NULL ,first_name String NOT NULL ,last_name String NOT NULL ,gender String NOT NULL ,hire_date Date32 NOT NULL ,`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) ORDER BY (emp_no)"));
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("CREATE TABLE employees.employees_predated(emp_no Int32 NOT NULL ,birth_date Date32 NOT NULL ,first_name String NOT NULL ,last_name String NOT NULL ,gender String NOT NULL ,hire_date Date32 NOT NULL ,`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) PARTITION BY  emp_no ORDER BY (emp_no)"));
         log.info("Create table " + clickHouseQuery);
     }
+
     @Test
     public void testCreateTableWithRangeByColumnsPartition() {
         String createQuery = "CREATE TABLE rcx ( a INT, b INT, c CHAR(3), d INT) PARTITION BY RANGE COLUMNS(a,d,c) ( PARTITION p0 VALUES LESS THAN (5,10,'ggg'), PARTITION p1 VALUES LESS THAN (10,20,'mmm'), " +
@@ -57,6 +73,16 @@ public class MySqlDDLParserListenerImplTest {
         Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("CREATE TABLE employees.rcx(a Nullable(Int32),b Nullable(Int32),c Nullable(String),d Nullable(Int32),`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) PARTITION BY  (a,d,c) ORDER BY tuple()"));
         log.info("Create table " + clickHouseQuery);
     }
+
+//     @Test
+//     public void testAlterTableWithAnalyzePartition() {
+//
+//         String alterTableQuery = "alter  table  std_txn_agg analyze partition p20231229";
+//         StringBuffer clickHouseQuery = new StringBuffer();
+//         mySQLDDLParserService.parseSql(alterTableQuery, "Persons",  clickHouseQuery);
+//         Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE employees.std_txn_agg ANALYZE PARTITION p20231229"));
+//         log.info("Alter table " + clickHouseQuery);
+//     }
 
     @Test
     public void testCreateTableWithParitionRange() {
@@ -75,7 +101,7 @@ public class MySqlDDLParserListenerImplTest {
         StringBuffer clickHouseQuery = new StringBuffer();
         mySQLDDLParserService.parseSql(createQuery, "Persons", clickHouseQuery);
 
-        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("CREATE TABLE employees.t(id Nullable(Int32),dt Date32 NOT NULL ,`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) PARTITION BY  (dt) ORDER BY id"));
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("CREATE TABLE employees.t(id Int32 NOT NULL ,dt Date32 NOT NULL ,`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) PARTITION BY  (dt) ORDER BY id"));
         log.info("Create table " + clickHouseQuery);
 
         String createQueryWithoutPrimaryKey =  "create table t(\n" +
@@ -95,6 +121,31 @@ public class MySqlDDLParserListenerImplTest {
         Assert.assertTrue(clickHouseQueryWOPrimaryKey.toString().equalsIgnoreCase("CREATE TABLE employees.t(id Nullable(Int32),dt Date32 NOT NULL ,`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) PARTITION BY  (dt) ORDER BY tuple()"));
         log.info("Create table " + clickHouseQueryWOPrimaryKey);
     }
+
+    @Test
+    public void testCreateTableWithCommentedPartition() {
+        String createQuery = "create table t(\n" +
+                "id int not null,\n" +
+                "dt date not null,\n" +
+                "primary key(id, dt)\n" +
+                ") ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8\n" +
+                "/*!50500 PARTITION BY RANGE  COLUMNS(dt)\n" +
+                "(PARTITION p20201231 VALUES LESS THAN ('2021-01-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20211230 VALUES LESS THAN ('2021-12-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20211231 VALUES LESS THAN ('2022-01-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20220103 VALUES LESS THAN ('2022-01-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20220104 VALUES LESS THAN ('2022-01-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20220105 VALUES LESS THAN ('2022-01-06') ENGINE = InnoDB\n" +
+                ")*/;";
+        StringBuffer clickHouseQuery = new StringBuffer();
+        mySQLDDLParserService.parseSql(createQuery, "Persons", clickHouseQuery);
+        
+        // This test verifies that our regex fallback correctly parses partition columns from commented partition syntax
+        Assert.assertTrue(clickHouseQuery.toString().contains("PARTITION BY"));
+        Assert.assertTrue(clickHouseQuery.toString().contains("dt"));
+        log.info("Create table with commented partition: " + clickHouseQuery);
+    }
+
     @Test
     public void testCreateTableWithKeyPartition() {
         String createQuery = "CREATE TABLE members (\n" +
@@ -172,6 +223,17 @@ public class MySqlDDLParserListenerImplTest {
     }
 
     @Test
+    public void testAutoCreateTable() {
+        String createQuery = "CREATE TABLE IF NOT EXISTS test.autocreate_e904bc35_aac8_11f0_9925_e114ebd31e17 (id INT NOT NULL,D4 DECIMAL(2,1), D5 DECIMAL(30, 10), Doublex DOUBLE, x_date DATE,x_datetime6 DATETIME(6),x_time TIME,x_time6 TIME(6),Intmin INT, Intmax INT,UIntmin INT UNSIGNED, UIntmax INT UNSIGNED,BIGIntmin BIGINT,BIGIntmax BIGINT,UBIGIntmin BIGINT UNSIGNED,UBIGIntmax BIGINT UNSIGNED,TIntmin TINYINT,TIntmax TINYINT,UTIntmin TINYINT UNSIGNED,UTIntmax TINYINT UNSIGNED,SIntmin SMALLINT,SIntmax SMALLINT,USIntmin SMALLINT UNSIGNED,USIntmax SMALLINT UNSIGNED,MIntmin MEDIUMINT,MIntmax MEDIUMINT,UMIntmin MEDIUMINT UNSIGNED,UMIntmax MEDIUMINT UNSIGNED, x_char CHAR, x_text TEXT, x_varchar VARCHAR(4), x_Blob BLOB, x_Mediumblob MEDIUMBLOB, x_Longblob LONGBLOB, x_binary BINARY, x_varbinary VARBINARY(4), PRIMARY KEY (id)) ENGINE = InnoDB";
+
+        StringBuffer clickHouseQuery = new StringBuffer();
+        HashMap<String, String> props = new HashMap<>();
+        MySQLDDLParserService mySQLDDLParserService1 = new MySQLDDLParserService(new ClickHouseSinkConnectorConfig(props), "datatypes");
+        mySQLDDLParserService1.parseSql(createQuery, "Persons", clickHouseQuery);
+        String expectedQuery = "CREATE TABLE if not exists datatypes.autocreate_e904bc35_aac8_11f0_9925_e114ebd31e17(id Int32 NOT NULL ,D4 Nullable(Decimal(2,1)),D5 Nullable(Decimal(30,10)),Doublex Nullable(Float32),x_date Nullable(Date32),x_datetime6 Nullable(DateTime64(6, 0)),x_time Nullable(String),x_time6 Nullable(String),Intmin Nullable(Int32),Intmax Nullable(Int32),UIntmin Nullable(Int64),UIntmax Nullable(Int64),BIGIntmin Nullable(Int64),BIGIntmax Nullable(Int64),UBIGIntmin Nullable(UInt64),UBIGIntmax Nullable(UInt64),TIntmin Nullable(Int8),TIntmax Nullable(Int8),UTIntmin Nullable(Int16),UTIntmax Nullable(Int16),SIntmin Nullable(Int16),SIntmax Nullable(Int16),USIntmin Nullable(Int32),USIntmax Nullable(Int32),MIntmin Nullable(Int32),MIntmax Nullable(Int32),UMIntmin Nullable(Int32),UMIntmax Nullable(Int32),x_char Nullable(String),x_text Nullable(String),x_varchar Nullable(String),x_Blob Nullable(String),x_Mediumblob Nullable(String),x_Longblob Nullable(String),x_binary Nullable(String),x_varbinary Nullable(String),`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) ORDER BY (id)";
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(expectedQuery));
+    }
+    @Test
     @DisplayName("Auto create table with user provided clickhouse timezone")
     public void testAutoCreateTableWithCHTimezone() {
         String createQuery6 = "CREATE TABLE `temporal_types_DATETIME4` (\n" +
@@ -214,6 +276,37 @@ public class MySqlDDLParserListenerImplTest {
     }
 
     @Test
+    public void testDropDatabaseWithOverrideMap() {
+        StringBuffer clickHouseQuery = new StringBuffer();
+        String dropQuery = "DROP DATABASE `test`";
+        Map<String, String> config = new HashMap<>();
+        config.put(CLICKHOUSE_DATABASE_OVERRIDE_MAP.toString(), "test:test2");
+
+        MySQLDDLParserService mySQLDDLParserService1 = new MySQLDDLParserService(new ClickHouseSinkConnectorConfig(config), "test");
+        mySQLDDLParserService1.parseSql(dropQuery, "test", clickHouseQuery);
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("DROP DATABASE IF EXISTS test2"));
+        log.info("Drop database " + clickHouseQuery);
+    }
+    @Test
+    public void testCreateTableWithReplicatedReplacingMergeTree() {
+
+        StringBuffer clickHouseQuery = new StringBuffer();
+        String createDB = "CREATE TABLE IF NOT EXISTS mysql1.`table_7220f7bd_8c8c_11ef_94db_67ff65f7711d` (id INT NOT NULL,col1 varchar(255), col2 int, PRIMARY KEY (id)) ENGINE = InnoDB";
+
+        // Set ClickHouse sink connector config to set replicated tables.
+        Map<String, String> config = new HashMap<>();
+        config.put(ClickHouseSinkConnectorConfigVariables.AUTO_CREATE_TABLES_REPLICATED.toString(), "true");
+        config.put(CLICKHOUSE_DATABASE_OVERRIDE_MAP.toString(), "mysql1:ch1");
+
+        ClickHouseSinkConnectorConfig clickHouseSinkConnectorConfig = new ClickHouseSinkConnectorConfig(config);
+        MySQLDDLParserService mySQLDDLParserService = new MySQLDDLParserService(clickHouseSinkConnectorConfig, "ch1");
+        mySQLDDLParserService.parseSql(createDB, "Persons", clickHouseQuery);
+        log.info("Create table " + clickHouseQuery);
+
+        String expectedQuery = "CREATE TABLE if not exists ch1.`table_7220f7bd_8c8c_11ef_94db_67ff65f7711d` ON CLUSTER `{cluster}`(id Int32 NOT NULL ,col1 Nullable(String),col2 Nullable(Int32),`_version` UInt64,`is_deleted` UInt8) Engine=ReplicatedReplacingMergeTree(_version, is_deleted) ORDER BY (id)";
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(expectedQuery));
+    }
+    @Test
     public void testCreateTableAutoIncrement() {
         StringBuffer clickHouseQuery = new StringBuffer();
         String createDB = "CREATE TABLE IF NOT EXISTS 730b595f_d475_11ed_b64a_398b553542b2 (id INT AUTO_INCREMENT,x INT, PRIMARY KEY (id)) ENGINE = InnoDB;";
@@ -228,6 +321,7 @@ public class MySqlDDLParserListenerImplTest {
         StringBuffer clickHouseQuery = new StringBuffer();
         String createDB = "CREATE TABLE new_tbl LIKE orig_tbl;";
         mySQLDDLParserService.parseSql(createDB, "Persons", clickHouseQuery);
+        Assert.assertTrue("CREATE TABLE employees.new_tbl AS employees.orig_tbl".equalsIgnoreCase(clickHouseQuery.toString()));
         log.info("Create table " + clickHouseQuery);
     }
     @Test
@@ -240,6 +334,7 @@ public class MySqlDDLParserListenerImplTest {
         log.info("Create table " + clickHouseQuery);
 
     }
+
     @Test
     public void testCreateTableWithNulLFields() {
         StringBuffer clickHouseQuery = new StringBuffer();
@@ -284,7 +379,22 @@ public class MySqlDDLParserListenerImplTest {
 
         String clickhouseExpectedQuery = "ALTER TABLE employees.employees ADD COLUMN ssn_number Nullable(String)";
         StringBuffer clickHouseQuery = new StringBuffer();
-        String alterDBAddColumn = "ALTER TABLE employees add column ssn_number varchar(100)";
+        String alterDBAddColumn = "ALTER TABLE employees ADD COLUMN ssn_number varchar(255)";
+        mySQLDDLParserService.parseSql(alterDBAddColumn, "employees", clickHouseQuery);
+
+        log.info("CLICKHOUSE QUERY" + clickHouseQuery);
+
+        Assert.assertTrue(clickHouseQuery != null && clickHouseQuery.length() != 0);
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(clickhouseExpectedQuery));
+    }
+
+    @Test
+    public void testAlterAddColumnWithColumnKeyword() {
+
+        String alterDBAddColumn = "alter table db1.table1 add entity varchar(255) , ALGORITHM=INPLACE, LOCK=NONE";
+        String clickhouseExpectedQuery = "ALTER TABLE employees.table1 ADD COLUMN entity Nullable(String)";
+        StringBuffer clickHouseQuery = new StringBuffer();
+
         mySQLDDLParserService.parseSql(alterDBAddColumn, "employees", clickHouseQuery);
 
         log.info("CLICKHOUSE QUERY" + clickHouseQuery);
@@ -306,10 +416,40 @@ public class MySqlDDLParserListenerImplTest {
         //Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(clickhouseExpectedQuery));
     }
 
+    // Add column by data type mapping from 'config_schema_override' file
+    @Test
+    public void testAlterDatabaseAddColumnDataTypeMapping() {
+
+        String addColumnNullable = "ALTER TABLE foo_new9 ADD COLUMN gmt_time3 DATETIME";
+        String clickhouseExpectedQuery = "ALTER TABLE employees.foo_new9 ADD COLUMN gmt_time3 Nullable(DateTime64)";
+        StringBuffer clickHouseQuery = new StringBuffer();
+        mySQLDDLParserService.parseSql(addColumnNullable, "foo_new9", clickHouseQuery);
+
+        log.info("CLICKHOUSE QUERY" + clickHouseQuery);
+
+        Assert.assertTrue(clickHouseQuery != null && clickHouseQuery.length() != 0);
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(clickhouseExpectedQuery));
+    }
+
+    // Add or rename column by data type mapping from 'config_schema_override' file
+    @Test
+    public void testAlterDatabaseRenameColumnDataTypeMapping() {
+
+        String addColumnNullable = "ALTER TABLE foo_new9 CHANGE COLUMN gmt_time3 gmt_time5 DATETIME;";
+        // String clickhouseExpectedQuery = "ALTER TABLE employees.foo_new9 ADD COLUMN gmt_time3 Nullable(String)";
+        StringBuffer clickHouseQuery = new StringBuffer();
+        mySQLDDLParserService.parseSql(addColumnNullable, "employees", clickHouseQuery);
+
+        log.info("CLICKHOUSE QUERY" + clickHouseQuery);
+
+        Assert.assertTrue(clickHouseQuery != null && clickHouseQuery.length() != 0);
+        // Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(clickhouseExpectedQuery));
+    }
+
     // Before, After
     @Test
     public void testAlterDatabaseAddMultipleColumns1() {
-        String expectedClickHouseQuery = "ALTER TABLE employees.employees ADD COLUMN ship_spec Nullable(String)  first, ADD COLUMN somecol Nullable(Int32)  after start_build,";
+        String expectedClickHouseQuery = "ALTER TABLE employees.employees ADD COLUMN ship_spec Nullable(String)  first, ADD COLUMN somecol Nullable(Int32)  after start_build";
         StringBuffer clickHouseQuery = new StringBuffer();
         String query = "alter table employees.employees add column ship_spec varchar(150) first, add somecol int after start_build, algorithm=instant;";
         mySQLDDLParserService.parseSql(query, "employees", clickHouseQuery);
@@ -350,9 +490,13 @@ public class MySqlDDLParserListenerImplTest {
         StringBuffer clickHouseQuery = new StringBuffer();
         mySQLDDLParserService.parseSql(mysqlQuery, "add_test", clickHouseQuery);
 
-        String expectedCHQuery = "ALTER TABLE employees.add_test ADD COLUMN customer_address String, ADD COLUMN customer_name Nullable(String)";
-        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(expectedCHQuery));
-        log.info("CLICKHOUSE QUERY: " + clickHouseQuery);
+        String mysqlQuery2 = "ALTER TABLE server_team_replicate.test ADD COLUMN coins TINYINT(1) NOT NULL DEFAULT 0 AFTER lglent_group;";
+        StringBuffer clickHouseQuery2 = new StringBuffer();
+        mySQLDDLParserService.parseSql(mysqlQuery2, "server_team_replicate", clickHouseQuery2);
+        String expectedQuery = "ALTER TABLE employees.test ADD COLUMN coins Int8 DEFAULT 0 AFTER lglent_group";
+        Assert.assertTrue(clickHouseQuery2.toString().equalsIgnoreCase(expectedQuery));
+        log.info("CLICKHOUSE QUERY: " + clickHouseQuery2);
+
     }
 
     @Test
@@ -379,7 +523,22 @@ public class MySqlDDLParserListenerImplTest {
         Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(expectedClickHouseQuery));
     }
 
+    @Test
+    public void testAlterTableModifyColumn() {
+        StringBuffer clickHouseQuery = new StringBuffer();
+        String alterTableModifyColumn = "ALTER TABLE employees.add_test MODIFY COLUMN col1 INT;";
+        mySQLDDLParserService.parseSql(alterTableModifyColumn, "add_test", clickHouseQuery);
 
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE employees.add_test MODIFY COLUMN col1 Int32"));
+    }
+
+    @Test
+    public void testAlterTableModifyAddColumn() {
+        StringBuffer clickHouseQuery2 = new StringBuffer();
+        String alterTableModifyColumn2 = "alter table  test1 add  column `vendor_folder` varchar(128) COLLATE latin1_general_cs NOT NULL after expected_arrival_time";
+        mySQLDDLParserService.parseSql(alterTableModifyColumn2, "add_test", clickHouseQuery2);
+        Assert.assertTrue(clickHouseQuery2.toString().equalsIgnoreCase("ALTER TABLE employees.test1 ADD COLUMN `vendor_folder` String after expected_arrival_time"));
+    }
 
     @Test
     public void testAlterDatabaseModifyColumns() {
@@ -397,7 +556,7 @@ public class MySqlDDLParserListenerImplTest {
         mySQLDDLParserService.parseSql(alterDBAddColumnNonNullable, "contacts", clickHouseQueryNonNullable);
         //Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE contacts MODIFY COLUMN last_name Nullable(String)"));
         log.info("CLICKHOUSE QUERY" + clickHouseQueryNonNullable);
-        Assert.assertTrue(clickHouseQueryNonNullable.toString().equalsIgnoreCase("ALTER TABLE database_1.`table_fcdd63fd_0c60_11ef_a293_cfcc8bfdbf55` MODIFY COLUMN col1 String\n" +
+        Assert.assertTrue(clickHouseQueryNonNullable.toString().equalsIgnoreCase("ALTER TABLE employees.`table_fcdd63fd_0c60_11ef_a293_cfcc8bfdbf55` MODIFY COLUMN col1 String\n" +
                 "ALTER TABLE database_1.`table_fcdd63fd_0c60_11ef_a293_cfcc8bfdbf55` RENAME COLUMN col1 to new_col"));
     }
 
@@ -436,6 +595,19 @@ public class MySqlDDLParserListenerImplTest {
 
     }
 
+    @Test
+    public void testRenameColumnWithDatabaseOverride() {
+
+        Map<String, String> props = new HashMap<>();
+        props.put(CLICKHOUSE_DATABASE_OVERRIDE_MAP.toString(), "mysql1:ch1");
+        ClickHouseSinkConnectorConfig config = new ClickHouseSinkConnectorConfig(props);
+        MySQLDDLParserService mySQLDDLParserService = new MySQLDDLParserService(config, "ch1");
+
+        StringBuffer clickHouseQuery = new StringBuffer();
+        String sql = "ALTER TABLE mysql1.table_01dacfed_9875_11ef_b2c5_e7434a0f1a60 RENAME COLUMN col1 to new_col";
+        mySQLDDLParserService.parseSql(sql, "t2", clickHouseQuery);
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE ch1.table_01dacfed_9875_11ef_b2c5_e7434a0f1a60 RENAME COLUMN col1 to new_col"));
+    }
     @Test
     public void testChangeColumn() {
         StringBuffer clickHouseQuery = new StringBuffer();
@@ -492,11 +664,20 @@ public class MySqlDDLParserListenerImplTest {
         String sql = "alter table t2 add constraint t2_pk_constraint primary key (1c), alter column `_` set default 1;\n";
         mySQLDDLParserService.parseSql(sql, "t2", clickHouseQuery);
 
-
         StringBuffer clickHouseQuery2 = new StringBuffer();
 
         String checkConstraintSql = "ALTER TABLE orders ADD CONSTRAINT check_revenue_positive CHECK (revenue >= 0);";
         mySQLDDLParserService.parseSql(checkConstraintSql, " ", clickHouseQuery2);
+    }
+
+    @Test
+    public void testDropContraints() {
+        StringBuffer clickhouseQuery = new StringBuffer();
+
+        String dropConstraintsSql = "alter table employees drop CONSTRAINT employees_ibfk_2";
+        mySQLDDLParserService.parseSql(dropConstraintsSql, "employees", clickhouseQuery);
+
+        Assert.assertTrue(clickhouseQuery.toString().equalsIgnoreCase("ALTER TABLE employees.employees DROP CONSTRAINT IF EXISTS employees_ibfk_2"));
     }
 
     @Test
@@ -515,7 +696,7 @@ public class MySqlDDLParserListenerImplTest {
 
         String sql = "alter table table1 add primary key (id)";
         mySQLDDLParserService.parseSql(sql, "table1", clickHouseQuery);
-
+    //    Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("alter table employees.table1 add primary key (id)"));
     }
 
     @Test
@@ -526,6 +707,49 @@ public class MySqlDDLParserListenerImplTest {
         mySQLDDLParserService.parseSql(sql, "table1", clickHouseQuery);
 
         Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("TRUNCATE TABLE employees.add_test"));
+    }
+
+    @Test
+    public void truncateTableWithQualifiedName() {
+        StringBuffer clickHouseQuery = new StringBuffer();
+
+        String sql = "truncate table mydb.add_test";
+        mySQLDDLParserService.parseSql(sql, "table1", clickHouseQuery);
+
+        // When the table name is already qualified (mydb.add_test), the method should
+        // strip the source database and use the configured databaseName instead,
+        // producing employees.add_test (not employees.mydb.add_test).
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("TRUNCATE TABLE employees.add_test"));
+    }
+
+    @Test
+    public void dropTableWithQualifiedName() {
+        StringBuffer clickHouseQuery = new StringBuffer();
+
+        String sql = "drop table mydb.add_test";
+        mySQLDDLParserService.parseSql(sql, "table1", clickHouseQuery);
+
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("DROP TABLE employees.add_test"));
+    }
+
+    @Test
+    public void renameTableWithMixedQualification() {
+        StringBuffer clickHouseQuery = new StringBuffer();
+
+        String sql = "rename table mydb.old_table to new_table";
+        mySQLDDLParserService.parseSql(sql, "table1", clickHouseQuery);
+
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("RENAME TABLE employees.old_table to employees.new_table"));
+    }
+
+    @Test
+    public void dropTableUnqualifiedName() {
+        StringBuffer clickHouseQuery = new StringBuffer();
+
+        String sql = "drop table add_test";
+        mySQLDDLParserService.parseSql(sql, "table1", clickHouseQuery);
+
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("DROP TABLE employees.add_test"));
     }
 
     @Test
@@ -559,6 +783,24 @@ public class MySqlDDLParserListenerImplTest {
     }
 
     @Test
+    public void renameTableWithoutTableKeyword() {
+        StringBuffer clickHouseQuery = new StringBuffer();
+
+        String sql = "ALTER TABLE employees.old_table RENAME employees.new_table";
+        mySQLDDLParserService.parseSql(sql, "table1", clickHouseQuery);
+
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("rename table employees.old_table to employees.new_table"));
+    }
+
+    @Test
+    public void renameTableWithTableKeyword() {
+        StringBuffer clickHouseQuery = new StringBuffer();
+        String sql = "ALTER TABLE old_table RENAME new_table";
+        mySQLDDLParserService.parseSql(sql, "table1", clickHouseQuery);
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("rename table employees.old_table to employees.new_table"));
+    }
+
+    @Test
     public void renameTable() {
         StringBuffer clickHouseQuery = new StringBuffer();
 
@@ -569,14 +811,29 @@ public class MySqlDDLParserListenerImplTest {
     }
 
     @Test
-    public void testAddIndex() {
+    public void testRenameTableWithDatabaseOverride() {
         StringBuffer clickHouseQuery = new StringBuffer();
 
-        String sql = "alter table add_test add index if not exists ix_add_test_col1 using btree (col1) comment 'test index';\n";
+        HashMap<String, String> props = new HashMap<>();
+        props.put(CLICKHOUSE_DATABASE_OVERRIDE_MAP.toString(), "employees:employees2, products:productsnew");
+        ClickHouseSinkConnectorConfig config = new ClickHouseSinkConnectorConfig(props);
+        MySQLDDLParserService mySQLDDLParserService = new MySQLDDLParserService(config, "employees2");
+
+        String sql = "rename table employees.add_test to employees.add_test_old";
+
         mySQLDDLParserService.parseSql(sql, "table1", clickHouseQuery);
-
-
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("rename table employees2.add_test to employees2.add_test_old"));
     }
+
+//    @Test
+//    public void testAddIndex() {
+//        StringBuffer clickHouseQuery = new StringBuffer();
+//
+//        String sql = "alter table add_test add index if not exists ix_add_test_col1 using btree (col1) comment 'test index';\n";
+//        mySQLDDLParserService.parseSql(sql, "table1", clickHouseQuery);
+//
+//
+//    }
 
 
     @Test
@@ -588,16 +845,6 @@ public class MySqlDDLParserListenerImplTest {
 
     }
 
-    @Test
-    public void testAlterColumnAddDefault() {
-
-        StringBuffer clickHouseQuery = new StringBuffer();
-
-        String sql = "alter table add_test alter flag add default 1";
-        mySQLDDLParserService.parseSql(sql, "table1", clickHouseQuery);
-
-
-    }
 
     @Test
     public void testCreateDatabase() {
@@ -607,6 +854,21 @@ public class MySqlDDLParserListenerImplTest {
         mySQLDDLParserService.parseSql(sql, "table1", clickHouseQuery);
 
         Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("create database if not exists test_ddl"));
+    }
+
+    @Test
+    public void testCreateDatabaseReplicated() {
+        StringBuffer clickHouseQuery = new StringBuffer();
+
+        HashMap<String, String> map = new HashMap<>();
+        map.put(ClickHouseSinkConnectorConfigVariables.AUTO_CREATE_TABLES_REPLICATED.toString(), "true");
+        ClickHouseSinkConnectorConfig config = new ClickHouseSinkConnectorConfig(map);
+
+        MySQLDDLParserService mySQLDDLParserService = new MySQLDDLParserService(config, "test");
+        String sql = "create database if not exists repl_test_ddl";
+        mySQLDDLParserService.parseSql(sql, "table1", clickHouseQuery);
+
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("create database if not exists repl_test_ddl on cluster `{cluster}`"));
     }
 
     @Test
@@ -644,7 +906,7 @@ public class MySqlDDLParserListenerImplTest {
         String sql = "rename /* gh-ost */ table `trade_prod`.`enriched_trade` to `trade_prod`.`_enriched_trade_del`, `trade_prod`.`_enriched_trade_gho` to `trade_prod`.`enriched_trade`\n";
         mySQLDDLParserService.parseSql(sql, "", clickHouseQuery);
 
-        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("RENAME TABLE `trade_prod`.`enriched_trade` to `trade_prod`.`_enriched_trade_del`,`trade_prod`.`_enriched_trade_gho` to `trade_prod`.`enriched_trade`"));
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("RENAME TABLE employees.`enriched_trade` to employees.`_enriched_trade_del`,employees.`_enriched_trade_gho` to employees.`enriched_trade`"));
     }
     @Test
     public void alterTableRenameTable() {
@@ -654,6 +916,26 @@ public class MySqlDDLParserListenerImplTest {
         mySQLDDLParserService.parseSql(sql, "", clickHouseQuery);
 
         Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("RENAME TABLE employees.test_table to employees.test_table_new"));
+    }
+
+    @Test
+    public void testAlterTableColumnWithComment() {
+        StringBuffer clickHouseQuery = new StringBuffer();
+
+        String sql = "ALTER TABLE test_table ADD COLUMN col1 varchar(255) COMMENT 'test column';";
+        mySQLDDLParserService.parseSql(sql, "", clickHouseQuery);
+
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE employees.test_table ADD COLUMN col1 Nullable(String)"));
+    }
+
+    @Test
+    public void testAlterTableColumnWithCommentAndDecimalScale() {
+        StringBuffer clickHouseQuery = new StringBuffer();
+
+        String sql = "ALTER TABLE test_table ADD COLUMN col1 decimal(10,2) COMMENT 'test column';";
+        mySQLDDLParserService.parseSql(sql, "", clickHouseQuery);
+
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE employees.test_table ADD COLUMN col1 Nullable(Decimal(10,2))"));
     }
 
     @Test
@@ -670,10 +952,13 @@ public class MySqlDDLParserListenerImplTest {
     public void testSourceWithIsDeletedColumn() {
         StringBuffer clickHouseQuery = new StringBuffer();
 
+        String expectedQuery = "CREATE TABLE employees.new_table(col1 Nullable(String),col2 Nullable(Int32),is_deleted Nullable(Int32),_sign Nullable(Int32),`_version` UInt64,`_is_deleted` UInt8) Engine=ReplacingMergeTree(_version,_is_deleted) ORDER BY tuple()";
+
         String sql = "create table new_table(col1 varchar(255), col2 int, is_deleted int, _sign int);";
         mySQLDDLParserService.parseSql(sql, "", clickHouseQuery);
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(expectedQuery));
 
-        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("CREATE TABLE employees.new_table(col1 Nullable(String),col2 Nullable(Int32),is_deleted Nullable(Int32),_sign Nullable(Int32),`_version` UInt64,`__is_deleted` UInt8) Engine=ReplacingMergeTree(_version,__is_deleted) ORDER BY tuple()"));
+        //Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("CREATE TABLE employees.new_table(col1 Nullable(String),col2 Nullable(Int32),is_deleted Nullable(Int32),_sign Nullable(Int32),`_version` UInt64,`_is_deleted` UInt8) Engine=ReplacingMergeTree(_version,__is_deleted) ORDER BY tuple()"));
     }
 
     @ParameterizedTest
@@ -681,7 +966,6 @@ public class MySqlDDLParserListenerImplTest {
             "ALTER TABLE test_table rename to test_table_new, false",
             "drop table if exists table1, true",
             "drop database db1, true",
-            "drop database db2 if exists, true",
             "truncate table table1, true",
             "create database test_ddl, false",
             "ALTER TABLE add_test MODIFY COLUMN stocks Bool after col1, ALTER TABLE add_test RENAME COLUMN stocks to options, false"
@@ -708,7 +992,7 @@ public class MySqlDDLParserListenerImplTest {
         String sql = "CREATE TABLE temporal_types_TIMESTAMP1(`Mid_Value` timestamp(1) NOT NULL) ENGINE=InnoDB;";
         mySQLDDLParserService.parseSql(sql, "temporal_types_DATETIME4", clickHouseQuery, isDropOrTruncate);
 
-        String expectedResult = "CREATE TABLE datatypes.temporal_types_TIMESTAMP1 ON CLUSTER `{cluster}`(`Mid_Value` DateTime64(1, 0) NOT NULL ,`_version` UInt64,`is_deleted` UInt8)Engine=ReplicatedReplacingMergeTree(_version, is_deleted) ORDER BY tuple()";
+        String expectedResult = "CREATE TABLE datatypes.temporal_types_TIMESTAMP1 ON CLUSTER `{cluster}`(`Mid_Value` DateTime64(1, 0) NOT NULL ,`_version` UInt64,`is_deleted` UInt8) Engine=ReplicatedReplacingMergeTree(_version, is_deleted) ORDER BY tuple()";
         Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(expectedResult));
 
 
@@ -793,7 +1077,7 @@ public class MySqlDDLParserListenerImplTest {
         mySQLDDLParserService.parseSql(sql, "employees", clickHouseQuery);
 
         Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(
-                "CREATE TABLE employees.`city`(`ID` Int32 NOT NULL ,`Name` String NOT NULL ,`CountryCode` String NOT NULL ,`District` String NOT NULL ,`Population` Int32 NOT NULL ,`is_deleted` Nullable(Int16),`_version` UInt64,`__is_deleted` UInt8) Engine=ReplacingMergeTree(_version,__is_deleted) ORDER BY (`ID`)"));
+                "CREATE TABLE employees.`city`(`ID` Int32 NOT NULL ,`Name` String NOT NULL ,`CountryCode` String NOT NULL ,`District` String NOT NULL ,`Population` Int32 NOT NULL ,`is_deleted` Nullable(Int8),`_version` UInt64,`_is_deleted` UInt8) Engine=ReplacingMergeTree(_version,_is_deleted) ORDER BY (`ID`)"));
 
 
         String sqlWithoutBackticks = "create table city(id int not null auto_increment, Name char(35) , is_deleted tinyint(1) DEFAULT 0, primary key(id))";
@@ -802,29 +1086,1384 @@ public class MySqlDDLParserListenerImplTest {
         mySQLDDLParserService.parseSql(sqlWithoutBackticks, "employees", clickHouseQuery2);
 
         Assert.assertTrue(clickHouseQuery2.toString().equalsIgnoreCase(
-                "CREATE TABLE employees.city(id Int32 NOT NULL ,Name Nullable(String),is_deleted Nullable(Int16),`_version` UInt64,`__is_deleted` UInt8) Engine=ReplacingMergeTree(_version,__is_deleted) ORDER BY (id)"));
+                "CREATE TABLE employees.city(id Int32 NOT NULL ,Name Nullable(String),is_deleted Nullable(Int8),`_version` UInt64,`_is_deleted` UInt8) Engine=ReplacingMergeTree(_version,_is_deleted) ORDER BY (id)"));
     }
-//    @Test
-//    public void deleteData() {
-//        String sql = "DELETE FROM Customers WHERE CustomerName='Alfreds Futterkiste'";
-//        StringBuffer clickHouseQuery = new StringBuffer();
-//
-//        AtomicBoolean isDropOrTruncate = new AtomicBoolean();
-//        MySQLDDLParserService mySQLDDLParserService2 = new MySQLDDLParserService();
-//        mySQLDDLParserService2.parseSql(sql, "", clickHouseQuery, isDropOrTruncate);
-//
-//        System.out.println("Clickhouse query" + clickHouseQuery);
-//
-//    }
 
-//    @Test
-//    public void testDropDatabase() {
-//        StringBuffer clickHouseQuery = new StringBuffer();
-//
-//        String sql = "drop database if exists employees";
-//        MySQLDDLParserService mySQLDDLParserService2 = new MySQLDDLParserService();
-//        mySQLDDLParserService2.parseSql(sql, "", clickHouseQuery);
-//
-//        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(sql));
-//    }
+    @Test
+    public void testGhostSQL() {
+        String sql = " alter /* gh-ost */ table `p_prod`.`_j_failed_s_g` REMOVE PARTITIONING;\n";
+        StringBuffer clickHouseQuery = new StringBuffer();
+        mySQLDDLParserService.parseSql(sql, "employees", clickHouseQuery);
+
+        //Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("alter table `p_prod`.`_j_failed_s_g` REMOVE PARTITIONING"));
+
+        String createTableQuery = "create /* gh-ost */ table `p_prod`.`_j_failed_s_g`(id int auto_increment primary key)engine=InnoDB comment='ghost-cut-over'";
+
+        StringBuffer clickHouseQuery2 = new StringBuffer();
+        mySQLDDLParserService.parseSql(createTableQuery, "employees", clickHouseQuery2);
+
+        Assert.assertTrue(clickHouseQuery2.toString().equalsIgnoreCase("CREATE TABLE employees.`_j_failed_s_g`(id Int32 NOT NULL ,`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) ORDER BY id"));
+    }
+
+    @Test
+    public void testCreateDefiner() {
+        String sql = "CREATE DEFINER=`bcadmin`@`%` PROCEDURE `sp_next_available_otc_instance_strategy_id`()\n" +
+                "begin\n" +
+                "  select min(st.value) as strategy_id\n" +
+                "  from SEQUENCE_TABLE(100000) st\n" +
+                "  join btc_quant.stratId_ranges r on r.stratId0 <= st.value and st.value < r.stratId1\n" +
+                "  left join otc_instance i on i.strategy_id=st.value\n" +
+                "  where r.category = 'otc' and now() between validFromDate and coalesce(validToDate, now())\n" +
+                "  and i.strategy_id is null;\n" +
+                "end";
+
+        StringBuffer clickHouseQuery = new StringBuffer();
+        mySQLDDLParserService.parseSql(sql, "employees", clickHouseQuery);
+
+        // Just validates that the debezium parsor does not throw an error
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(""));
+
+        String sqlTrigger = "CREATE DEFINER=`bcadmin`@`%` TRIGGER `host_id_constraint` BEFORE INSERT ON `host` FOR EACH ROW\n"
+                + "BEGIN\n"
+                + "  DECLARE next_id INT;\n"
+                + "  DECLARE max_id INT;\n"
+                + "  DECLARE error_msg VARCHAR(100);\n"
+                + "\n"
+                + "  SET max_id = POWER(2, 9)-1;\n"
+                + "  SET next_id = NULL;\n"
+                + "\n"
+                + "  SELECT MIN(st.value) INTO next_id\n"
+                + "  FROM SEQUENCE_TABLE(max_id+1) st\n"
+                + "  LEFT JOIN host h ON h.id = st.value\n"
+                + "  WHERE st.value > 0\n"
+                + "  AND h.id IS NULL;\n"
+                + "\n"
+                + "  IF ISNULL(next_id)\n"
+                + "  THEN\n"
+                + "    SET error_msg = CONCAT('no free ids in range [1, ', CAST(max_id AS CHAR), ']');\n"
+                + "    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = error_msg;\n"
+                + "  END IF;\n"
+                + "\n"
+                + "  IF next_id > max_id\n"
+                + "  THEN\n"
+                + "    SET error_msg = CONCAT('next id too high to insert: next_id=', CAST(next_id AS CHAR), ' max_id=', CAST(max_id AS CHAR));\n"
+                + "    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = error_msg;\n"
+                + "  END IF;\n"
+                + "\n"
+                + "  SET NEW.id = next_id;\n"
+                + "END";
+
+
+        StringBuffer clickHouseQuery2 = new StringBuffer();
+        mySQLDDLParserService.parseSql(sqlTrigger, "employees", clickHouseQuery2);
+
+        Assert.assertTrue(clickHouseQuery2.toString().equalsIgnoreCase(""));
+    }
+
+    @Test
+    public void testCreateTableWithPartitionByRange() {
+
+        String sql2 = "CREATE TABLE `clearing_position_incomplete_detail` (\n" +
+                "  `clearing_position_incomplete_detail_id` bigint unsigned NOT NULL AUTO_INCREMENT,\n" +
+                "  `clearing_date` date NOT NULL,\n" +
+                "  `incomplete_reason_id` smallint unsigned NOT NULL,\n" +
+                "  `incomplete_lookup_type_id` smallint unsigned NOT NULL,\n" +
+                "  `clearing_position_id` bigint DEFAULT NULL,\n" +
+                "  `ref_lookup_db_time` datetime(6) NOT NULL,\n" +
+                "  PRIMARY KEY (`clearing_position_incomplete_detail_id`,`clearing_date`),\n" +
+                "  UNIQUE KEY `clearing_position_incomplete_detail_uq1` (`clearing_date`,`incomplete_reason_id`,`incomplete_lookup_type_id`,`clearing_position_id`),\n" +
+                "  KEY `clearing_position_incomplete_detail_idx1` (`clearing_position_id`,`clearing_date`),\n" +
+                "  KEY `clearing_position_incomplete_detail_idx2` (`incomplete_reason_id`),\n" +
+                "  KEY `clearing_position_incomplete_detail_idx3` (`incomplete_lookup_type_id`)\n" +
+                ") ENGINE=InnoDB AUTO_INCREMENT=2364061321790051335 DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs STATS_SAMPLE_PAGES=200\n" +
+                "/*!50500 PARTITION BY RANGE  COLUMNS(clearing_date)\n" +
+                "(PARTITION p20201231 VALUES LESS THAN ('2021-01-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20211230 VALUES LESS THAN ('2021-12-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20211231 VALUES LESS THAN ('2022-01-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20221229 VALUES LESS THAN ('2022-12-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20221230 VALUES LESS THAN ('2023-01-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20230102 VALUES LESS THAN ('2023-01-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20230103 VALUES LESS THAN ('2023-01-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20230104 VALUES LESS THAN ('2023-01-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20230105 VALUES LESS THAN ('2023-01-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20230106 VALUES LESS THAN ('2023-01-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20230109 VALUES LESS THAN ('2023-01-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20230110 VALUES LESS THAN ('2023-01-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20230111 VALUES LESS THAN ('2023-01-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20230112 VALUES LESS THAN ('2023-01-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20230113 VALUES LESS THAN ('2023-01-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20230116 VALUES LESS THAN ('2023-01-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20230117 VALUES LESS THAN ('2023-01-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20230118 VALUES LESS THAN ('2023-01-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20230119 VALUES LESS THAN ('2023-01-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20230120 VALUES LESS THAN ('2023-01-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20230123 VALUES LESS THAN ('2023-01-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20230124 VALUES LESS THAN ('2023-01-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20230125 VALUES LESS THAN ('2023-01-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20230126 VALUES LESS THAN ('2023-01-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20230127 VALUES LESS THAN ('2023-01-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20230130 VALUES LESS THAN ('2023-01-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20230131 VALUES LESS THAN ('2023-02-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20230201 VALUES LESS THAN ('2023-02-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20230202 VALUES LESS THAN ('2023-02-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20230203 VALUES LESS THAN ('2023-02-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20230206 VALUES LESS THAN ('2023-02-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20230207 VALUES LESS THAN ('2023-02-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20230208 VALUES LESS THAN ('2023-02-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20230209 VALUES LESS THAN ('2023-02-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20230210 VALUES LESS THAN ('2023-02-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20230213 VALUES LESS THAN ('2023-02-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20230214 VALUES LESS THAN ('2023-02-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20230215 VALUES LESS THAN ('2023-02-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20230216 VALUES LESS THAN ('2023-02-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20230217 VALUES LESS THAN ('2023-02-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20230220 VALUES LESS THAN ('2023-02-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20230221 VALUES LESS THAN ('2023-02-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20230222 VALUES LESS THAN ('2023-02-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20230223 VALUES LESS THAN ('2023-02-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20230224 VALUES LESS THAN ('2023-02-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20230227 VALUES LESS THAN ('2023-02-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20230228 VALUES LESS THAN ('2023-03-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20230301 VALUES LESS THAN ('2023-03-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20230302 VALUES LESS THAN ('2023-03-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20230303 VALUES LESS THAN ('2023-03-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20230306 VALUES LESS THAN ('2023-03-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20230307 VALUES LESS THAN ('2023-03-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20230308 VALUES LESS THAN ('2023-03-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20230309 VALUES LESS THAN ('2023-03-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20230310 VALUES LESS THAN ('2023-03-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20230313 VALUES LESS THAN ('2023-03-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20230314 VALUES LESS THAN ('2023-03-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20230315 VALUES LESS THAN ('2023-03-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20230316 VALUES LESS THAN ('2023-03-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20230317 VALUES LESS THAN ('2023-03-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20230320 VALUES LESS THAN ('2023-03-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20230321 VALUES LESS THAN ('2023-03-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20230322 VALUES LESS THAN ('2023-03-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20230323 VALUES LESS THAN ('2023-03-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20230324 VALUES LESS THAN ('2023-03-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20230327 VALUES LESS THAN ('2023-03-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20230328 VALUES LESS THAN ('2023-03-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20230329 VALUES LESS THAN ('2023-03-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20230330 VALUES LESS THAN ('2023-03-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20230331 VALUES LESS THAN ('2023-04-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20230403 VALUES LESS THAN ('2023-04-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20230404 VALUES LESS THAN ('2023-04-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20230405 VALUES LESS THAN ('2023-04-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20230406 VALUES LESS THAN ('2023-04-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20230407 VALUES LESS THAN ('2023-04-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20230410 VALUES LESS THAN ('2023-04-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20230411 VALUES LESS THAN ('2023-04-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20230412 VALUES LESS THAN ('2023-04-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20230413 VALUES LESS THAN ('2023-04-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20230414 VALUES LESS THAN ('2023-04-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20230417 VALUES LESS THAN ('2023-04-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20230418 VALUES LESS THAN ('2023-04-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20230419 VALUES LESS THAN ('2023-04-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20230420 VALUES LESS THAN ('2023-04-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20230421 VALUES LESS THAN ('2023-04-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20230424 VALUES LESS THAN ('2023-04-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20230425 VALUES LESS THAN ('2023-04-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20230426 VALUES LESS THAN ('2023-04-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20230427 VALUES LESS THAN ('2023-04-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20230428 VALUES LESS THAN ('2023-05-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20230501 VALUES LESS THAN ('2023-05-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20230502 VALUES LESS THAN ('2023-05-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20230503 VALUES LESS THAN ('2023-05-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20230504 VALUES LESS THAN ('2023-05-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20230505 VALUES LESS THAN ('2023-05-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20230508 VALUES LESS THAN ('2023-05-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20230509 VALUES LESS THAN ('2023-05-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20230510 VALUES LESS THAN ('2023-05-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20230511 VALUES LESS THAN ('2023-05-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20230512 VALUES LESS THAN ('2023-05-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20230515 VALUES LESS THAN ('2023-05-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20230516 VALUES LESS THAN ('2023-05-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20230517 VALUES LESS THAN ('2023-05-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20230518 VALUES LESS THAN ('2023-05-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20230519 VALUES LESS THAN ('2023-05-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20230522 VALUES LESS THAN ('2023-05-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20230523 VALUES LESS THAN ('2023-05-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20230524 VALUES LESS THAN ('2023-05-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20230525 VALUES LESS THAN ('2023-05-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20230526 VALUES LESS THAN ('2023-05-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20230529 VALUES LESS THAN ('2023-05-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20230530 VALUES LESS THAN ('2023-05-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20230531 VALUES LESS THAN ('2023-06-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20230601 VALUES LESS THAN ('2023-06-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20230602 VALUES LESS THAN ('2023-06-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20230605 VALUES LESS THAN ('2023-06-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20230606 VALUES LESS THAN ('2023-06-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20230607 VALUES LESS THAN ('2023-06-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20230608 VALUES LESS THAN ('2023-06-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20230609 VALUES LESS THAN ('2023-06-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20230612 VALUES LESS THAN ('2023-06-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20230613 VALUES LESS THAN ('2023-06-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20230614 VALUES LESS THAN ('2023-06-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20230615 VALUES LESS THAN ('2023-06-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20230616 VALUES LESS THAN ('2023-06-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20230619 VALUES LESS THAN ('2023-06-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20230620 VALUES LESS THAN ('2023-06-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20230621 VALUES LESS THAN ('2023-06-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20230622 VALUES LESS THAN ('2023-06-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20230623 VALUES LESS THAN ('2023-06-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20230626 VALUES LESS THAN ('2023-06-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20230627 VALUES LESS THAN ('2023-06-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20230628 VALUES LESS THAN ('2023-06-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20230629 VALUES LESS THAN ('2023-06-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20230630 VALUES LESS THAN ('2023-07-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20230703 VALUES LESS THAN ('2023-07-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20230704 VALUES LESS THAN ('2023-07-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20230705 VALUES LESS THAN ('2023-07-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20230706 VALUES LESS THAN ('2023-07-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20230707 VALUES LESS THAN ('2023-07-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20230710 VALUES LESS THAN ('2023-07-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20230711 VALUES LESS THAN ('2023-07-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20230712 VALUES LESS THAN ('2023-07-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20230713 VALUES LESS THAN ('2023-07-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20230714 VALUES LESS THAN ('2023-07-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20230717 VALUES LESS THAN ('2023-07-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20230718 VALUES LESS THAN ('2023-07-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20230719 VALUES LESS THAN ('2023-07-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20230720 VALUES LESS THAN ('2023-07-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20230721 VALUES LESS THAN ('2023-07-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20230724 VALUES LESS THAN ('2023-07-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20230725 VALUES LESS THAN ('2023-07-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20230726 VALUES LESS THAN ('2023-07-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20230727 VALUES LESS THAN ('2023-07-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20230728 VALUES LESS THAN ('2023-07-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20230731 VALUES LESS THAN ('2023-08-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20230801 VALUES LESS THAN ('2023-08-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20230802 VALUES LESS THAN ('2023-08-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20230803 VALUES LESS THAN ('2023-08-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20230804 VALUES LESS THAN ('2023-08-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20230807 VALUES LESS THAN ('2023-08-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20230808 VALUES LESS THAN ('2023-08-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20230809 VALUES LESS THAN ('2023-08-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20230810 VALUES LESS THAN ('2023-08-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20230811 VALUES LESS THAN ('2023-08-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20230814 VALUES LESS THAN ('2023-08-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20230815 VALUES LESS THAN ('2023-08-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20230816 VALUES LESS THAN ('2023-08-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20230817 VALUES LESS THAN ('2023-08-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20230818 VALUES LESS THAN ('2023-08-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20230821 VALUES LESS THAN ('2023-08-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20230822 VALUES LESS THAN ('2023-08-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20230823 VALUES LESS THAN ('2023-08-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20230824 VALUES LESS THAN ('2023-08-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20230825 VALUES LESS THAN ('2023-08-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20230828 VALUES LESS THAN ('2023-08-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20230829 VALUES LESS THAN ('2023-08-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20230830 VALUES LESS THAN ('2023-08-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20230831 VALUES LESS THAN ('2023-09-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20230901 VALUES LESS THAN ('2023-09-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20230904 VALUES LESS THAN ('2023-09-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20230905 VALUES LESS THAN ('2023-09-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20230906 VALUES LESS THAN ('2023-09-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20230907 VALUES LESS THAN ('2023-09-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20230908 VALUES LESS THAN ('2023-09-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20230911 VALUES LESS THAN ('2023-09-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20230912 VALUES LESS THAN ('2023-09-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20230913 VALUES LESS THAN ('2023-09-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20230914 VALUES LESS THAN ('2023-09-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20230915 VALUES LESS THAN ('2023-09-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20230918 VALUES LESS THAN ('2023-09-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20230919 VALUES LESS THAN ('2023-09-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20230920 VALUES LESS THAN ('2023-09-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20230921 VALUES LESS THAN ('2023-09-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20230922 VALUES LESS THAN ('2023-09-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20230925 VALUES LESS THAN ('2023-09-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20230926 VALUES LESS THAN ('2023-09-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20230927 VALUES LESS THAN ('2023-09-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20230928 VALUES LESS THAN ('2023-09-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20230929 VALUES LESS THAN ('2023-10-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20231002 VALUES LESS THAN ('2023-10-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20231003 VALUES LESS THAN ('2023-10-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20231004 VALUES LESS THAN ('2023-10-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20231005 VALUES LESS THAN ('2023-10-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20231006 VALUES LESS THAN ('2023-10-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20231009 VALUES LESS THAN ('2023-10-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20231010 VALUES LESS THAN ('2023-10-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20231011 VALUES LESS THAN ('2023-10-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20231012 VALUES LESS THAN ('2023-10-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20231013 VALUES LESS THAN ('2023-10-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20231016 VALUES LESS THAN ('2023-10-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20231017 VALUES LESS THAN ('2023-10-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20231018 VALUES LESS THAN ('2023-10-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20231019 VALUES LESS THAN ('2023-10-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20231020 VALUES LESS THAN ('2023-10-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20231023 VALUES LESS THAN ('2023-10-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20231024 VALUES LESS THAN ('2023-10-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20231025 VALUES LESS THAN ('2023-10-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20231026 VALUES LESS THAN ('2023-10-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20231027 VALUES LESS THAN ('2023-10-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20231030 VALUES LESS THAN ('2023-10-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20231031 VALUES LESS THAN ('2023-11-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20231101 VALUES LESS THAN ('2023-11-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20231102 VALUES LESS THAN ('2023-11-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20231103 VALUES LESS THAN ('2023-11-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20231106 VALUES LESS THAN ('2023-11-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20231107 VALUES LESS THAN ('2023-11-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20231108 VALUES LESS THAN ('2023-11-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20231109 VALUES LESS THAN ('2023-11-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20231110 VALUES LESS THAN ('2023-11-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20231113 VALUES LESS THAN ('2023-11-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20231114 VALUES LESS THAN ('2023-11-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20231115 VALUES LESS THAN ('2023-11-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20231116 VALUES LESS THAN ('2023-11-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20231117 VALUES LESS THAN ('2023-11-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20231120 VALUES LESS THAN ('2023-11-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20231121 VALUES LESS THAN ('2023-11-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20231122 VALUES LESS THAN ('2023-11-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20231123 VALUES LESS THAN ('2023-11-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20231124 VALUES LESS THAN ('2023-11-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20231127 VALUES LESS THAN ('2023-11-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20231128 VALUES LESS THAN ('2023-11-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20231129 VALUES LESS THAN ('2023-11-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20231130 VALUES LESS THAN ('2023-12-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20231201 VALUES LESS THAN ('2023-12-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20231204 VALUES LESS THAN ('2023-12-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20231205 VALUES LESS THAN ('2023-12-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20231206 VALUES LESS THAN ('2023-12-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20231207 VALUES LESS THAN ('2023-12-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20231208 VALUES LESS THAN ('2023-12-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20231211 VALUES LESS THAN ('2023-12-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20231212 VALUES LESS THAN ('2023-12-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20231213 VALUES LESS THAN ('2023-12-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20231214 VALUES LESS THAN ('2023-12-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20231215 VALUES LESS THAN ('2023-12-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20231218 VALUES LESS THAN ('2023-12-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20231219 VALUES LESS THAN ('2023-12-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20231220 VALUES LESS THAN ('2023-12-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20231221 VALUES LESS THAN ('2023-12-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20231222 VALUES LESS THAN ('2023-12-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20231225 VALUES LESS THAN ('2023-12-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20231226 VALUES LESS THAN ('2023-12-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20231227 VALUES LESS THAN ('2023-12-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20231228 VALUES LESS THAN ('2023-12-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20231229 VALUES LESS THAN ('2024-01-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20240101 VALUES LESS THAN ('2024-01-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20240102 VALUES LESS THAN ('2024-01-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20240103 VALUES LESS THAN ('2024-01-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20240104 VALUES LESS THAN ('2024-01-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20240105 VALUES LESS THAN ('2024-01-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20240108 VALUES LESS THAN ('2024-01-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20240109 VALUES LESS THAN ('2024-01-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20240110 VALUES LESS THAN ('2024-01-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20240111 VALUES LESS THAN ('2024-01-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20240112 VALUES LESS THAN ('2024-01-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20240115 VALUES LESS THAN ('2024-01-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20240116 VALUES LESS THAN ('2024-01-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20240117 VALUES LESS THAN ('2024-01-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20240118 VALUES LESS THAN ('2024-01-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20240119 VALUES LESS THAN ('2024-01-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20240122 VALUES LESS THAN ('2024-01-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20240123 VALUES LESS THAN ('2024-01-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20240124 VALUES LESS THAN ('2024-01-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20240125 VALUES LESS THAN ('2024-01-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20240126 VALUES LESS THAN ('2024-01-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20240129 VALUES LESS THAN ('2024-01-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20240130 VALUES LESS THAN ('2024-01-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20240131 VALUES LESS THAN ('2024-02-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20240201 VALUES LESS THAN ('2024-02-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20240202 VALUES LESS THAN ('2024-02-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20240205 VALUES LESS THAN ('2024-02-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20240206 VALUES LESS THAN ('2024-02-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20240207 VALUES LESS THAN ('2024-02-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20240208 VALUES LESS THAN ('2024-02-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20240209 VALUES LESS THAN ('2024-02-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20240212 VALUES LESS THAN ('2024-02-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20240213 VALUES LESS THAN ('2024-02-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20240214 VALUES LESS THAN ('2024-02-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20240215 VALUES LESS THAN ('2024-02-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20240216 VALUES LESS THAN ('2024-02-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20240219 VALUES LESS THAN ('2024-02-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20240220 VALUES LESS THAN ('2024-02-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20240221 VALUES LESS THAN ('2024-02-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20240222 VALUES LESS THAN ('2024-02-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20240223 VALUES LESS THAN ('2024-02-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20240226 VALUES LESS THAN ('2024-02-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20240227 VALUES LESS THAN ('2024-02-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20240228 VALUES LESS THAN ('2024-02-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20240229 VALUES LESS THAN ('2024-03-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20240301 VALUES LESS THAN ('2024-03-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20240304 VALUES LESS THAN ('2024-03-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20240305 VALUES LESS THAN ('2024-03-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20240306 VALUES LESS THAN ('2024-03-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20240307 VALUES LESS THAN ('2024-03-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20240308 VALUES LESS THAN ('2024-03-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20240311 VALUES LESS THAN ('2024-03-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20240312 VALUES LESS THAN ('2024-03-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20240313 VALUES LESS THAN ('2024-03-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20240314 VALUES LESS THAN ('2024-03-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20240315 VALUES LESS THAN ('2024-03-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20240318 VALUES LESS THAN ('2024-03-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20240319 VALUES LESS THAN ('2024-03-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20240320 VALUES LESS THAN ('2024-03-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20240321 VALUES LESS THAN ('2024-03-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20240322 VALUES LESS THAN ('2024-03-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20240325 VALUES LESS THAN ('2024-03-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20240326 VALUES LESS THAN ('2024-03-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20240327 VALUES LESS THAN ('2024-03-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20240328 VALUES LESS THAN ('2024-03-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20240329 VALUES LESS THAN ('2024-04-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20240401 VALUES LESS THAN ('2024-04-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20240402 VALUES LESS THAN ('2024-04-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20240403 VALUES LESS THAN ('2024-04-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20240404 VALUES LESS THAN ('2024-04-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20240405 VALUES LESS THAN ('2024-04-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20240408 VALUES LESS THAN ('2024-04-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20240409 VALUES LESS THAN ('2024-04-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20240410 VALUES LESS THAN ('2024-04-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20240411 VALUES LESS THAN ('2024-04-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20240412 VALUES LESS THAN ('2024-04-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20240415 VALUES LESS THAN ('2024-04-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20240416 VALUES LESS THAN ('2024-04-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20240417 VALUES LESS THAN ('2024-04-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20240418 VALUES LESS THAN ('2024-04-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20240419 VALUES LESS THAN ('2024-04-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20240422 VALUES LESS THAN ('2024-04-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20240423 VALUES LESS THAN ('2024-04-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20240424 VALUES LESS THAN ('2024-04-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20240425 VALUES LESS THAN ('2024-04-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20240426 VALUES LESS THAN ('2024-04-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20240429 VALUES LESS THAN ('2024-04-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20240430 VALUES LESS THAN ('2024-05-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20240501 VALUES LESS THAN ('2024-05-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20240502 VALUES LESS THAN ('2024-05-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20240503 VALUES LESS THAN ('2024-05-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20240506 VALUES LESS THAN ('2024-05-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20240507 VALUES LESS THAN ('2024-05-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20240508 VALUES LESS THAN ('2024-05-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20240509 VALUES LESS THAN ('2024-05-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20240510 VALUES LESS THAN ('2024-05-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20240513 VALUES LESS THAN ('2024-05-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20240514 VALUES LESS THAN ('2024-05-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20240515 VALUES LESS THAN ('2024-05-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20240516 VALUES LESS THAN ('2024-05-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20240517 VALUES LESS THAN ('2024-05-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20240520 VALUES LESS THAN ('2024-05-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20240521 VALUES LESS THAN ('2024-05-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20240522 VALUES LESS THAN ('2024-05-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20240523 VALUES LESS THAN ('2024-05-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20240524 VALUES LESS THAN ('2024-05-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20240527 VALUES LESS THAN ('2024-05-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20240528 VALUES LESS THAN ('2024-05-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20240529 VALUES LESS THAN ('2024-05-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20240530 VALUES LESS THAN ('2024-05-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20240531 VALUES LESS THAN ('2024-06-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20240603 VALUES LESS THAN ('2024-06-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20240604 VALUES LESS THAN ('2024-06-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20240605 VALUES LESS THAN ('2024-06-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20240606 VALUES LESS THAN ('2024-06-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20240607 VALUES LESS THAN ('2024-06-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20240610 VALUES LESS THAN ('2024-06-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20240611 VALUES LESS THAN ('2024-06-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20240612 VALUES LESS THAN ('2024-06-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20240613 VALUES LESS THAN ('2024-06-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20240614 VALUES LESS THAN ('2024-06-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20240617 VALUES LESS THAN ('2024-06-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20240618 VALUES LESS THAN ('2024-06-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20240619 VALUES LESS THAN ('2024-06-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20240620 VALUES LESS THAN ('2024-06-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20240621 VALUES LESS THAN ('2024-06-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20240624 VALUES LESS THAN ('2024-06-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20240625 VALUES LESS THAN ('2024-06-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20240626 VALUES LESS THAN ('2024-06-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20240627 VALUES LESS THAN ('2024-06-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20240628 VALUES LESS THAN ('2024-07-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20240701 VALUES LESS THAN ('2024-07-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20240702 VALUES LESS THAN ('2024-07-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20240703 VALUES LESS THAN ('2024-07-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20240704 VALUES LESS THAN ('2024-07-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20240705 VALUES LESS THAN ('2024-07-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20240708 VALUES LESS THAN ('2024-07-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20240709 VALUES LESS THAN ('2024-07-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20240710 VALUES LESS THAN ('2024-07-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20240711 VALUES LESS THAN ('2024-07-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20240712 VALUES LESS THAN ('2024-07-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20240715 VALUES LESS THAN ('2024-07-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20240716 VALUES LESS THAN ('2024-07-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20240717 VALUES LESS THAN ('2024-07-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20240718 VALUES LESS THAN ('2024-07-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20240719 VALUES LESS THAN ('2024-07-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20240722 VALUES LESS THAN ('2024-07-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20240723 VALUES LESS THAN ('2024-07-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20240724 VALUES LESS THAN ('2024-07-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20240725 VALUES LESS THAN ('2024-07-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20240726 VALUES LESS THAN ('2024-07-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20240729 VALUES LESS THAN ('2024-07-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20240730 VALUES LESS THAN ('2024-07-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20240731 VALUES LESS THAN ('2024-08-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20240801 VALUES LESS THAN ('2024-08-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20240802 VALUES LESS THAN ('2024-08-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20240805 VALUES LESS THAN ('2024-08-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20240806 VALUES LESS THAN ('2024-08-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20240807 VALUES LESS THAN ('2024-08-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20240808 VALUES LESS THAN ('2024-08-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20240809 VALUES LESS THAN ('2024-08-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20240812 VALUES LESS THAN ('2024-08-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20240813 VALUES LESS THAN ('2024-08-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20240814 VALUES LESS THAN ('2024-08-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20240815 VALUES LESS THAN ('2024-08-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20240816 VALUES LESS THAN ('2024-08-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20240819 VALUES LESS THAN ('2024-08-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20240820 VALUES LESS THAN ('2024-08-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20240821 VALUES LESS THAN ('2024-08-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20240822 VALUES LESS THAN ('2024-08-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20240823 VALUES LESS THAN ('2024-08-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20240826 VALUES LESS THAN ('2024-08-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20240827 VALUES LESS THAN ('2024-08-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20240828 VALUES LESS THAN ('2024-08-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20240829 VALUES LESS THAN ('2024-08-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20240830 VALUES LESS THAN ('2024-09-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20240902 VALUES LESS THAN ('2024-09-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20240903 VALUES LESS THAN ('2024-09-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20240904 VALUES LESS THAN ('2024-09-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20240905 VALUES LESS THAN ('2024-09-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20240906 VALUES LESS THAN ('2024-09-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20240909 VALUES LESS THAN ('2024-09-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20240910 VALUES LESS THAN ('2024-09-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20240911 VALUES LESS THAN ('2024-09-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20240912 VALUES LESS THAN ('2024-09-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20240913 VALUES LESS THAN ('2024-09-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20240916 VALUES LESS THAN ('2024-09-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20240917 VALUES LESS THAN ('2024-09-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20240918 VALUES LESS THAN ('2024-09-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20240919 VALUES LESS THAN ('2024-09-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20240920 VALUES LESS THAN ('2024-09-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20240923 VALUES LESS THAN ('2024-09-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20240924 VALUES LESS THAN ('2024-09-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20240925 VALUES LESS THAN ('2024-09-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20240926 VALUES LESS THAN ('2024-09-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20240927 VALUES LESS THAN ('2024-09-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20240930 VALUES LESS THAN ('2024-10-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20241001 VALUES LESS THAN ('2024-10-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20241002 VALUES LESS THAN ('2024-10-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20241003 VALUES LESS THAN ('2024-10-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20241004 VALUES LESS THAN ('2024-10-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20241007 VALUES LESS THAN ('2024-10-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20241008 VALUES LESS THAN ('2024-10-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20241009 VALUES LESS THAN ('2024-10-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20241010 VALUES LESS THAN ('2024-10-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20241011 VALUES LESS THAN ('2024-10-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20241014 VALUES LESS THAN ('2024-10-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20241015 VALUES LESS THAN ('2024-10-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20241016 VALUES LESS THAN ('2024-10-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20241017 VALUES LESS THAN ('2024-10-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20241018 VALUES LESS THAN ('2024-10-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20241021 VALUES LESS THAN ('2024-10-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20241022 VALUES LESS THAN ('2024-10-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20241023 VALUES LESS THAN ('2024-10-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20241024 VALUES LESS THAN ('2024-10-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20241025 VALUES LESS THAN ('2024-10-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20241028 VALUES LESS THAN ('2024-10-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20241029 VALUES LESS THAN ('2024-10-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20241030 VALUES LESS THAN ('2024-10-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20241031 VALUES LESS THAN ('2024-11-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20241101 VALUES LESS THAN ('2024-11-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20241104 VALUES LESS THAN ('2024-11-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20241105 VALUES LESS THAN ('2024-11-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20241106 VALUES LESS THAN ('2024-11-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20241107 VALUES LESS THAN ('2024-11-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20241108 VALUES LESS THAN ('2024-11-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20241111 VALUES LESS THAN ('2024-11-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20241112 VALUES LESS THAN ('2024-11-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20241113 VALUES LESS THAN ('2024-11-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20241114 VALUES LESS THAN ('2024-11-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20241115 VALUES LESS THAN ('2024-11-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20241118 VALUES LESS THAN ('2024-11-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20241119 VALUES LESS THAN ('2024-11-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20241120 VALUES LESS THAN ('2024-11-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20241121 VALUES LESS THAN ('2024-11-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20241122 VALUES LESS THAN ('2024-11-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20241125 VALUES LESS THAN ('2024-11-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20241126 VALUES LESS THAN ('2024-11-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20241127 VALUES LESS THAN ('2024-11-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20241128 VALUES LESS THAN ('2024-11-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20241129 VALUES LESS THAN ('2024-12-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20241202 VALUES LESS THAN ('2024-12-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20241203 VALUES LESS THAN ('2024-12-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20241204 VALUES LESS THAN ('2024-12-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20241205 VALUES LESS THAN ('2024-12-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20241206 VALUES LESS THAN ('2024-12-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20241209 VALUES LESS THAN ('2024-12-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20241210 VALUES LESS THAN ('2024-12-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20241211 VALUES LESS THAN ('2024-12-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20241212 VALUES LESS THAN ('2024-12-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20241213 VALUES LESS THAN ('2024-12-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20241216 VALUES LESS THAN ('2024-12-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20241217 VALUES LESS THAN ('2024-12-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20241218 VALUES LESS THAN ('2024-12-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20241219 VALUES LESS THAN ('2024-12-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20241220 VALUES LESS THAN ('2024-12-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20241223 VALUES LESS THAN ('2024-12-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20241224 VALUES LESS THAN ('2024-12-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20241225 VALUES LESS THAN ('2024-12-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20241226 VALUES LESS THAN ('2024-12-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20241227 VALUES LESS THAN ('2024-12-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20241230 VALUES LESS THAN ('2024-12-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20241231 VALUES LESS THAN ('2025-01-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20250101 VALUES LESS THAN ('2025-01-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20250102 VALUES LESS THAN ('2025-01-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20250103 VALUES LESS THAN ('2025-01-06') ENGINE = InnoDB,\n" +
+                " PARTITION p99991231 VALUES LESS THAN (MAXVALUE) ENGINE = InnoDB) */";
+
+
+
+        StringBuffer clickHouseQuery = new StringBuffer();
+        mySQLDDLParserService.parseSql(sql2, "employees", clickHouseQuery);
+        //String expectedQuery = "CREATE TABLE employees.`clearing_position_incomplete_detail`(`clearing_position_incomplete_detail_id` UInt64 NOT NULL ,`clearing_date` Date32 NOT NULL ,`incomplete_reason_id` Int32 NOT NULL ,`incomplete_lookup_type_id` Int32 NOT NULL ,`clearing_position_id` Nullable(Int64),`ref_lookup_db_time` DateTime64(6, 0) NOT NULL ,`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) ORDER BY (`clearing_position_incomplete_detail_id`,`clearing_date`)";
+        String expectedQuery = "CREATE TABLE employees.`clearing_position_incomplete_detail`(`clearing_position_incomplete_detail_id` UInt64 NOT NULL ,`clearing_date` Date32 NOT NULL ,`incomplete_reason_id` Int32 NOT NULL ,`incomplete_lookup_type_id` Int32 NOT NULL ,`clearing_position_id` Nullable(Int64),`ref_lookup_db_time` DateTime64(6, 0) NOT NULL ,`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) PARTITION BY  clearing_date ORDER BY (`clearing_position_incomplete_detail_id`,`clearing_date`)";
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(expectedQuery));
+        //Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(expectedQuery));
+    }
+
+    @Test
+    public void testPartitionByRange() {
+        String sql = "CREATE TABLE `enriched_trade` (\n" +
+                "  `enriched_trade_id` bigint unsigned NOT NULL,\n" +
+                "  `enriched_trade_key` bigint unsigned NOT NULL,\n" +
+                "  `version_num` smallint unsigned NOT NULL DEFAULT '0',\n" +
+                "  `pos_agg_id` bigint unsigned DEFAULT NULL,\n" +
+                "  `is_complete` tinyint(1) NOT NULL,\n" +
+                "  `enriched_trade_type_id` smallint unsigned NOT NULL,\n" +
+                "  `trade_date` date NOT NULL,\n" +
+                "  `street_trade_date` date DEFAULT NULL,\n" +
+                "  `settlement_date` date DEFAULT NULL,\n" +
+                "  `direction_id` tinyint(1) NOT NULL,\n" +
+                "  `price` decimal(24,10) DEFAULT NULL,\n" +
+                "  `quantity` decimal(30,10) NOT NULL,\n" +
+                "  `sid` bigint unsigned DEFAULT NULL,\n" +
+                "  `currency_sid` bigint unsigned DEFAULT NULL,\n" +
+                "  `currency_id` smallint unsigned DEFAULT NULL,\n" +
+                "  `unit_value` decimal(30,10) DEFAULT NULL,\n" +
+                "  `exchange_lglent_id` int DEFAULT NULL,\n" +
+                "  `exec_broker_lglent_id` int DEFAULT NULL,\n" +
+                "  `branch_id` int DEFAULT NULL,\n" +
+                "  `dim_risk_strategy_id` int unsigned DEFAULT NULL,\n" +
+                "  `account_id` int DEFAULT NULL,\n" +
+                "  `parent_account_id` int DEFAULT NULL,\n" +
+                "  `child_account_id` int DEFAULT NULL,\n" +
+                "  `account_relshp_type_id` smallint unsigned DEFAULT NULL,\n" +
+                "  `valid_time` datetime(6) NOT NULL,\n" +
+                "  `db_from` datetime(6) NOT NULL,\n" +
+                "  `db_to` datetime(6) NOT NULL,\n" +
+                "  `created_by` int NOT NULL,\n" +
+                "  `capped_by` int DEFAULT NULL,\n" +
+                "  `user_id` mediumint NOT NULL,\n" +
+                "  `valid_ts` bigint unsigned DEFAULT NULL,\n" +
+                "  `kafka_ts` bigint unsigned DEFAULT NULL,\n" +
+                "  `kafka_offset` bigint DEFAULT NULL,\n" +
+                "  `kafka_partition` int unsigned DEFAULT NULL,\n" +
+                "  `inst_type_id` int NOT NULL,\n" +
+                "  `enriched_trade_attributes_1` bigint unsigned DEFAULT '0',\n" +
+                "  `is_reversal` int GENERATED ALWAYS AS (((`enriched_trade_attributes_1` & (1 << 0)) > 0)) VIRTUAL,\n" +
+                "  PRIMARY KEY (`enriched_trade_id`,`trade_date`),\n" +
+                "  UNIQUE KEY `enriched_trade_uq1` (`enriched_trade_key`,`trade_date`,`version_num`),\n" +
+                "  UNIQUE KEY `enriched_trade_uq3` (`enriched_trade_id`,`trade_date`,`db_to`),\n" +
+                "  UNIQUE KEY `enriched_trade_uq2` (`street_trade_date`,`enriched_trade_id`,`trade_date`),\n" +
+                "  KEY `enriched_trade_idx1` (`trade_date`,`valid_time`),\n" +
+                "  KEY `enriched_trade_idx2` (`trade_date`,`db_from`,`db_to`),\n" +
+                "  KEY `enriched_trade_idx3` (`db_to`,`trade_date`),\n" +
+                "  KEY `enriched_trade_idx4` (`db_from`),\n" +
+                "  KEY `enriched_trade_idx5` (`sid`,`trade_date`),\n" +
+                "  KEY `enriched_trade_idx6` (`account_id`,`trade_date`),\n" +
+                "  KEY `enriched_trade_idx7` (`exchange_lglent_id`,`trade_date`),\n" +
+                "  KEY `enriched_trade_idx8` (`enriched_trade_type_id`,`street_trade_date`),\n" +
+                "  KEY `enriched_trade_idx9` (`enriched_trade_type_id`,`trade_date`),\n" +
+                "  KEY `enriched_trade_idx10` (`created_by`,`db_from`,`street_trade_date`,`trade_date`),\n" +
+                "  KEY `enriched_trade_idx11` (`capped_by`,`db_to`,`street_trade_date`,`trade_date`),\n" +
+                "  KEY `enriched_trade_idx12` (`inst_type_id`,`trade_date`),\n" +
+                "  KEY `enriched_trade_idx13` (`kafka_partition`,`trade_date`),\n" +
+                "  KEY `idx1_test` (`inst_type_id`,`trade_date`,`account_id`)\n" +
+                ") ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs STATS_SAMPLE_PAGES=200\n" +
+                "/*!50500 PARTITION BY RANGE  COLUMNS(trade_date)\n" +
+                "(PARTITION p20211230 VALUES LESS THAN ('2021-12-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20211231 VALUES LESS THAN ('2022-01-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20221229 VALUES LESS THAN ('2022-12-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20221230 VALUES LESS THAN ('2023-01-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20230102 VALUES LESS THAN ('2023-01-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20230103 VALUES LESS THAN ('2023-01-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20230104 VALUES LESS THAN ('2023-01-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20230105 VALUES LESS THAN ('2023-01-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20230106 VALUES LESS THAN ('2023-01-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20230109 VALUES LESS THAN ('2023-01-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20230110 VALUES LESS THAN ('2023-01-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20230111 VALUES LESS THAN ('2023-01-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20230112 VALUES LESS THAN ('2023-01-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20230113 VALUES LESS THAN ('2023-01-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20230116 VALUES LESS THAN ('2023-01-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20230117 VALUES LESS THAN ('2023-01-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20230118 VALUES LESS THAN ('2023-01-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20230119 VALUES LESS THAN ('2023-01-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20230120 VALUES LESS THAN ('2023-01-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20230123 VALUES LESS THAN ('2023-01-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20230124 VALUES LESS THAN ('2023-01-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20230125 VALUES LESS THAN ('2023-01-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20230126 VALUES LESS THAN ('2023-01-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20230127 VALUES LESS THAN ('2023-01-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20230130 VALUES LESS THAN ('2023-01-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20230131 VALUES LESS THAN ('2023-02-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20230201 VALUES LESS THAN ('2023-02-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20230202 VALUES LESS THAN ('2023-02-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20230203 VALUES LESS THAN ('2023-02-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20230206 VALUES LESS THAN ('2023-02-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20230207 VALUES LESS THAN ('2023-02-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20230208 VALUES LESS THAN ('2023-02-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20230209 VALUES LESS THAN ('2023-02-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20230210 VALUES LESS THAN ('2023-02-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20230213 VALUES LESS THAN ('2023-02-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20230214 VALUES LESS THAN ('2023-02-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20230215 VALUES LESS THAN ('2023-02-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20230216 VALUES LESS THAN ('2023-02-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20230217 VALUES LESS THAN ('2023-02-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20230220 VALUES LESS THAN ('2023-02-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20230221 VALUES LESS THAN ('2023-02-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20230222 VALUES LESS THAN ('2023-02-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20230223 VALUES LESS THAN ('2023-02-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20230224 VALUES LESS THAN ('2023-02-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20230227 VALUES LESS THAN ('2023-02-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20230228 VALUES LESS THAN ('2023-03-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20230301 VALUES LESS THAN ('2023-03-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20230302 VALUES LESS THAN ('2023-03-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20230303 VALUES LESS THAN ('2023-03-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20230306 VALUES LESS THAN ('2023-03-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20230307 VALUES LESS THAN ('2023-03-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20230308 VALUES LESS THAN ('2023-03-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20230309 VALUES LESS THAN ('2023-03-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20230310 VALUES LESS THAN ('2023-03-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20230313 VALUES LESS THAN ('2023-03-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20230314 VALUES LESS THAN ('2023-03-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20230315 VALUES LESS THAN ('2023-03-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20230316 VALUES LESS THAN ('2023-03-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20230317 VALUES LESS THAN ('2023-03-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20230320 VALUES LESS THAN ('2023-03-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20230321 VALUES LESS THAN ('2023-03-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20230322 VALUES LESS THAN ('2023-03-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20230323 VALUES LESS THAN ('2023-03-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20230324 VALUES LESS THAN ('2023-03-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20230327 VALUES LESS THAN ('2023-03-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20230328 VALUES LESS THAN ('2023-03-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20230329 VALUES LESS THAN ('2023-03-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20230330 VALUES LESS THAN ('2023-03-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20230331 VALUES LESS THAN ('2023-04-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20230403 VALUES LESS THAN ('2023-04-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20230404 VALUES LESS THAN ('2023-04-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20230405 VALUES LESS THAN ('2023-04-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20230406 VALUES LESS THAN ('2023-04-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20230407 VALUES LESS THAN ('2023-04-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20230410 VALUES LESS THAN ('2023-04-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20230411 VALUES LESS THAN ('2023-04-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20230412 VALUES LESS THAN ('2023-04-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20230413 VALUES LESS THAN ('2023-04-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20230414 VALUES LESS THAN ('2023-04-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20230417 VALUES LESS THAN ('2023-04-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20230418 VALUES LESS THAN ('2023-04-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20230419 VALUES LESS THAN ('2023-04-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20230420 VALUES LESS THAN ('2023-04-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20230421 VALUES LESS THAN ('2023-04-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20230424 VALUES LESS THAN ('2023-04-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20230425 VALUES LESS THAN ('2023-04-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20230426 VALUES LESS THAN ('2023-04-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20230427 VALUES LESS THAN ('2023-04-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20230428 VALUES LESS THAN ('2023-05-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20230501 VALUES LESS THAN ('2023-05-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20230502 VALUES LESS THAN ('2023-05-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20230503 VALUES LESS THAN ('2023-05-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20230504 VALUES LESS THAN ('2023-05-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20230505 VALUES LESS THAN ('2023-05-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20230508 VALUES LESS THAN ('2023-05-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20230509 VALUES LESS THAN ('2023-05-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20230510 VALUES LESS THAN ('2023-05-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20230511 VALUES LESS THAN ('2023-05-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20230512 VALUES LESS THAN ('2023-05-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20230515 VALUES LESS THAN ('2023-05-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20230516 VALUES LESS THAN ('2023-05-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20230517 VALUES LESS THAN ('2023-05-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20230518 VALUES LESS THAN ('2023-05-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20230519 VALUES LESS THAN ('2023-05-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20230522 VALUES LESS THAN ('2023-05-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20230523 VALUES LESS THAN ('2023-05-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20230524 VALUES LESS THAN ('2023-05-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20230525 VALUES LESS THAN ('2023-05-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20230526 VALUES LESS THAN ('2023-05-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20230529 VALUES LESS THAN ('2023-05-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20230530 VALUES LESS THAN ('2023-05-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20230531 VALUES LESS THAN ('2023-06-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20230601 VALUES LESS THAN ('2023-06-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20230602 VALUES LESS THAN ('2023-06-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20230605 VALUES LESS THAN ('2023-06-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20230606 VALUES LESS THAN ('2023-06-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20230607 VALUES LESS THAN ('2023-06-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20230608 VALUES LESS THAN ('2023-06-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20230609 VALUES LESS THAN ('2023-06-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20230612 VALUES LESS THAN ('2023-06-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20230613 VALUES LESS THAN ('2023-06-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20230614 VALUES LESS THAN ('2023-06-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20230615 VALUES LESS THAN ('2023-06-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20230616 VALUES LESS THAN ('2023-06-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20230619 VALUES LESS THAN ('2023-06-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20230620 VALUES LESS THAN ('2023-06-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20230621 VALUES LESS THAN ('2023-06-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20230622 VALUES LESS THAN ('2023-06-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20230623 VALUES LESS THAN ('2023-06-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20230626 VALUES LESS THAN ('2023-06-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20230627 VALUES LESS THAN ('2023-06-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20230628 VALUES LESS THAN ('2023-06-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20230629 VALUES LESS THAN ('2023-06-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20230630 VALUES LESS THAN ('2023-07-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20230703 VALUES LESS THAN ('2023-07-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20230704 VALUES LESS THAN ('2023-07-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20230705 VALUES LESS THAN ('2023-07-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20230706 VALUES LESS THAN ('2023-07-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20230707 VALUES LESS THAN ('2023-07-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20230710 VALUES LESS THAN ('2023-07-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20230711 VALUES LESS THAN ('2023-07-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20230712 VALUES LESS THAN ('2023-07-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20230713 VALUES LESS THAN ('2023-07-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20230714 VALUES LESS THAN ('2023-07-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20230717 VALUES LESS THAN ('2023-07-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20230718 VALUES LESS THAN ('2023-07-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20230719 VALUES LESS THAN ('2023-07-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20230720 VALUES LESS THAN ('2023-07-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20230721 VALUES LESS THAN ('2023-07-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20230724 VALUES LESS THAN ('2023-07-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20230725 VALUES LESS THAN ('2023-07-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20230726 VALUES LESS THAN ('2023-07-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20230727 VALUES LESS THAN ('2023-07-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20230728 VALUES LESS THAN ('2023-07-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20230731 VALUES LESS THAN ('2023-08-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20230801 VALUES LESS THAN ('2023-08-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20230802 VALUES LESS THAN ('2023-08-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20230803 VALUES LESS THAN ('2023-08-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20230804 VALUES LESS THAN ('2023-08-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20230807 VALUES LESS THAN ('2023-08-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20230808 VALUES LESS THAN ('2023-08-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20230809 VALUES LESS THAN ('2023-08-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20230810 VALUES LESS THAN ('2023-08-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20230811 VALUES LESS THAN ('2023-08-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20230814 VALUES LESS THAN ('2023-08-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20230815 VALUES LESS THAN ('2023-08-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20230816 VALUES LESS THAN ('2023-08-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20230817 VALUES LESS THAN ('2023-08-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20230818 VALUES LESS THAN ('2023-08-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20230821 VALUES LESS THAN ('2023-08-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20230822 VALUES LESS THAN ('2023-08-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20230823 VALUES LESS THAN ('2023-08-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20230824 VALUES LESS THAN ('2023-08-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20230825 VALUES LESS THAN ('2023-08-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20230828 VALUES LESS THAN ('2023-08-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20230829 VALUES LESS THAN ('2023-08-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20230830 VALUES LESS THAN ('2023-08-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20230831 VALUES LESS THAN ('2023-09-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20230901 VALUES LESS THAN ('2023-09-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20230904 VALUES LESS THAN ('2023-09-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20230905 VALUES LESS THAN ('2023-09-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20230906 VALUES LESS THAN ('2023-09-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20230907 VALUES LESS THAN ('2023-09-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20230908 VALUES LESS THAN ('2023-09-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20230911 VALUES LESS THAN ('2023-09-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20230912 VALUES LESS THAN ('2023-09-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20230913 VALUES LESS THAN ('2023-09-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20230914 VALUES LESS THAN ('2023-09-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20230915 VALUES LESS THAN ('2023-09-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20230918 VALUES LESS THAN ('2023-09-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20230919 VALUES LESS THAN ('2023-09-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20230920 VALUES LESS THAN ('2023-09-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20230921 VALUES LESS THAN ('2023-09-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20230922 VALUES LESS THAN ('2023-09-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20230925 VALUES LESS THAN ('2023-09-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20230926 VALUES LESS THAN ('2023-09-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20230927 VALUES LESS THAN ('2023-09-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20230928 VALUES LESS THAN ('2023-09-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20230929 VALUES LESS THAN ('2023-10-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20231002 VALUES LESS THAN ('2023-10-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20231003 VALUES LESS THAN ('2023-10-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20231004 VALUES LESS THAN ('2023-10-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20231005 VALUES LESS THAN ('2023-10-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20231006 VALUES LESS THAN ('2023-10-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20231009 VALUES LESS THAN ('2023-10-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20231010 VALUES LESS THAN ('2023-10-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20231011 VALUES LESS THAN ('2023-10-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20231012 VALUES LESS THAN ('2023-10-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20231013 VALUES LESS THAN ('2023-10-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20231016 VALUES LESS THAN ('2023-10-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20231017 VALUES LESS THAN ('2023-10-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20231018 VALUES LESS THAN ('2023-10-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20231019 VALUES LESS THAN ('2023-10-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20231020 VALUES LESS THAN ('2023-10-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20231023 VALUES LESS THAN ('2023-10-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20231024 VALUES LESS THAN ('2023-10-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20231025 VALUES LESS THAN ('2023-10-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20231026 VALUES LESS THAN ('2023-10-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20231027 VALUES LESS THAN ('2023-10-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20231030 VALUES LESS THAN ('2023-10-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20231031 VALUES LESS THAN ('2023-11-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20231101 VALUES LESS THAN ('2023-11-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20231102 VALUES LESS THAN ('2023-11-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20231103 VALUES LESS THAN ('2023-11-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20231106 VALUES LESS THAN ('2023-11-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20231107 VALUES LESS THAN ('2023-11-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20231108 VALUES LESS THAN ('2023-11-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20231109 VALUES LESS THAN ('2023-11-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20231110 VALUES LESS THAN ('2023-11-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20231113 VALUES LESS THAN ('2023-11-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20231114 VALUES LESS THAN ('2023-11-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20231115 VALUES LESS THAN ('2023-11-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20231116 VALUES LESS THAN ('2023-11-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20231117 VALUES LESS THAN ('2023-11-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20231120 VALUES LESS THAN ('2023-11-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20231121 VALUES LESS THAN ('2023-11-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20231122 VALUES LESS THAN ('2023-11-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20231123 VALUES LESS THAN ('2023-11-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20231124 VALUES LESS THAN ('2023-11-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20231127 VALUES LESS THAN ('2023-11-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20231128 VALUES LESS THAN ('2023-11-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20231129 VALUES LESS THAN ('2023-11-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20231130 VALUES LESS THAN ('2023-12-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20231201 VALUES LESS THAN ('2023-12-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20231204 VALUES LESS THAN ('2023-12-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20231205 VALUES LESS THAN ('2023-12-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20231206 VALUES LESS THAN ('2023-12-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20231207 VALUES LESS THAN ('2023-12-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20231208 VALUES LESS THAN ('2023-12-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20231211 VALUES LESS THAN ('2023-12-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20231212 VALUES LESS THAN ('2023-12-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20231213 VALUES LESS THAN ('2023-12-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20231214 VALUES LESS THAN ('2023-12-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20231215 VALUES LESS THAN ('2023-12-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20231218 VALUES LESS THAN ('2023-12-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20231219 VALUES LESS THAN ('2023-12-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20231220 VALUES LESS THAN ('2023-12-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20231221 VALUES LESS THAN ('2023-12-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20231222 VALUES LESS THAN ('2023-12-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20231225 VALUES LESS THAN ('2023-12-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20231226 VALUES LESS THAN ('2023-12-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20231227 VALUES LESS THAN ('2023-12-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20231228 VALUES LESS THAN ('2023-12-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20231229 VALUES LESS THAN ('2024-01-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20240101 VALUES LESS THAN ('2024-01-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20240102 VALUES LESS THAN ('2024-01-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20240103 VALUES LESS THAN ('2024-01-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20240104 VALUES LESS THAN ('2024-01-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20240105 VALUES LESS THAN ('2024-01-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20240108 VALUES LESS THAN ('2024-01-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20240109 VALUES LESS THAN ('2024-01-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20240110 VALUES LESS THAN ('2024-01-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20240111 VALUES LESS THAN ('2024-01-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20240112 VALUES LESS THAN ('2024-01-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20240115 VALUES LESS THAN ('2024-01-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20240116 VALUES LESS THAN ('2024-01-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20240117 VALUES LESS THAN ('2024-01-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20240118 VALUES LESS THAN ('2024-01-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20240119 VALUES LESS THAN ('2024-01-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20240122 VALUES LESS THAN ('2024-01-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20240123 VALUES LESS THAN ('2024-01-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20240124 VALUES LESS THAN ('2024-01-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20240125 VALUES LESS THAN ('2024-01-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20240126 VALUES LESS THAN ('2024-01-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20240129 VALUES LESS THAN ('2024-01-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20240130 VALUES LESS THAN ('2024-01-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20240131 VALUES LESS THAN ('2024-02-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20240201 VALUES LESS THAN ('2024-02-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20240202 VALUES LESS THAN ('2024-02-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20240205 VALUES LESS THAN ('2024-02-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20240206 VALUES LESS THAN ('2024-02-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20240207 VALUES LESS THAN ('2024-02-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20240208 VALUES LESS THAN ('2024-02-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20240209 VALUES LESS THAN ('2024-02-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20240212 VALUES LESS THAN ('2024-02-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20240213 VALUES LESS THAN ('2024-02-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20240214 VALUES LESS THAN ('2024-02-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20240215 VALUES LESS THAN ('2024-02-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20240216 VALUES LESS THAN ('2024-02-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20240219 VALUES LESS THAN ('2024-02-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20240220 VALUES LESS THAN ('2024-02-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20240221 VALUES LESS THAN ('2024-02-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20240222 VALUES LESS THAN ('2024-02-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20240223 VALUES LESS THAN ('2024-02-26') ENGINE = InnoDB,\n" +
+                " PAR0TITION p20240226 VALUES LESS THAN ('2024-02-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20240227 VALUES LESS THAN ('2024-02-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20240228 VALUES LESS THAN ('2024-02-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20240229 VALUES LESS THAN ('2024-03-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20240301 VALUES LESS THAN ('2024-03-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20240304 VALUES LESS THAN ('2024-03-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20240305 VALUES LESS THAN ('2024-03-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20240306 VALUES LESS THAN ('2024-03-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20240307 VALUES LESS THAN ('2024-03-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20240308 VALUES LESS THAN ('2024-03-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20240311 VALUES LESS THAN ('2024-03-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20240312 VALUES LESS THAN ('2024-03-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20240313 VALUES LESS THAN ('2024-03-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20240314 VALUES LESS THAN ('2024-03-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20240315 VALUES LESS THAN ('2024-03-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20240318 VALUES LESS THAN ('2024-03-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20240319 VALUES LESS THAN ('2024-03-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20240320 VALUES LESS THAN ('2024-03-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20240321 VALUES LESS THAN ('2024-03-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20240322 VALUES LESS THAN ('2024-03-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20240325 VALUES LESS THAN ('2024-03-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20240326 VALUES LESS THAN ('2024-03-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20240327 VALUES LESS THAN ('2024-03-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20240328 VALUES LESS THAN ('2024-03-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20240329 VALUES LESS THAN ('2024-04-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20240401 VALUES LESS THAN ('2024-04-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20240402 VALUES LESS THAN ('2024-04-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20240403 VALUES LESS THAN ('2024-04-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20240404 VALUES LESS THAN ('2024-04-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20240405 VALUES LESS THAN ('2024-04-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20240408 VALUES LESS THAN ('2024-04-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20240409 VALUES LESS THAN ('2024-04-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20240410 VALUES LESS THAN ('2024-04-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20240411 VALUES LESS THAN ('2024-04-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20240412 VALUES LESS THAN ('2024-04-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20240415 VALUES LESS THAN ('2024-04-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20240416 VALUES LESS THAN ('2024-04-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20240417 VALUES LESS THAN ('2024-04-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20240418 VALUES LESS THAN ('2024-04-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20240419 VALUES LESS THAN ('2024-04-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20240422 VALUES LESS THAN ('2024-04-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20240423 VALUES LESS THAN ('2024-04-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20240424 VALUES LESS THAN ('2024-04-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20240425 VALUES LESS THAN ('2024-04-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20240426 VALUES LESS THAN ('2024-04-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20240429 VALUES LESS THAN ('2024-04-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20240430 VALUES LESS THAN ('2024-05-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20240501 VALUES LESS THAN ('2024-05-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20240502 VALUES LESS THAN ('2024-05-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20240503 VALUES LESS THAN ('2024-05-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20240506 VALUES LESS THAN ('2024-05-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20240507 VALUES LESS THAN ('2024-05-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20240508 VALUES LESS THAN ('2024-05-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20240509 VALUES LESS THAN ('2024-05-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20240510 VALUES LESS THAN ('2024-05-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20240513 VALUES LESS THAN ('2024-05-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20240514 VALUES LESS THAN ('2024-05-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20240515 VALUES LESS THAN ('2024-05-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20240516 VALUES LESS THAN ('2024-05-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20240517 VALUES LESS THAN ('2024-05-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20240520 VALUES LESS THAN ('2024-05-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20240521 VALUES LESS THAN ('2024-05-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20240522 VALUES LESS THAN ('2024-05-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20240523 VALUES LESS THAN ('2024-05-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20240524 VALUES LESS THAN ('2024-05-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20240527 VALUES LESS THAN ('2024-05-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20240528 VALUES LESS THAN ('2024-05-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20240529 VALUES LESS THAN ('2024-05-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20240530 VALUES LESS THAN ('2024-05-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20240531 VALUES LESS THAN ('2024-06-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20240603 VALUES LESS THAN ('2024-06-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20240604 VALUES LESS THAN ('2024-06-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20240605 VALUES LESS THAN ('2024-06-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20240606 VALUES LESS THAN ('2024-06-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20240607 VALUES LESS THAN ('2024-06-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20240610 VALUES LESS THAN ('2024-06-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20240611 VALUES LESS THAN ('2024-06-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20240612 VALUES LESS THAN ('2024-06-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20240613 VALUES LESS THAN ('2024-06-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20240614 VALUES LESS THAN ('2024-06-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20240617 VALUES LESS THAN ('2024-06-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20240618 VALUES LESS THAN ('2024-06-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20240619 VALUES LESS THAN ('2024-06-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20240620 VALUES LESS THAN ('2024-06-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20240621 VALUES LESS THAN ('2024-06-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20240624 VALUES LESS THAN ('2024-06-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20240625 VALUES LESS THAN ('2024-06-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20240626 VALUES LESS THAN ('2024-06-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20240627 VALUES LESS THAN ('2024-06-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20240628 VALUES LESS THAN ('2024-07-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20240701 VALUES LESS THAN ('2024-07-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20240702 VALUES LESS THAN ('2024-07-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20240703 VALUES LESS THAN ('2024-07-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20240704 VALUES LESS THAN ('2024-07-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20240705 VALUES LESS THAN ('2024-07-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20240708 VALUES LESS THAN ('2024-07-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20240709 VALUES LESS THAN ('2024-07-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20240710 VALUES LESS THAN ('2024-07-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20240711 VALUES LESS THAN ('2024-07-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20240712 VALUES LESS THAN ('2024-07-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20240715 VALUES LESS THAN ('2024-07-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20240716 VALUES LESS THAN ('2024-07-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20240717 VALUES LESS THAN ('2024-07-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20240718 VALUES LESS THAN ('2024-07-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20240719 VALUES LESS THAN ('2024-07-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20240722 VALUES LESS THAN ('2024-07-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20240723 VALUES LESS THAN ('2024-07-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20240724 VALUES LESS THAN ('2024-07-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20240725 VALUES LESS THAN ('2024-07-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20240726 VALUES LESS THAN ('2024-07-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20240729 VALUES LESS THAN ('2024-07-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20240730 VALUES LESS THAN ('2024-07-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20240731 VALUES LESS THAN ('2024-08-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20240801 VALUES LESS THAN ('2024-08-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20240802 VALUES LESS THAN ('2024-08-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20240805 VALUES LESS THAN ('2024-08-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20240806 VALUES LESS THAN ('2024-08-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20240807 VALUES LESS THAN ('2024-08-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20240808 VALUES LESS THAN ('2024-08-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20240809 VALUES LESS THAN ('2024-08-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20240812 VALUES LESS THAN ('2024-08-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20240813 VALUES LESS THAN ('2024-08-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20240814 VALUES LESS THAN ('2024-08-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20240815 VALUES LESS THAN ('2024-08-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20240816 VALUES LESS THAN ('2024-08-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20240819 VALUES LESS THAN ('2024-08-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20240820 VALUES LESS THAN ('2024-08-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20240821 VALUES LESS THAN ('2024-08-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20240822 VALUES LESS THAN ('2024-08-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20240823 VALUES LESS THAN ('2024-08-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20240826 VALUES LESS THAN ('2024-08-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20240827 VALUES LESS THAN ('2024-08-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20240828 VALUES LESS THAN ('2024-08-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20240829 VALUES LESS THAN ('2024-08-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20240830 VALUES LESS THAN ('2024-09-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20240902 VALUES LESS THAN ('2024-09-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20240903 VALUES LESS THAN ('2024-09-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20240904 VALUES LESS THAN ('2024-09-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20240905 VALUES LESS THAN ('2024-09-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20240906 VALUES LESS THAN ('2024-09-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20240909 VALUES LESS THAN ('2024-09-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20240910 VALUES LESS THAN ('2024-09-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20240911 VALUES LESS THAN ('2024-09-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20240912 VALUES LESS THAN ('2024-09-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20240913 VALUES LESS THAN ('2024-09-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20240916 VALUES LESS THAN ('2024-09-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20240917 VALUES LESS THAN ('2024-09-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20240918 VALUES LESS THAN ('2024-09-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20240919 VALUES LESS THAN ('2024-09-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20240920 VALUES LESS THAN ('2024-09-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20240923 VALUES LESS THAN ('2024-09-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20240924 VALUES LESS THAN ('2024-09-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20240925 VALUES LESS THAN ('2024-09-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20240926 VALUES LESS THAN ('2024-09-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20240927 VALUES LESS THAN ('2024-09-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20240930 VALUES LESS THAN ('2024-10-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20241001 VALUES LESS THAN ('2024-10-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20241002 VALUES LESS THAN ('2024-10-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20241003 VALUES LESS THAN ('2024-10-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20241004 VALUES LESS THAN ('2024-10-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20241007 VALUES LESS THAN ('2024-10-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20241008 VALUES LESS THAN ('2024-10-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20241009 VALUES LESS THAN ('2024-10-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20241010 VALUES LESS THAN ('2024-10-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20241011 VALUES LESS THAN ('2024-10-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20241014 VALUES LESS THAN ('2024-10-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20241015 VALUES LESS THAN ('2024-10-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20241016 VALUES LESS THAN ('2024-10-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20241017 VALUES LESS THAN ('2024-10-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20241018 VALUES LESS THAN ('2024-10-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20241021 VALUES LESS THAN ('2024-10-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20241022 VALUES LESS THAN ('2024-10-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20241023 VALUES LESS THAN ('2024-10-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20241024 VALUES LESS THAN ('2024-10-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20241025 VALUES LESS THAN ('2024-10-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20241028 VALUES LESS THAN ('2024-10-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20241029 VALUES LESS THAN ('2024-10-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20241030 VALUES LESS THAN ('2024-10-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20241031 VALUES LESS THAN ('2024-11-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20241101 VALUES LESS THAN ('2024-11-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20241104 VALUES LESS THAN ('2024-11-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20241105 VALUES LESS THAN ('2024-11-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20241106 VALUES LESS THAN ('2024-11-07') ENGINE = InnoDB,\n" +
+                " PARTITION p20241107 VALUES LESS THAN ('2024-11-08') ENGINE = InnoDB,\n" +
+                " PARTITION p20241108 VALUES LESS THAN ('2024-11-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20241111 VALUES LESS THAN ('2024-11-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20241112 VALUES LESS THAN ('2024-11-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20241113 VALUES LESS THAN ('2024-11-14') ENGINE = InnoDB,\n" +
+                " PARTITION p20241114 VALUES LESS THAN ('2024-11-15') ENGINE = InnoDB,\n" +
+                " PARTITION p20241115 VALUES LESS THAN ('2024-11-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20241118 VALUES LESS THAN ('2024-11-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20241119 VALUES LESS THAN ('2024-11-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20241120 VALUES LESS THAN ('2024-11-21') ENGINE = InnoDB,\n" +
+                " PARTITION p20241121 VALUES LESS THAN ('2024-11-22') ENGINE = InnoDB,\n" +
+                " PARTITION p20241122 VALUES LESS THAN ('2024-11-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20241125 VALUES LESS THAN ('2024-11-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20241126 VALUES LESS THAN ('2024-11-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20241127 VALUES LESS THAN ('2024-11-28') ENGINE = InnoDB,\n" +
+                " PARTITION p20241128 VALUES LESS THAN ('2024-11-29') ENGINE = InnoDB,\n" +
+                " PARTITION p20241129 VALUES LESS THAN ('2024-12-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20241202 VALUES LESS THAN ('2024-12-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20241203 VALUES LESS THAN ('2024-12-04') ENGINE = InnoDB,\n" +
+                " PARTITION p20241204 VALUES LESS THAN ('2024-12-05') ENGINE = InnoDB,\n" +
+                " PARTITION p20241205 VALUES LESS THAN ('2024-12-06') ENGINE = InnoDB,\n" +
+                " PARTITION p20241206 VALUES LESS THAN ('2024-12-09') ENGINE = InnoDB,\n" +
+                " PARTITION p20241209 VALUES LESS THAN ('2024-12-10') ENGINE = InnoDB,\n" +
+                " PARTITION p20241210 VALUES LESS THAN ('2024-12-11') ENGINE = InnoDB,\n" +
+                " PARTITION p20241211 VALUES LESS THAN ('2024-12-12') ENGINE = InnoDB,\n" +
+                " PARTITION p20241212 VALUES LESS THAN ('2024-12-13') ENGINE = InnoDB,\n" +
+                " PARTITION p20241213 VALUES LESS THAN ('2024-12-16') ENGINE = InnoDB,\n" +
+                " PARTITION p20241216 VALUES LESS THAN ('2024-12-17') ENGINE = InnoDB,\n" +
+                " PARTITION p20241217 VALUES LESS THAN ('2024-12-18') ENGINE = InnoDB,\n" +
+                " PARTITION p20241218 VALUES LESS THAN ('2024-12-19') ENGINE = InnoDB,\n" +
+                " PARTITION p20241219 VALUES LESS THAN ('2024-12-20') ENGINE = InnoDB,\n" +
+                " PARTITION p20241220 VALUES LESS THAN ('2024-12-23') ENGINE = InnoDB,\n" +
+                " PARTITION p20241223 VALUES LESS THAN ('2024-12-24') ENGINE = InnoDB,\n" +
+                " PARTITION p20241224 VALUES LESS THAN ('2024-12-25') ENGINE = InnoDB,\n" +
+                " PARTITION p20241225 VALUES LESS THAN ('2024-12-26') ENGINE = InnoDB,\n" +
+                " PARTITION p20241226 VALUES LESS THAN ('2024-12-27') ENGINE = InnoDB,\n" +
+                " PARTITION p20241227 VALUES LESS THAN ('2024-12-30') ENGINE = InnoDB,\n" +
+                " PARTITION p20241230 VALUES LESS THAN ('2024-12-31') ENGINE = InnoDB,\n" +
+                " PARTITION p20241231 VALUES LESS THAN ('2025-01-01') ENGINE = InnoDB,\n" +
+                " PARTITION p20250101 VALUES LESS THAN ('2025-01-02') ENGINE = InnoDB,\n" +
+                " PARTITION p20250102 VALUES LESS THAN ('2025-01-03') ENGINE = InnoDB,\n" +
+                " PARTITION p20250103 VALUES LESS THAN ('2025-01-06') ENGINE = InnoDB,\n" +
+                " PARTITION p99991231 VALUES LESS THAN (MAXVALUE) ENGINE = InnoDB) */";
+
+        StringBuffer clickHouseQuery = new StringBuffer();
+        mySQLDDLParserService.parseSql(sql, "employees", clickHouseQuery);
+
+        String expectedQuery = "CREATE TABLE employees.`enriched_trade`(`enriched_trade_id` UInt64 NOT NULL ,`enriched_trade_key` UInt64 NOT NULL ,`version_num` Int32 NOT NULL ,`pos_agg_id` Nullable(UInt64),`is_complete` Int8 NOT NULL ,`enriched_trade_type_id` Int32 NOT NULL ,`trade_date` Date32 NOT NULL ,`street_trade_date` Nullable(Date32),`settlement_date` Nullable(Date32),`direction_id` Int8 NOT NULL ,`price` Nullable(Decimal(24,10)),`quantity` Decimal(30,10) NOT NULL ,`sid` Nullable(UInt64),`currency_sid` Nullable(UInt64),`currency_id` Nullable(Int32),`unit_value` Nullable(Decimal(30,10)),`exchange_lglent_id` Nullable(Int32),`exec_broker_lglent_id` Nullable(Int32),`branch_id` Nullable(Int32),`dim_risk_strategy_id` Nullable(Int64),`account_id` Nullable(Int32),`parent_account_id` Nullable(Int32),`child_account_id` Nullable(Int32),`account_relshp_type_id` Nullable(Int32),`valid_time` DateTime64(6, 0) NOT NULL ,`db_from` DateTime64(6, 0) NOT NULL ,`db_to` DateTime64(6, 0) NOT NULL ,`created_by` Int32 NOT NULL ,`capped_by` Nullable(Int32),`user_id` Int32 NOT NULL ,`valid_ts` Nullable(UInt64),`kafka_ts` Nullable(UInt64),`kafka_offset` Nullable(Int64),`kafka_partition` Nullable(Int64),`inst_type_id` Int32 NOT NULL ,`enriched_trade_attributes_1` Nullable(UInt64),`is_reversal` Nullable(Int32) MATERIALIZED ((`enriched_trade_attributes_1`&(1<<0))>0),`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) PARTITION BY  trade_date ORDER BY (`enriched_trade_id`,`trade_date`)";
+        //String expectedQuery = "CREATE TABLE employees.`enriched_trade`(`enriched_trade_id` UInt64 NOT NULL ,`enriched_trade_key` UInt64 NOT NULL ,`version_num` Int32 NOT NULL ,`pos_agg_id` Nullable(UInt64),`is_complete` Int8 NOT NULL ,`enriched_trade_type_id` Int32 NOT NULL ,`trade_date` Date32 NOT NULL ,`street_trade_date` Nullable(Date32),`settlement_date` Nullable(Date32),`direction_id` Int8 NOT NULL ,`price` Nullable(Decimal(24,10)),`quantity` Decimal(30,10) NOT NULL ,`sid` Nullable(UInt64),`currency_sid` Nullable(UInt64),`currency_id` Nullable(Int32),`unit_value` Nullable(Decimal(30,10)),`exchange_lglent_id` Nullable(Int32),`exec_broker_lglent_id` Nullable(Int32),`branch_id` Nullable(Int32),`dim_risk_strategy_id` Nullable(Int64),`account_id` Nullable(Int32),`parent_account_id` Nullable(Int32),`child_account_id` Nullable(Int32),`account_relshp_type_id` Nullable(Int32),`valid_time` DateTime64(6, 0) NOT NULL ,`db_from` DateTime64(6, 0) NOT NULL ,`db_to` DateTime64(6, 0) NOT NULL ,`created_by` Int32 NOT NULL ,`capped_by` Nullable(Int32),`user_id` Int32 NOT NULL ,`valid_ts` Nullable(UInt64),`kafka_ts` Nullable(UInt64),`kafka_offset` Nullable(Int64),`kafka_partition` Nullable(Int64),`inst_type_id` Int32 NOT NULL ,`enriched_trade_attributes_1` Nullable(UInt64),`is_reversal` Nullable(Int32) MATERIALIZED ((`enriched_trade_attributes_1`&(1<<0))>0),`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) ORDER BY (`enriched_trade_id`,`trade_date`)";
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(expectedQuery));
+    }
+
+    @Test
+    public void isNotNullCreateTable() {
+        String sql = " CREATE TABLE orders2(order_id INT PRIMARY KEY,     item_price DECIMAL(10, 2) NOT NULL, \n" +
+                "    quantity INT NOT NULL, total_price DECIMAL(12, 2) \n" +
+                "GENERATED ALWAYS AS (item_price * quantity is not null) STORED NOT NULL );\n";
+
+        StringBuffer clickHouseQuery = new StringBuffer();
+        mySQLDDLParserService.parseSql(sql, "employees", clickHouseQuery);
+
+        String expectedQuery = "CREATE TABLE employees.orders2(order_id Int32 NOT NULL ,item_price Decimal(10,2) NOT NULL ,quantity Int32 NOT NULL ,total_price Decimal(12,2) MATERIALIZED item_price*quantity,`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) ORDER BY order_id";
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(expectedQuery));
+
+    }
+    @Test
+    @Disabled
+    public void testPartitionedByRangeTable() {
+        String sql = "CREATE TABLE `city` (\n" +
+                "  `ID` int NOT NULL AUTO_INCREMENT,\n" +
+                "  `Name` char(35) COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',\n" +
+                "  `CountryCode` char(3) COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',\n" +
+                "  `District` char(20) COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',\n" +
+                "  `Population` int NOT NULL DEFAULT '0',\n" +
+                "  `is_deleted` tinyint(1) DEFAULT '0',\n" +
+                "  PRIMARY KEY (`ID`)\n" +
+                ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci PARTITION BY RANGE(`ID`)\n" +
+                "(PARTITION p0 VALUES LESS THAN (1000),\n" +
+                " PARTITION p1 VALUES LESS THAN (2000),\n" +
+                " PARTITION p2 VALUES LESS THAN (3000),\n" +
+                " PARTITION p3 VALUES LESS THAN (4000),\n" +
+                " PARTITION p4 VALUES LESS THAN (5000),\n" +
+                " PARTITION p5 VALUES LESS THAN (6000),\n" +
+                " PARTITION p6 VALUES LESS THAN (7000),\n" +
+                " PARTITION p7 VALUES LESS THAN (8000),\n" +
+                " PARTITION p8 VALUES LESS THAN (9000),\n" +
+                " PARTITION p9 VALUES LESS THAN (10000));";
+
+        StringBuffer clickHouseQuery = new StringBuffer();
+        mySQLDDLParserService.parseSql(sql, "employees", clickHouseQuery);
+
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(
+                "CREATE TABLE employees.`city`(`ID` Int32 NOT NULL ,`Name` String NOT NULL ,`CountryCode` String NOT NULL ,`District` String NOT NULL ,`Population` Int32 NOT NULL ,`is_deleted` Nullable(Int16),`_version` UInt64,`__is_deleted` UInt8) Engine=ReplacingMergeTree(_version,__is_deleted) ORDER BY (`ID`) PARTITION BY ID"));
+    }
+
+    @Test
+    public void testReplicationHistoryEnabledDDLTranslation() {
+        // Set up the configuration to enable replication history
+
+        HashMap<String, String> config = new HashMap<>();
+        config.put(ClickHouseSinkConnectorConfigVariables.REPLICATION_HISTORY_ENABLE.toString(), "true");
+        config.put(ClickHouseSinkConnectorConfigVariables.CLICKHOUSE_DATETIME_TIMEZONE.toString(), "America/Chicago");
+        
+        ClickHouseSinkConnectorConfig sinkConnectorConfig = new ClickHouseSinkConnectorConfig(config);
+        MySQLDDLParserService parserService = new MySQLDDLParserService(new ClickHouseSinkConnectorConfig(config),
+                "employees");
+        String sql = "CREATE TABLE `test_table` (\n" +
+                "  `id` INT PRIMARY KEY,\n" +
+                "  `name` VARCHAR(255) NOT NULL,\n" +
+                "  `created_at` DATETIME NOT NULL\n" +
+                ") ENGINE=InnoDB;";
+
+        StringBuffer clickHouseQuery = new StringBuffer();
+        parserService.parseSql(sql, "test_db", clickHouseQuery);
+
+        String expectedQuery = "CREATE TABLE employees.`test_table`(`id` Int32 NOT NULL ,`name` String NOT NULL ,`created_at` DateTime64(0,'America/Chicago') NOT NULL ,`_valid_from` DateTime('America/Chicago') DEFAULT '2100-01-01 00:00:00',`_valid_to` DateTime('America/Chicago') DEFAULT '2100-01-01 00:00:00',`_operation` LowCardinality(String),`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) PARTITION BY toDate(`_valid_to`) ORDER BY (`id`,`_valid_to`) TTL `_valid_to` + toIntervalDay(30)";
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(expectedQuery));
+    }
+
+    @Test
+    public void testAlterTableAddConstraint() {
+        String sql = "alter table employees drop CONSTRAINT employees_ibfk_2";
+        StringBuffer clickHouseQuery = new StringBuffer();
+        mySQLDDLParserService.parseSql(sql, "employees", clickHouseQuery);
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE employees.employees DROP CONSTRAINT IF EXISTS employees_ibfk_2"));
+    }
+
+    @Test
+    @DisplayName("Test that internal DDL ignore list correctly identifies partition operations")
+    public void testInternalDDLIgnoreList() {
+        // Map of DDL statements to whether they should be ignored (true) or allowed (false)
+        Map<String, Boolean> ddlTestCases = new HashMap<>();
+        
+        // Partition operations that SHOULD be ignored
+        ddlTestCases.put("ALTER TABLE employees.sales ANALYZE PARTITION p2023", true);
+        ddlTestCases.put("ALTER TABLE employees.sales ADD PARTITION (p2024)", true);
+        ddlTestCases.put("ALTER TABLE employees.sales DROP PARTITION p2022", true);
+        ddlTestCases.put("ALTER TABLE employees.sales REORGANIZE PARTITION p2023 INTO (p2023q1, p2023q2)", true);
+        ddlTestCases.put("ALTER TABLE employees.sales REMOVE PARTITIONING", true);
+        ddlTestCases.put("ALTER TABLE employees.sales TRUNCATE PARTITION p2022", true);
+        ddlTestCases.put("ALTER TABLE employees.sales CHECK PARTITION p2023", true);
+        ddlTestCases.put("ALTER TABLE employees.sales OPTIMIZE PARTITION p2023", true);
+        
+        // AUTO_INCREMENT operations that SHOULD be ignored
+        ddlTestCases.put("ALTER TABLE employees.sales AUTO_INCREMENT = 1000", true);
+        ddlTestCases.put("ALTER TABLE employees.users AUTO_INCREMENT=5000", true);
+        ddlTestCases.put("  ALTER TABLE test.mytable AUTO_INCREMENT = 12345  ", true);
+        
+        // Normal DDL operations that should NOT be ignored
+        ddlTestCases.put("ALTER TABLE employees.sales ADD COLUMN new_col INT", false);
+        ddlTestCases.put("ALTER TABLE employees.sales DROP COLUMN old_col", false);
+        ddlTestCases.put("ALTER TABLE employees.sales MODIFY COLUMN price DECIMAL(10,2)", false);
+        ddlTestCases.put("CREATE TABLE test (id INT PRIMARY KEY)", false);
+        ddlTestCases.put("DROP TABLE employees.old_table", false);
+        
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        
+        for (Map.Entry<String, Boolean> testCase : ddlTestCases.entrySet()) {
+            String ddl = testCase.getKey();
+            Boolean shouldBeIgnored = testCase.getValue();
+            boolean actuallyIgnored = capture.checkDDLAgainstRegexPatterns(ddl);
+            
+            Assert.assertEquals(
+                String.format("DDL '%s' ignore status mismatch", ddl),
+                shouldBeIgnored,
+                actuallyIgnored
+            );
+        }
+        
+        log.info("Successfully validated " + ddlTestCases.size() + " DDL ignore patterns");
+    }
+
+    @Test
+    public void testCreateTableWithRangePartitionByYearFunction() {
+        String createQuery = "CREATE TABLE test3 (\n" +
+                "    order_id INT AUTO_INCREMENT,\n" +
+                "    product_name VARCHAR(255),\n" +
+                "    quantity INT,\n" +
+                "    order_date DATE,\n" +
+                "    PRIMARY KEY (order_id, order_date)\n" +
+                ") \n" +
+                "ENGINE = InnoDB\n" +
+                "PARTITION BY RANGE( YEAR(order_date) ) (\n" +
+                "    PARTITION p2020 VALUES LESS THAN (2021),\n" +
+                "    PARTITION p2021 VALUES LESS THAN (2022),\n" +
+                "    PARTITION p2022 VALUES LESS THAN (2023),\n" +
+                "    PARTITION p2023 VALUES LESS THAN (2024),\n" +
+                "    PARTITION p2024 VALUES LESS THAN (2025)\n" +
+                ")";
+        
+        StringBuffer clickHouseQuery = new StringBuffer();
+        mySQLDDLParserService.parseSql(createQuery, "employees", clickHouseQuery);
+
+        String expectedQuery = "CREATE TABLE employees.test3(order_id Nullable(Int32),product_name Nullable(String),quantity Nullable(Int32),order_date Nullable(Date32),`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) PARTITION BY  toYear(order_date) ORDER BY (order_id,order_date)";
+
+        // Verify that MySQL's YEAR(order_date) partition is converted to ClickHouse's toYear(order_date)
+       Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(expectedQuery));
+        log.info("Create table with RANGE PARTITION BY YEAR function: " + clickHouseQuery);
+    }
+
 }


### PR DESCRIPTION
## Summary

Fixes #1308

Three methods in `MySqlDDLParserListenerImpl` incorrectly handle fully-qualified table names (e.g., `mydb.mytable`) during DDL replication:

1. **`enterTruncateTable()`** prepends `databaseName` to the full `TableNameContext.getText()` without checking for dots, producing `db.mydb.mytable` instead of `db.mytable`
2. **`enterDropTable()`** appends the table name without any `databaseName` prefix
3. **`enterRenameTable()`** uses `&&` instead of `||` when checking for dots, skipping qualified-name handling when only one table name is qualified

## Changes

All three methods now follow the same dot-check-and-split pattern already used by `enterAlterTable()`:
- Check if the table name contains a dot
- If yes, split on the dot and use only the table part (index 1)
- Always prepend the configured `databaseName`

## Tests

Added 4 new unit tests:
- `truncateTableWithQualifiedName`: verifies `TRUNCATE TABLE mydb.add_test` produces `TRUNCATE TABLE employees.add_test`
- `dropTableWithQualifiedName`: verifies `DROP TABLE mydb.add_test` produces `DROP TABLE employees.add_test`
- `renameTableWithMixedQualification`: verifies `RENAME TABLE mydb.old_table TO new_table` produces correct output with both names prefixed
- `dropTableUnqualifiedName`: verifies existing behavior is preserved for unqualified names

## Files Changed

- `sink-connector-lightweight/src/main/java/.../MySqlDDLParserListenerImpl.java` (3 method fixes)
- `sink-connector-lightweight/src/test/java/.../MySqlDDLParserListenerImplTest.java` (4 new tests)