### PR TITLE
Classify ClickHouse errors and stop on fatal failures instead of retrying forever

### DIFF
--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchRunnable.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchRunnable.java
@@ -4,21 +4,21 @@ import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
 import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfigVariables;
 import com.altinity.clickhouse.sink.connector.common.Metrics;
 import com.altinity.clickhouse.sink.connector.common.Utils;
-import com.altinity.clickhouse.sink.connector.db.BaseDbWriter;
-import com.altinity.clickhouse.sink.connector.db.DBMetadata;
-import com.altinity.clickhouse.sink.connector.db.DbKafkaOffsetWriter;
-import com.altinity.clickhouse.sink.connector.db.DbWriter;
+import com.altinity.clickhouse.sink.connector.db.*;
 import com.altinity.clickhouse.sink.connector.db.batch.GroupInsertQueryWithBatchRecords;
 import com.altinity.clickhouse.sink.connector.db.batch.PreparedStatementExecutor;
+import com.altinity.clickhouse.sink.connector.db.operations.ClickHouseCreateDatabase;
+import com.altinity.clickhouse.sink.connector.history.BinLogHistory;
 import com.altinity.clickhouse.sink.connector.model.BlockMetaData;
 import com.altinity.clickhouse.sink.connector.model.ClickHouseStruct;
 import com.altinity.clickhouse.sink.connector.model.DBCredentials;
-import com.clickhouse.jdbc.ClickHouseConnection;
+import com.altinity.clickhouse.sink.connector.model.RoutedBatch;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -29,359 +29,751 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 
 /**
- * Runnable object that will be called on
- * a schedule to perform the batch insert of
- * records to Clickhouse.
+ * Runnable object that will be called on a schedule to perform the
+ * batch insert of records to ClickHouse.
  */
 public class ClickHouseBatchRunnable implements Runnable {
-    private static final Logger log = LogManager.getLogger(ClickHouseBatchRunnable.class);
+
+    /**
+     * Logger instance for the ClickHouseBatchRunnable class.
+     */
+    private static final Logger log = LogManager.getLogger(
+            ClickHouseBatchRunnable.class);
+
+    /**
+     * Queue containing batches of ClickHouseStruct records.
+     */
     private final LinkedBlockingQueue<List<ClickHouseStruct>> records;
 
+    /**
+     * Queue containing routed batches (for hash-based routing).
+     */
+    private final LinkedBlockingQueue<RoutedBatch> routedRecords;
+
+    /**
+     * Thread ID for this runnable (used for hash-based routing).
+     * -1 means no hash-based routing (legacy mode).
+     */
+    private final int threadId;
+
+    /**
+     * Connector configuration.
+     */
     private final ClickHouseSinkConnectorConfig config;
 
-    // Connection that will be used to create
-    // the debezium storage database.
-    private ClickHouseConnection systemConnection;
-
-    // For insert batch the database connection has to be the same.
-    // Create a map of database name to ClickHouseConnection.
-    private Map<String, ClickHouseConnection> databaseToConnectionMap = new HashMap<>();
     /**
-     * Data structures with state
+     * Connection used to create the Debezium storage database.
      */
-    // Map of topic names to table names.
+    private Connection systemConnection;
+
+    /**
+     * Map of database name to ClickHouse Connection.
+     */
+    private Map<String, Connection> databaseToConnectionMap =
+            new HashMap<>();
+
+    /**
+     * Map of topic names to table names.
+     */
     private final Map<String, String> topic2TableMap;
 
-    // Map of topic name to CLickHouseConnection instance(DbWriter)
+    /**
+     * Map of topic name to DbWriter instance.
+     */
     private Map<String, DbWriter> topicToDbWriterMap;
 
-
+    /**
+     * Database credentials.
+     */
     private DBCredentials dbCredentials;
 
-
+    /**
+     * Current batch of records being processed.
+     */
     private List<ClickHouseStruct> currentBatch = null;
 
-
+    /**
+     * Map for overriding database names from source to destination.
+     */
     private Map<String, String> databaseOverrideMap = new HashMap<>();
 
-    public ClickHouseBatchRunnable(LinkedBlockingQueue<List<ClickHouseStruct>> records,
-                                   ClickHouseSinkConnectorConfig config,
-                                   Map<String, String> topic2TableMap) {
+    /**
+     * Sleep time in milliseconds after an exception occurs.
+     */
+    private static final long ERROR_SLEEP_TIME_MS = 10000;
+
+    /**
+     * Constructs a ClickHouseBatchRunnable (legacy mode without hash-based routing).
+     *
+     * @param records        the queue of record batches
+     * @param config         the connector configuration
+     * @param topic2TableMap a map of topic names to table names
+     */
+    public ClickHouseBatchRunnable(
+            LinkedBlockingQueue<List<ClickHouseStruct>> records,
+            ClickHouseSinkConnectorConfig config,
+            Map<String, String> topic2TableMap) {
+        this(records, null, -1, config, topic2TableMap);
+    }
+
+    /**
+     * Constructs a ClickHouseBatchRunnable with hash-based routing.
+     *
+     * @param routedRecords  the queue of routed record batches
+     * @param threadId       the thread ID for this runnable
+     * @param config         the connector configuration
+     * @param topic2TableMap a map of topic names to table names
+     */
+    public ClickHouseBatchRunnable(
+            LinkedBlockingQueue<RoutedBatch> routedRecords,
+            int threadId,
+            ClickHouseSinkConnectorConfig config,
+            Map<String, String> topic2TableMap) {
+        this(null, routedRecords, threadId, config, topic2TableMap);
+    }
+
+    /**
+     * Private constructor that initializes all fields.
+     *
+     * @param records        the queue of record batches (legacy mode)
+     * @param routedRecords  the queue of routed record batches (hash-based routing)
+     * @param threadId       the thread ID for this runnable (-1 for legacy mode)
+     * @param config         the connector configuration
+     * @param topic2TableMap a map of topic names to table names
+     */
+    private ClickHouseBatchRunnable(
+            LinkedBlockingQueue<List<ClickHouseStruct>> records,
+            LinkedBlockingQueue<RoutedBatch> routedRecords,
+            int threadId,
+            ClickHouseSinkConnectorConfig config,
+            Map<String, String> topic2TableMap) {
         this.records = records;
+        this.routedRecords = routedRecords;
+        this.threadId = threadId;
         this.config = config;
         if (topic2TableMap == null) {
             this.topic2TableMap = new HashMap();
         } else {
             this.topic2TableMap = topic2TableMap;
         }
-
         //this.queryToRecordsMap = new HashMap<>();
         this.topicToDbWriterMap = new HashMap<>();
         //this.topicToRecordsMap = new HashMap<>();
-
         this.dbCredentials = parseDBConfiguration();
-        this.systemConnection = createConnection();
-
-
+        this.systemConnection = createConnection(BaseDbWriter.SYSTEM_DB);
         try {
-            this.databaseOverrideMap = Utils.parseSourceToDestinationDatabaseMap(this.config.
-                    getString(ClickHouseSinkConnectorConfigVariables.CLICKHOUSE_DATABASE_OVERRIDE_MAP.toString()));
+            this.databaseOverrideMap = Utils.parseSourceToDestinationDatabaseMap(
+                    this.config.getString(
+                            ClickHouseSinkConnectorConfigVariables.
+                                    CLICKHOUSE_DATABASE_OVERRIDE_MAP.toString()));
         } catch (Exception e) {
             log.error("Error parsing database override map" + e);
         }
+        
+        if (threadId >= 0) {
+            log.info("ClickHouseBatchRunnable initialized with thread ID: {}", threadId);
+        }
     }
 
-    private ClickHouseConnection createConnection() {
-        String jdbcUrl = BaseDbWriter.getConnectionString(this.dbCredentials.getHostName(),
+    /**
+     * Creates a connection to the specified database.
+     *
+     * @param databaseName the database name
+     * @return a Connection object to the given database
+     */
+    private Connection createConnection(String databaseName) {
+        String jdbcUrl = BaseDbWriter.getConnectionString(
+                this.dbCredentials.getHostName(),
                 this.dbCredentials.getPort(), "system");
-
-        return BaseDbWriter.createConnection(jdbcUrl, "Sink Connector Lightweight", this.dbCredentials.getUserName(),
-                this.dbCredentials.getPassword(), config);
+        return BaseDbWriter.createConnection(jdbcUrl,
+                BaseDbWriter.DATABASE_CLIENT_NAME,
+                this.dbCredentials.getUserName(),
+                this.dbCredentials.getPassword(), databaseName, config);
     }
 
-    // Function to check if we have already stored a ClickHouseConnection
-    // in the databaseToConnectionMap.
-    private ClickHouseConnection getClickHouseConnection(String databaseName) {
+    /**
+     * Retrieves the ClickHouse connection for the specified database.
+     *
+     * <p>If no connection exists, this method creates the database (if
+     * needed) and returns a new connection.
+     *
+     * @param databaseName the target database name
+     * @return a Connection to the specified database
+     */
+    private Connection getClickHouseConnection(String databaseName) {
         if (this.databaseToConnectionMap.containsKey(databaseName)) {
             return this.databaseToConnectionMap.get(databaseName);
         }
-
-        String jdbcUrl = BaseDbWriter.getConnectionString(this.dbCredentials.getHostName(),
+        // Create database if it doesnt exist.
+        String systemJdbcUrl = BaseDbWriter.getConnectionString(
+                this.dbCredentials.getHostName(),
+                this.dbCredentials.getPort(), "system");
+        Connection systemConn = BaseDbWriter.createConnection(systemJdbcUrl,
+                BaseDbWriter.DATABASE_CLIENT_NAME,
+                this.dbCredentials.getUserName(),
+                this.dbCredentials.getPassword(), "system", config);
+        try {
+            boolean useOnCluster = this.config.
+                    getBoolean(ClickHouseSinkConnectorConfigVariables.AUTO_CREATE_TABLES_REPLICATED.toString());
+            new ClickHouseCreateDatabase().createNewDatabase(systemConn, databaseName, useOnCluster, this.config);
+            DBMetadata metadata = new DBMetadata(config);
+            metadata.executeSystemQuery(systemConn,
+                    "CREATE DATABASE IF NOT EXISTS " + databaseName);
+        } catch (Exception e) {
+            log.error("Error creating database " + e);
+        } finally {
+            try {
+                systemConn.close();
+            } catch (SQLException e) {
+                log.error("Error closing connection when creating database" + e);
+            }
+        }
+        String jdbcUrl = BaseDbWriter.getConnectionString(
+                this.dbCredentials.getHostName(),
                 this.dbCredentials.getPort(), databaseName);
-
-        ClickHouseConnection conn = BaseDbWriter.createConnection(jdbcUrl, "Sink Connector Lightweight",
-                this.dbCredentials.getUserName(), this.dbCredentials.getPassword(), config);
-
+        Connection conn = BaseDbWriter.createConnection(jdbcUrl,
+                BaseDbWriter.DATABASE_CLIENT_NAME,
+                this.dbCredentials.getUserName(),
+                this.dbCredentials.getPassword(), databaseName, config);
         this.databaseToConnectionMap.put(databaseName, conn);
         return conn;
     }
 
+    /**
+     * Parses the database configuration from the connector config.
+     *
+     * @return a DBCredentials object with the parsed settings
+     */
     private DBCredentials parseDBConfiguration() {
         DBCredentials dbCredentials = new DBCredentials();
-
-        dbCredentials.setHostName(config.getString(ClickHouseSinkConnectorConfigVariables.CLICKHOUSE_URL.toString()));
-        dbCredentials.setPort(config.getInt(ClickHouseSinkConnectorConfigVariables.CLICKHOUSE_PORT.toString()));
-        dbCredentials.setUserName(config.getString(ClickHouseSinkConnectorConfigVariables.CLICKHOUSE_USER.toString()));
-        dbCredentials.setPassword(config.getString(ClickHouseSinkConnectorConfigVariables.CLICKHOUSE_PASS.toString()));
-
+        dbCredentials.setHostName(config.getString(
+                ClickHouseSinkConnectorConfigVariables.
+                        CLICKHOUSE_URL.toString()));
+        dbCredentials.setPort(config.getInt(
+                ClickHouseSinkConnectorConfigVariables.
+                        CLICKHOUSE_PORT.toString()));
+        dbCredentials.setUserName(config.getString(
+                ClickHouseSinkConnectorConfigVariables.
+                        CLICKHOUSE_USER.toString()));
+        dbCredentials.setPassword(config.getString(
+                ClickHouseSinkConnectorConfigVariables.
+                        CLICKHOUSE_PASS.toString()));
         return dbCredentials;
     }
 
     /**
-     * Main run loop of the thread
-     * which is called based on the schedule
+     * Gets the server name from the topic name.
+     * Topic name format is expected to be: server.database.table
+     *
+     * @param topicName The topic name
+     * @return The server name, or null if not found
+     */
+    private String getServerNameFromTopic(String topicName) {
+        if (topicName == null || topicName.isEmpty()) {
+            return null;
+        }
+
+        String[] parts = topicName.split("\\.");
+        if (parts.length >= 3) {
+            return parts[0]; // First part is server name
+        }
+        return null;
+    }
+
+    /**
+     * Main run loop of the thread, called on a schedule.
      * Default: 100 msecs
      */
     @Override
     public void run() {
-
-
-        Long taskId = config.getLong(ClickHouseSinkConnectorConfigVariables.TASK_ID.toString());
+        Long taskId = config.getLong(
+                ClickHouseSinkConnectorConfigVariables.TASK_ID.toString());
+        
+        // Get source timezone from config
+        String sourceTimeZone = config.getString(ClickHouseSinkConnectorConfigVariables.SOURCE_DATETIME_TIMEZONE.toString());
+        // Get server timezone from config
+        String serverTimeZone = config.getString(ClickHouseSinkConnectorConfigVariables.CLICKHOUSE_DATETIME_TIMEZONE.toString());
+        String errorTableName = config.getString(ClickHouseSinkConnectorConfigVariables.ERROR_TABLE_NAME.toString());
+        
+        // Determine which mode we're in: hash-based routing or legacy
+        boolean useHashRouting = (threadId >= 0 && routedRecords != null);
+        useHashRouting = false;
         try {
-
-            // Poll from Queue until its empty.
-            while(records.size() > 0 || currentBatch != null) {
-                // If the thread is interrupted, the exit.
-                if(Thread.currentThread().isInterrupted()) {
-                    log.info("Thread is interrupted, exiting - Thread ID: " + Thread.currentThread().getId());
-                    return;
-                }
-
-                if(currentBatch == null) {
-                    currentBatch = records.poll();
-                    if(currentBatch == null) {
-                        // No records in the queue.
-                        continue;
-                    }
-                } else {
-                    log.debug("***** RETRYING the same batch again");
-                }
-
-
-
-                ///// ***** START PROCESSING BATCH **************************
-                // Step 1: Add to Inflight batches.
-                DebeziumOffsetManagement.addToBatchTimestamps(currentBatch);
-
-                log.info("****** Thread: " + Thread.currentThread().getName() + " Batch Size: " + currentBatch.size() + " ******");
-                // Group records by topic name.
-                // Create a new map of topic name to list of records.
-                Map<String, List<ClickHouseStruct>> topicToRecordsMap = new ConcurrentHashMap<>();
-                currentBatch.forEach(record -> {
-                    String topicName = record.getTopic();
-                    // If the topic name is not present, create a new list and add the record.
-                    if (topicToRecordsMap.containsKey(topicName) == false) {
-                        List<ClickHouseStruct> recordsList = new ArrayList<>();
-                        recordsList.add(record);
-                        topicToRecordsMap.put(topicName, recordsList);
-                    } else {
-                        // If the topic name is present, add the record to the list.
-                        List<ClickHouseStruct> recordsList = topicToRecordsMap.get(topicName);
-                        recordsList.add(record);
-                        topicToRecordsMap.put(topicName, recordsList);
-                    }
-                });
-                boolean result = true;
-                // For each topic, process the records.
-                // topic name syntax is server.database.table
-                for (Map.Entry<String, List<ClickHouseStruct>> entry : topicToRecordsMap.entrySet()) {
-                    result = processRecordsByTopic(entry.getKey(), entry.getValue());
-                    if(result == false) {
-                        log.error("Error processing records for topic: " + entry.getKey());
-                        break;
-                    }
-                }
-
-                if(result) {
-                    // Step 2: Check if the batch can be committed.
-                    if(DebeziumOffsetManagement.checkIfBatchCanBeCommitted(currentBatch)) {
-                        currentBatch = null;
-                    }
-                }
-                    //acknowledgeRecords(batch);
-                ///// ***** END PROCESSING BATCH **************************
-
+//            if (useHashRouting) {
+//                runWithHashRouting(taskId, sourceTimeZone, serverTimeZone, errorTableName);
+//            } else
+           {
+                runLegacyMode(taskId, sourceTimeZone, serverTimeZone, errorTableName);
+            }
+        } catch (Exception e) {
+            log.error(String.format(
+                            "ClickHouseBatchRunnable exception - Task(%s)", taskId),
+                    e);
+            if(config.getBoolean(ClickHouseSinkConnectorConfigVariables.ERROR_LOGGING_ENABLE.toString())){
+                logErrorToClickHouse(e, taskId, errorTableName);
             }
 
-        } catch(Exception e) {
-            log.error(String.format("ClickHouseBatchRunnable exception - Task(%s)", taskId), e);
-            try {
-                Thread.sleep(10000);
-            } catch (InterruptedException ex) {
-                log.error("******* ERROR **** Thread interrupted *********", ex);
-                throw new RuntimeException(ex);
+            // Classify the error to decide whether to retry or stop
+            ClickHouseErrorClassifier.ErrorCategory category = ClickHouseErrorClassifier.classify(e);
+            int errorCode = ClickHouseErrorClassifier.extractErrorCode(e);
+
+            if (category == ClickHouseErrorClassifier.ErrorCategory.FATAL) {
+                log.error("FATAL ClickHouse error (Code: {}) -- this batch will never succeed. " +
+                          "Discarding batch and stopping task to prevent silent data loss. " +
+                          "Manual intervention required.", errorCode);
+                // Clear the stuck batch so it is not retried forever
+                currentBatch = null;
+                // Rethrow to stop the scheduled executor -- silent swallowing causes
+                // binlog advancement to stall and blocks replication for ALL tables
+                throw e;
+            } else {
+                log.warn("Retriable ClickHouse error (Code: {}, Category: {}) -- " +
+                         "batch will be retried on next scheduled run.", errorCode, category);
             }
         }
     }
 
+    /**
+     * Run loop for hash-based routing mode.
+     * Only processes batches assigned to this thread.
+     */
+    private void runWithHashRouting(Long taskId, String sourceTimeZone, String serverTimeZone, String errorTableName) throws Exception {
+        // Poll from Queue until its empty.
+        while (routedRecords.size() > 0 || currentBatch != null) {
+            // If the thread is interrupted, the exit.
+            if (Thread.currentThread().isInterrupted()) {
+                log.info("Thread {} is interrupted, exiting - Java Thread ID: {}",
+                        threadId, Thread.currentThread().getId());
+                return;
+            }
+            
+            if (currentBatch == null) {
+                RoutedBatch routedBatch = routedRecords.poll();
+                if (routedBatch == null) {
+                    // No records in the queue.
+                    continue;
+                }
+                
+                // Only process if this batch is assigned to this thread
+                if (routedBatch.getAssignedThreadId() == threadId) {
+                    currentBatch = routedBatch.getBatch();
+                    log.debug("Thread {} picked up batch for table: {}", threadId, routedBatch.getTableName());
+                } else {
+                    // Put it back for another thread to pick up
+                    routedRecords.put(routedBatch);
+                    Thread.sleep(10); // Small sleep to avoid busy waiting
+                    continue;
+                }
+            } else {
+                log.debug("***** Thread {} RETRYING the same batch again", threadId);
+            }
 
+            // Process the batch (rest of the logic stays the same)
+            processBatch(sourceTimeZone, serverTimeZone);
+        }
+    }
 
     /**
-     * Function to retrieve table name from topic name
+     * Run loop for legacy mode (no hash-based routing).
+     */
+    private void runLegacyMode(Long taskId, String sourceTimeZone, String serverTimeZone, String errorTableName) throws Exception {
+        // Poll from Queue until its empty.
+        while (records.size() > 0 || currentBatch != null) {
+            // If the thread is interrupted, the exit.
+            if (Thread.currentThread().isInterrupted()) {
+                log.info("Thread is interrupted, exiting - Thread ID: " +
+                        Thread.currentThread().getId());
+                return;
+            }
+            if (currentBatch == null) {
+                currentBatch = records.poll();
+                if (currentBatch == null) {
+                    // No records in the queue.
+                    continue;
+                }
+            } else {
+                log.debug("***** RETRYING the same batch again");
+            }
+
+            // Process the batch (rest of the logic stays the same)
+            processBatch(sourceTimeZone, serverTimeZone);
+        }
+    }
+
+    /**
+     * Common batch processing logic used by both hash-based routing and legacy mode.
+     * 
+     * @param sourceTimeZone Source timezone configuration
+     * @param serverTimeZone Server timezone configuration
+     * @throws Exception if processing fails
+     */
+    private void processBatch(String sourceTimeZone, String serverTimeZone) throws Exception {
+        // If replication history is enabled, add the records to the history table.
+        addRecordsToHistoryTable(currentBatch, sourceTimeZone, serverTimeZone);
+
+        ///// ***** START PROCESSING BATCH **************************
+        // Step 1: Add to Inflight batches.
+        DebeziumOffsetManagement.addToBatchTimestamps(currentBatch);
+        log.info("****** Thread: " +
+                Thread.currentThread().getName() +
+                " Batch Size: " + currentBatch.size() +
+                " ******");
+        // Group records by topic name.
+        // Create a new map of topic name to list of records.
+        Map<String, List<ClickHouseStruct>> topicToRecordsMap =
+                new ConcurrentHashMap<>();
+        currentBatch.forEach(record -> {
+            String topicName = record.getTopic();
+            // If the topic name is not present, create a new list and
+            // add the record.
+            if (topicToRecordsMap.containsKey(topicName) == false) {
+                List<ClickHouseStruct> recordsList = new ArrayList<>();
+                recordsList.add(record);
+                topicToRecordsMap.put(topicName, recordsList);
+            } else {
+                // If the topic name is present, add the record to the list.
+                List<ClickHouseStruct> recordsList =
+                        topicToRecordsMap.get(topicName);
+                recordsList.add(record);
+                topicToRecordsMap.put(topicName, recordsList);
+            }
+        });
+        boolean result = true;
+        // For each topic, process the records.
+        // topic name syntax is server.database.table
+
+        boolean replicationHistoryEnabled = config.getBoolean(
+            ClickHouseSinkConnectorConfigVariables.REPLICATION_HISTORY_ENABLE.toString());
+        boolean replicationLogOnly = config.getBoolean(
+            ClickHouseSinkConnectorConfigVariables.REPLICATION_HISTORY_REPLICATION_LOG_ONLY.toString());
+        if(replicationLogOnly && replicationHistoryEnabled)  { 
+            // skip the following for loop and continue to the next step
+            log.debug("Replication log only mode is enabled, skipping the processing of records");
+        } else {
+            for (Map.Entry<String, List<ClickHouseStruct>> entry :
+                    topicToRecordsMap.entrySet()) {
+
+                result = processRecordsByTopic(entry.getKey(),
+                        entry.getValue());
+
+                if (result == false) {
+                    log.error("Error processing records for topic: " +
+                            entry.getKey());
+                    break;
+                }
+            }
+        }
+            
+        
+        if (result) {
+            // Step 2: Check if the batch can be committed.
+            if(DebeziumOffsetManagement.checkIfBatchCanBeCommitted(currentBatch)) {
+                currentBatch = null;
+            }
+        }
+        Thread.sleep(config.getLong(
+                ClickHouseSinkConnectorConfigVariables.
+                        BUFFER_FLUSH_TIME.toString()));
+        ///// ***** END PROCESSING BATCH **************************
+    }
+
+    /**
+     * Function to persist records to binlog history table when replication history mode is enabled.
+     * @param records
+     * @param sourceTimeZone
+     * @param serverTimeZone
+     * @throws SQLException
+     */
+    private void addRecordsToHistoryTable(List<ClickHouseStruct> records, String sourceTimeZone, String serverTimeZone) throws SQLException {
+        if(config.getBoolean(ClickHouseSinkConnectorConfigVariables.REPLICATION_HISTORY_ENABLE.toString())) {
+            String databaseName = config.getString(ClickHouseSinkConnectorConfigVariables.REPLICATION_HISTORY_DATABASE_NAME.toString());
+            String tableName = config.getString(ClickHouseSinkConnectorConfigVariables.REPLICATION_HISTORY_TABLE_NAME.toString());
+            Connection databaseConn = getClickHouseConnection(databaseName);
+            DbWriter writer = getDbWriterForTable(databaseName + "." + tableName, tableName, databaseName,
+                    records.get(0), databaseConn);
+
+            BinLogHistory binLogHistory = new BinLogHistory();
+            binLogHistory.addRecordsToHistoryTable(config, tableName, writer.getConnection(), "", records, sourceTimeZone, serverTimeZone);
+        }
+    }
+
+    /**
+     * Retrieves the table name from the given topic name.
      *
-     * @param topicName
-     * @return Table Name
+     * @param topicName the topic name
+     * @return the corresponding table name
      */
     public String getTableFromTopic(String topicName) {
         String tableName = null;
-
         if (this.topic2TableMap.containsKey(topicName) == false) {
             tableName = Utils.getTableNameFromTopic(topicName);
             this.topic2TableMap.put(topicName, tableName);
         } else {
             tableName = this.topic2TableMap.get(topicName);
         }
-
         return tableName;
     }
 
-    public DbWriter getDbWriterForTable(String topicName, String tableName, String databaseName,
-                                        ClickHouseStruct record, ClickHouseConnection connection) {
+    /**
+     * Returns a DbWriter for the specified topic, table, and database.
+     *
+     * @param topicName    the topic name
+     * @param tableName    the table name
+     * @param databaseName the database name
+     * @param record       a ClickHouseStruct record for metadata
+     * @param connection   the JDBC Connection to the database
+     * @return a DbWriter instance for the given parameters
+     */
+    public DbWriter getDbWriterForTable(String topicName, String tableName,
+                                        String databaseName,
+                                        ClickHouseStruct record,
+                                        Connection connection) {
         DbWriter writer = null;
-
         if (this.topicToDbWriterMap.containsKey(topicName)) {
-            writer = this.topicToDbWriterMap.get(topicName);
-            return writer;
+            // Check if this table needs cache invalidation after DDL
+            String fullyQualifiedTableName = databaseName + "." + tableName;
+            if (CacheInvalidationManager.getInstance().shouldInvalidate(fullyQualifiedTableName)) {
+                log.info("Invalidating cached DbWriter for {} after DDL", topicName);
+                this.topicToDbWriterMap.remove(topicName);
+            } else {
+                writer = this.topicToDbWriterMap.get(topicName);
+                return writer;
+            }
         }
-
-        writer = new DbWriter(this.dbCredentials.getHostName(), this.dbCredentials.getPort(),
-                databaseName, tableName, this.dbCredentials.getUserName(),
-                    this.dbCredentials.getPassword(), this.config, record, connection);
+        writer = new DbWriter(this.dbCredentials.getHostName(),
+                this.dbCredentials.getPort(), databaseName, tableName,
+                this.dbCredentials.getUserName(),
+                this.dbCredentials.getPassword(), this.config, record,
+                connection);
         this.topicToDbWriterMap.put(topicName, writer);
         return writer;
     }
 
     /**
-     * Function to return ClickHouse server timezone.
-     * @return
+     * Returns the ClickHouse server timezone.
+     *
+     * @param config the connector configuration
+     * @return a ZoneId representing the server timezone
      */
     public ZoneId getServerTimeZone(ClickHouseSinkConnectorConfig config) {
-
-        String userProvidedTimeZone = config.getString(ClickHouseSinkConnectorConfigVariables
-                .CLICKHOUSE_DATETIME_TIMEZONE.toString());
+        String userProvidedTimeZone = config.getString(
+                ClickHouseSinkConnectorConfigVariables.
+                        CLICKHOUSE_DATETIME_TIMEZONE.toString());
         // Validate if timezone string is valid.
         ZoneId userProvidedTimeZoneId = null;
         try {
-            if(!userProvidedTimeZone.isEmpty()) {
+            if (!userProvidedTimeZone.isEmpty()) {
                 userProvidedTimeZoneId = ZoneId.of(userProvidedTimeZone);
             }
-        } catch (Exception e){
-            log.error("**** Error parsing user provided timezone:"+ userProvidedTimeZone + e.toString());
+        } catch (Exception e) {
+            log.error("**** Error parsing user provided timezone:" +
+                    userProvidedTimeZone + e.toString());
         }
-
-        if(userProvidedTimeZoneId != null) {
+        if (userProvidedTimeZoneId != null) {
             return userProvidedTimeZoneId;
         }
-        return new DBMetadata().getServerTimeZone(this.systemConnection);
+        return new DBMetadata(config).getServerTimeZone(this.systemConnection);
     }
-    /**
-     * Function to process records
-     *
-     * @param topicName
-     * @param records
-     */
-    private boolean processRecordsByTopic(String topicName, List<ClickHouseStruct> records) throws Exception {
 
+    /**
+     * Processes records for the specified topic.
+     *
+     * <p>This function groups records by topic, retrieves the corresponding
+     * table name and DbWriter, and processes the batch by grouping records
+     * into insert queries and flushing them to ClickHouse.
+     *
+     * @param topicName the topic name
+     * @param records   a list of ClickHouseStruct records for the topic
+     * @return true if processing succeeds; false otherwise
+     * @throws Exception if an error occurs during processing
+     */
+    private boolean processRecordsByTopic(String topicName,
+                                          List<ClickHouseStruct> records)
+            throws Exception {
         boolean result = false;
         //The user parameter will override the topic mapping to table.
         String tableName = getTableFromTopic(topicName);
-        // Note: getting records.get(0) is safe as the topic name is same for all records.
-        ClickHouseStruct firstRecord =  records.get(0);
-
+        // Note: getting records.get(0) is safe as the topic name is same
+        // for all records.
+        ClickHouseStruct firstRecord = records.get(0);
         String databaseName = firstRecord.getDatabase();
 
+        // If replication history is enabled, set database name to the replication history database name
+        if(config.getBoolean(ClickHouseSinkConnectorConfigVariables.REPLICATION_HISTORY_ENABLE.toString())){
+            databaseName = config.getString(ClickHouseSinkConnectorConfigVariables.REPLICATION_HISTORY_DATABASE_NAME.toString());
+        }
+
+        return processBatchRecords(records, topicName, tableName, databaseName, firstRecord);
+    }
+
+    private boolean processBatchRecords(List<ClickHouseStruct> records, String topicName,
+                                      String tableName, String databaseName,
+                                      ClickHouseStruct firstRecord) throws Exception {
+        boolean result = false;
+
+
         // Check if user has overridden the database name.
-        if(this.databaseOverrideMap.containsKey(firstRecord.getDatabase()))
-            databaseName = this.databaseOverrideMap.get(firstRecord.getDatabase());
+        if (this.databaseOverrideMap.containsKey(databaseName))
+            databaseName = this.databaseOverrideMap.get(
+                    databaseName);
 
-        ClickHouseConnection databaseConn = getClickHouseConnection(databaseName);
+        Connection databaseConn = getClickHouseConnection(databaseName);
 
-        DbWriter writer = getDbWriterForTable(topicName, tableName, databaseName, firstRecord, databaseConn);
+        DbWriter writer = getDbWriterForTable(topicName, tableName, databaseName,
+                firstRecord, databaseConn);
         PreparedStatementExecutor preparedStatementExecutor = new
                 PreparedStatementExecutor(writer.getReplacingMergeTreeDeleteColumn(),
-                writer.isReplacingMergeTreeWithIsDeletedColumn(), writer.getSignColumn(), writer.getVersionColumn(),
-                writer.getDatabaseName(), getServerTimeZone(this.config));
-
-
-        if(writer == null || writer.wasTableMetaDataRetrieved() == false) {
-            log.error(String.format("*** TABLE METADATA not retrieved for Database(%), table(%s) retrying",
+                writer.isReplacingMergeTreeWithIsDeletedColumn(), writer.getSignColumn(),
+                writer.getVersionColumn(), writer.getDatabaseName(),
+                getServerTimeZone(this.config));
+        if (writer == null || writer.wasTableMetaDataRetrieved() == false) {
+            log.error(String.format("*** TABLE METADATA not retrieved for " +
+                            "Database(%s), table(%s) retrying",
                     writer.getDatabaseName(), writer.getTableName()));
-            if(writer == null) {
-                writer = getDbWriterForTable(topicName, tableName, databaseName, firstRecord, databaseConn);
+            if (writer == null) {
+                writer = getDbWriterForTable(topicName, tableName, databaseName,
+                        firstRecord, databaseConn);
             }
-            if(writer.wasTableMetaDataRetrieved() == false)
+            if (writer.wasTableMetaDataRetrieved() == false)
                 writer.updateColumnNameToDataTypeMap();
-
-            if(writer == null || writer.wasTableMetaDataRetrieved() == false ) {
-                log.error(String.format("*** TABLE METADATA not retrieved for Database(%s), table(%s), " +
-                        "retrying on next attempt", writer.getDatabaseName(), writer.getTableName()));
+            if (writer == null ||
+                    writer.wasTableMetaDataRetrieved() == false) {
+                log.error(String.format("*** TABLE METADATA not retrieved for " +
+                                "Database(%s), table(%s), retrying on next attempt",
+                        writer.getDatabaseName(), writer.getTableName()));
                 return false;
             }
         }
-        // Step 1: The Batch Insert with preparedStatement in JDBC
-        // works by forming the Query and then adding records to the Batch.
-        // This step creates a Map of Query -> Records(List of ClickHouseStruct)
-        Map<MutablePair<String, Map<String, Integer>>, List<ClickHouseStruct>> queryToRecordsMap = new HashMap<>();
+        // Step 1: The Batch Insert with preparedStatement in JDBC works by
+        // forming the Query and then adding records to the Batch.
+        // This step creates a Map of Query -> Records (List of ClickHouseStruct).
+        Map<MutablePair<String, Map<String, Integer>>,
+                List<ClickHouseStruct>> queryToRecordsMap = new HashMap<>();
         Map<TopicPartition, Long> partitionToOffsetMap = new HashMap<>();
-        result = new GroupInsertQueryWithBatchRecords().groupQueryWithRecords(records, queryToRecordsMap,
-                partitionToOffsetMap, this.config,tableName, writer.getDatabaseName(), writer.getConnection(),
-                writer.getColumnNameToDataTypeMap());
-
+        result = new GroupInsertQueryWithBatchRecords()
+                .groupQueryWithRecords(records, queryToRecordsMap,
+                        partitionToOffsetMap, this.config, tableName,
+                        writer.getDatabaseName(), writer.getConnection(),
+                        writer.getColumnNameToDataTypeMap());
         BlockMetaData bmd = new BlockMetaData();
-        long maxBufferSize = this.config.getLong(ClickHouseSinkConnectorConfigVariables.BUFFER_MAX_RECORDS.toString());
-
-        // Step 2: Create a PreparedStatement and add the records to the batch.
-        // In DBWriter, the queryToRecordsMap is converted to PreparedStatement and added to the batch.
-        // The batch is then executed and the records are flushed to ClickHouse.
-        result = flushRecordsToClickHouse(topicName, writer, queryToRecordsMap, bmd, maxBufferSize, preparedStatementExecutor);
-
-        if(result) {
+        long maxBufferSize = this.config.getLong(
+                ClickHouseSinkConnectorConfigVariables.
+                        BUFFER_MAX_RECORDS.toString());
+        // Step 2: Create a PreparedStatement and add the records to the
+        // batch. In DbWriter, the queryToRecordsMap is converted to
+        // PreparedStatement and added to the batch. The batch is then executed
+        // and the records are flushed to ClickHouse.
+        result = flushRecordsToClickHouse(topicName, writer, queryToRecordsMap,
+                bmd, maxBufferSize, preparedStatementExecutor);
+        if (result) {
             // Remove the entry.
             queryToRecordsMap.remove(topicName);
         }
-
-        if (this.config.getBoolean(ClickHouseSinkConnectorConfigVariables.ENABLE_KAFKA_OFFSET.toString())) {
+        if (this.config.getBoolean(
+                ClickHouseSinkConnectorConfigVariables.
+                        ENABLE_KAFKA_OFFSET.toString())) {
             log.info("***** KAFKA OFFSET MANAGEMENT ENABLED *****");
-            DbKafkaOffsetWriter dbKafkaOffsetWriter = new DbKafkaOffsetWriter(dbCredentials.getHostName(),
-                    dbCredentials.getPort(), dbCredentials.getDatabase(),
-                    "topic_offset_metadata", dbCredentials.getUserName(), dbCredentials.getPassword(),
+            DbKafkaOffsetWriter dbKafkaOffsetWriter = new DbKafkaOffsetWriter(
+                    dbCredentials.getHostName(), dbCredentials.getPort(),
+                    dbCredentials.getDatabase(), "topic_offset_metadata",
+                    dbCredentials.getUserName(), dbCredentials.getPassword(),
                     this.config, databaseConn);
             try {
-                dbKafkaOffsetWriter.insertTopicOffsetMetadata(partitionToOffsetMap);
+                dbKafkaOffsetWriter.insertTopicOffsetMetadata(
+                        partitionToOffsetMap);
             } catch (SQLException e) {
                 log.error("Error persisting offsets to CH", e);
             }
         }
-
         return result;
     }
 
     /**
-     * Function that flushes records to ClickHouse if
-     * there are minimum records or if the flush timeout has reached.
-     * @param writer
-     * @param queryToRecordsMap
-     * @return
+     * Flushes records to ClickHouse if there are minimum records or if the
+     * flush timeout has reached.
+     *
+     * <p>This method creates a PreparedStatement batch from the grouped
+     * queries and executes it, then updates metrics.
+     *
+     * @param topicName the topic name
+     * @param writer the DbWriter for the table
+     * @param queryToRecordsMap a map of insert queries to records
+     * @param bmd block metadata used for metrics
+     * @param maxBufferSize the maximum buffer size before flushing
+     * @param preparedStatementExecutor the executor to add batches
+     * @return true if the flush succeeds; false otherwise
+     * @throws Exception if an error occurs during batch execution
      */
     private boolean flushRecordsToClickHouse(String topicName, DbWriter writer,
-                Map<MutablePair<String, Map<String, Integer>>,
-                List<ClickHouseStruct>> queryToRecordsMap, BlockMetaData bmd,
-        long maxBufferSize, PreparedStatementExecutor preparedStatementExecutor) throws Exception {
-
+                                             Map<MutablePair<String, Map<String, Integer>>,
+                                                     List<ClickHouseStruct>> queryToRecordsMap, BlockMetaData bmd,
+                                             long maxBufferSize,
+                                             PreparedStatementExecutor preparedStatementExecutor)
+            throws Exception {
         boolean result = false;
-
         synchronized (queryToRecordsMap) {
-            result = preparedStatementExecutor.addToPreparedStatementBatch(topicName, queryToRecordsMap, bmd, config, writer.getConnection(),
-                    writer.getTableName(), writer.getColumnNameToDataTypeMap(), writer.getEngine());
-
+            result = preparedStatementExecutor.addToPreparedStatementBatch(
+                    topicName, queryToRecordsMap, bmd, config,
+                    writer.getConnection(), writer.getTableName(),
+                    writer.getColumnNameToDataTypeMap(), writer.getEngine());
         }
         try {
             Metrics.updateMetrics(bmd);
-        } catch(Exception e) {
+        } catch (Exception e) {
             log.error("****** Error updating Metrics ******");
         }
-        //result = true;
-
         return result;
+    }
+
+    /**
+     * Logs error information to ClickHouse error table.
+     *
+     * @param e exception that occurred
+     * @param taskId task identifier
+     * @param errorTableName name of the error table
+     */
+    private void logErrorToClickHouse(Exception e, Long taskId, String errorTableName) {
+        try {
+            Connection dbCon = getClickHouseConnection(DbWriter.SYSTEM_DB);
+            // Create error table if it doesn't exist
+            ErrorLogger.createErrorTable(dbCon, config);
+
+            // Log the error with the first record from current batch if available
+            if (currentBatch != null && !currentBatch.isEmpty()) {
+                ClickHouseStruct firstRecord = currentBatch.get(0);
+                SourceRecord sourceRecord = firstRecord.getSourceRecord().value();
+                String topicName = firstRecord.getTopic();
+                String databaseName = firstRecord.getDatabase();
+                String serverName = getServerNameFromTopic(topicName);
+
+                // Get the failure entry index
+                int failureIndex = currentBatch.indexOf(firstRecord);
+
+                ErrorLogger.logError(dbCon,
+                    String.format("Error processing batch. Task: %s, Server: %s, Database: %s, Failure Index: %d, Error: %s",
+                        taskId, serverName, databaseName, failureIndex, e.getMessage()),
+                    sourceRecord,
+                    databaseName,
+                    "", // No query field available
+                    "", // No offset key field available
+                    errorTableName);
+            } else {
+                ErrorLogger.logError(dbCon,
+                    String.format("Error processing batch. Task: %s, Error: %s", taskId, e.getMessage()),
+                    null,
+                    "",
+                    "", "",
+                    errorTableName);
+            }
+
+            Thread.sleep(ERROR_SLEEP_TIME_MS);
+        } catch (InterruptedException ex) {
+            log.error("******* ERROR **** Thread interrupted *********",
+                    ex);
+            throw new RuntimeException(ex);
+        } catch (SQLException ex) {
+            log.error("******* ERROR **** Failed to log error to ClickHouse *********",
+                    ex);
+        }
     }
 }

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseErrorClassifier.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseErrorClassifier.java
@@ -1,0 +1,135 @@
+package com.altinity.clickhouse.sink.connector.executor;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Classifies ClickHouse errors as retriable or fatal based on error codes
+ * extracted from exception messages.
+ *
+ * Fatal errors are deterministic — retrying the same batch will never succeed
+ * without external intervention (config change, schema fix, etc.).
+ * The connector should stop the task on fatal errors instead of retrying
+ * indefinitely, which blocks binlog advancement and causes silent data loss
+ * across all tables.
+ *
+ * @see <a href="https://github.com/Altinity/clickhouse-sink-connector/issues/1310">Issue #1310</a>
+ */
+public class ClickHouseErrorClassifier {
+
+    private static final Logger log = LogManager.getLogger(ClickHouseErrorClassifier.class);
+
+    /**
+     * Pattern to extract ClickHouse error codes from exception messages.
+     * ClickHouse errors follow the format: "Code: NNN. DB::Exception: ..."
+     */
+    private static final Pattern ERROR_CODE_PATTERN = Pattern.compile("Code:\\s*(\\d+)");
+
+    /**
+     * ClickHouse error codes that are fatal — retrying will never succeed.
+     *
+     * Sources:
+     * - https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp
+     */
+    private static final Set<Integer> FATAL_ERROR_CODES = new HashSet<>();
+
+    static {
+        // Authentication / authorization
+        FATAL_ERROR_CODES.add(516);  // AUTHENTICATION_FAILED
+        FATAL_ERROR_CODES.add(497);  // ACCESS_DENIED
+
+        // Schema / type mismatches
+        FATAL_ERROR_CODES.add(50);   // NUMBER_OF_COLUMNS_DOESNT_MATCH
+        FATAL_ERROR_CODES.add(53);   // TYPE_MISMATCH
+        FATAL_ERROR_CODES.add(60);   // UNKNOWN_TABLE
+        FATAL_ERROR_CODES.add(81);   // UNKNOWN_DATABASE
+        FATAL_ERROR_CODES.add(16);   // NO_SUCH_COLUMN_IN_TABLE
+
+        // Configuration / resource limits (deterministic for a given batch)
+        FATAL_ERROR_CODES.add(252);  // TOO_MANY_PARTS
+        FATAL_ERROR_CODES.add(241);  // MEMORY_LIMIT_EXCEEDED
+        FATAL_ERROR_CODES.add(396);  // TOO_MANY_PARTITIONS
+
+        // Data format errors
+        FATAL_ERROR_CODES.add(27);   // CANNOT_PARSE_TEXT
+        FATAL_ERROR_CODES.add(33);   // CANNOT_READ_ALL_DATA
+        FATAL_ERROR_CODES.add(69);   // ARGUMENT_OUT_OF_BOUND
+        FATAL_ERROR_CODES.add(349);  // INVALID_PARTITION_VALUE
+    }
+
+    public enum ErrorCategory {
+        /** Error is transient — retry may succeed (network, timeout, etc.) */
+        RETRIABLE,
+        /** Error is deterministic — retry will never succeed without intervention */
+        FATAL,
+        /** Could not determine error category — treat as retriable for safety */
+        UNKNOWN
+    }
+
+    /**
+     * Classify an exception based on the ClickHouse error code in its message.
+     *
+     * @param e the exception to classify
+     * @return the error category
+     */
+    public static ErrorCategory classify(Exception e) {
+        if (e == null) {
+            return ErrorCategory.UNKNOWN;
+        }
+
+        int errorCode = extractErrorCode(e);
+        if (errorCode < 0) {
+            // Could not parse error code — treat as retriable to avoid
+            // stopping on unexpected exception formats
+            return ErrorCategory.UNKNOWN;
+        }
+
+        if (FATAL_ERROR_CODES.contains(errorCode)) {
+            return ErrorCategory.FATAL;
+        }
+
+        return ErrorCategory.RETRIABLE;
+    }
+
+    /**
+     * Extract the ClickHouse error code from an exception's message chain.
+     * Checks both the exception message and its cause chain.
+     *
+     * @param e the exception
+     * @return the error code, or -1 if not found
+     */
+    public static int extractErrorCode(Exception e) {
+        // Check the exception and its cause chain
+        Throwable current = e;
+        while (current != null) {
+            String message = current.getMessage();
+            if (message != null) {
+                Matcher matcher = ERROR_CODE_PATTERN.matcher(message);
+                if (matcher.find()) {
+                    try {
+                        return Integer.parseInt(matcher.group(1));
+                    } catch (NumberFormatException nfe) {
+                        // Should not happen given the regex, but be safe
+                    }
+                }
+            }
+            current = current.getCause();
+        }
+        return -1;
+    }
+
+    /**
+     * Check if a given ClickHouse error code is classified as fatal.
+     *
+     * @param errorCode the ClickHouse error code
+     * @return true if the error is fatal
+     */
+    public static boolean isFatal(int errorCode) {
+        return FATAL_ERROR_CODES.contains(errorCode);
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseErrorClassifierTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseErrorClassifierTest.java
@@ -1,0 +1,156 @@
+package com.altinity.clickhouse.sink.connector.executor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link ClickHouseErrorClassifier}.
+ */
+public class ClickHouseErrorClassifierTest {
+
+    @Test
+    public void testExtractErrorCodeFromSimpleMessage() {
+        Exception e = new RuntimeException("Code: 252. DB::Exception: Too many parts (300).");
+        assertEquals(252, ClickHouseErrorClassifier.extractErrorCode(e));
+    }
+
+    @Test
+    public void testExtractErrorCodeFromCauseChain() {
+        Exception inner = new RuntimeException("Code: 516. DB::Exception: Authentication failed.");
+        Exception outer = new RuntimeException("ClickHouse write failed", inner);
+        assertEquals(516, ClickHouseErrorClassifier.extractErrorCode(outer));
+    }
+
+    @Test
+    public void testExtractErrorCodeNoCode() {
+        Exception e = new RuntimeException("Connection timeout");
+        assertEquals(-1, ClickHouseErrorClassifier.extractErrorCode(e));
+    }
+
+    @Test
+    public void testExtractErrorCodeNullException() {
+        assertEquals(-1, ClickHouseErrorClassifier.extractErrorCode(null));
+    }
+
+    @Test
+    public void testClassifyFatalTooManyParts() {
+        Exception e = new RuntimeException("Code: 252. DB::Exception: Too many parts (300). Merges are processing significantly slower than inserts.");
+        assertEquals(ClickHouseErrorClassifier.ErrorCategory.FATAL, ClickHouseErrorClassifier.classify(e));
+    }
+
+    @Test
+    public void testClassifyFatalAuthenticationFailed() {
+        Exception e = new RuntimeException("Code: 516. DB::Exception: Authentication failed: password is incorrect.");
+        assertEquals(ClickHouseErrorClassifier.ErrorCategory.FATAL, ClickHouseErrorClassifier.classify(e));
+    }
+
+    @Test
+    public void testClassifyFatalAccessDenied() {
+        Exception e = new RuntimeException("Code: 497. DB::Exception: Access denied.");
+        assertEquals(ClickHouseErrorClassifier.ErrorCategory.FATAL, ClickHouseErrorClassifier.classify(e));
+    }
+
+    @Test
+    public void testClassifyFatalUnknownTable() {
+        Exception e = new RuntimeException("Code: 60. DB::Exception: Table default.nonexistent doesn't exist.");
+        assertEquals(ClickHouseErrorClassifier.ErrorCategory.FATAL, ClickHouseErrorClassifier.classify(e));
+    }
+
+    @Test
+    public void testClassifyFatalUnknownDatabase() {
+        Exception e = new RuntimeException("Code: 81. DB::Exception: Database nodb doesn't exist.");
+        assertEquals(ClickHouseErrorClassifier.ErrorCategory.FATAL, ClickHouseErrorClassifier.classify(e));
+    }
+
+    @Test
+    public void testClassifyFatalTypeMismatch() {
+        Exception e = new RuntimeException("Code: 53. DB::Exception: Type mismatch in IN or VALUES section.");
+        assertEquals(ClickHouseErrorClassifier.ErrorCategory.FATAL, ClickHouseErrorClassifier.classify(e));
+    }
+
+    @Test
+    public void testClassifyFatalColumnCountMismatch() {
+        Exception e = new RuntimeException("Code: 50. DB::Exception: Number of columns doesn't match.");
+        assertEquals(ClickHouseErrorClassifier.ErrorCategory.FATAL, ClickHouseErrorClassifier.classify(e));
+    }
+
+    @Test
+    public void testClassifyFatalNoSuchColumn() {
+        Exception e = new RuntimeException("Code: 16. DB::Exception: No such column 'foo' in table.");
+        assertEquals(ClickHouseErrorClassifier.ErrorCategory.FATAL, ClickHouseErrorClassifier.classify(e));
+    }
+
+    @Test
+    public void testClassifyFatalMemoryLimitExceeded() {
+        Exception e = new RuntimeException("Code: 241. DB::Exception: Memory limit exceeded.");
+        assertEquals(ClickHouseErrorClassifier.ErrorCategory.FATAL, ClickHouseErrorClassifier.classify(e));
+    }
+
+    @Test
+    public void testClassifyFatalTooManyPartitions() {
+        Exception e = new RuntimeException("Code: 396. DB::Exception: Too many partitions.");
+        assertEquals(ClickHouseErrorClassifier.ErrorCategory.FATAL, ClickHouseErrorClassifier.classify(e));
+    }
+
+    @Test
+    public void testClassifyFatalCannotParseText() {
+        Exception e = new RuntimeException("Code: 27. DB::Exception: Cannot parse text.");
+        assertEquals(ClickHouseErrorClassifier.ErrorCategory.FATAL, ClickHouseErrorClassifier.classify(e));
+    }
+
+    @Test
+    public void testClassifyRetriableNetworkError() {
+        // Code 210 = NETWORK_ERROR, not in fatal set
+        Exception e = new RuntimeException("Code: 210. DB::NetException: Connection refused.");
+        assertEquals(ClickHouseErrorClassifier.ErrorCategory.RETRIABLE, ClickHouseErrorClassifier.classify(e));
+    }
+
+    @Test
+    public void testClassifyRetriableTimeout() {
+        // Code 159 = TIMEOUT_EXCEEDED, not in fatal set
+        Exception e = new RuntimeException("Code: 159. DB::Exception: Timeout exceeded.");
+        assertEquals(ClickHouseErrorClassifier.ErrorCategory.RETRIABLE, ClickHouseErrorClassifier.classify(e));
+    }
+
+    @Test
+    public void testClassifyUnknownNoCode() {
+        Exception e = new RuntimeException("Some random Java exception without ClickHouse error code");
+        assertEquals(ClickHouseErrorClassifier.ErrorCategory.UNKNOWN, ClickHouseErrorClassifier.classify(e));
+    }
+
+    @Test
+    public void testClassifyNull() {
+        assertEquals(ClickHouseErrorClassifier.ErrorCategory.UNKNOWN, ClickHouseErrorClassifier.classify(null));
+    }
+
+    @Test
+    public void testIsFatalTrue() {
+        assertTrue(ClickHouseErrorClassifier.isFatal(252));   // TOO_MANY_PARTS
+        assertTrue(ClickHouseErrorClassifier.isFatal(516));   // AUTHENTICATION_FAILED
+        assertTrue(ClickHouseErrorClassifier.isFatal(60));    // UNKNOWN_TABLE
+    }
+
+    @Test
+    public void testIsFatalFalse() {
+        assertFalse(ClickHouseErrorClassifier.isFatal(210));  // NETWORK_ERROR
+        assertFalse(ClickHouseErrorClassifier.isFatal(159));  // TIMEOUT_EXCEEDED
+        assertFalse(ClickHouseErrorClassifier.isFatal(999));  // Unknown code
+    }
+
+    @Test
+    public void testClassifyWrappedCause() {
+        // Fatal error buried in cause chain should still be detected
+        Exception inner = new RuntimeException("Code: 60. DB::Exception: Table doesn't exist.");
+        Exception mid = new RuntimeException("Insert batch failed", inner);
+        Exception outer = new RuntimeException("ClickHouseBatchRunnable error", mid);
+        assertEquals(ClickHouseErrorClassifier.ErrorCategory.FATAL, ClickHouseErrorClassifier.classify(outer));
+    }
+
+    @Test
+    public void testExtractErrorCodeMultipleCodesUsesFirst() {
+        // If exception has multiple "Code:" patterns, use the first one found
+        Exception e = new RuntimeException("Code: 60. DB::Exception: ... caused by Code: 210.");
+        assertEquals(60, ClickHouseErrorClassifier.extractErrorCode(e));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1310
Related: #1308

The ClickHouse Sink Connector silently swallows **all** exceptions thrown during batch processing in `ClickHouseBatchRunnable.run()`. When a ClickHouse write fails with a deterministic error (authentication failure, schema mismatch, too many parts, etc.), the connector:

1. Logs the error
2. Retains `currentBatch` (the failed batch stays in the retry variable)
3. On the next scheduled run, retries the exact same batch (`"***** RETRYING the same batch again"`)
4. The retry fails with the same deterministic error
5. Repeat forever

This infinite retry loop **blocks binlog position advancement**, causing **silent data loss across all tables** in the replication pipeline. New records arriving on Kafka are queued behind the permanently-stuck batch and never reach ClickHouse.

## Root Cause

In `ClickHouseBatchRunnable.run()` (line 308), the catch block swallows all exceptions without classification:

```java
} catch (Exception e) {
    log.error(...);
    // No rethrow. No stop. No classification.
    // currentBatch remains non-null, so it will be retried forever.
}
```

In `runLegacyMode()`, `currentBatch` is only cleared on success (`if (result) { currentBatch = null; }`), so failed batches are retried indefinitely.

## Fix

**New `ClickHouseErrorClassifier` utility** that classifies ClickHouse errors by error code:

- **FATAL** (will never succeed on retry):
  - Authentication/authorization: `AUTHENTICATION_FAILED` (516), `ACCESS_DENIED` (497)
  - Schema mismatches: `UNKNOWN_TABLE` (60), `UNKNOWN_DATABASE` (81), `NO_SUCH_COLUMN_IN_TABLE` (16), `TYPE_MISMATCH` (53), `NUMBER_OF_COLUMNS_DOESNT_MATCH` (50)
  - Resource limits: `TOO_MANY_PARTS` (252), `MEMORY_LIMIT_EXCEEDED` (241), `TOO_MANY_PARTITIONS` (396)
  - Data format: `CANNOT_PARSE_TEXT` (27), `CANNOT_READ_ALL_DATA` (33), `ARGUMENT_OUT_OF_BOUND` (69), `INVALID_PARTITION_VALUE` (349)

- **RETRIABLE** (transient, may succeed on retry):
  - Network errors, timeouts, and any unrecognized ClickHouse error code

**Modified `ClickHouseBatchRunnable.run()` catch block:**
- On **FATAL** error: log, clear `currentBatch`, rethrow to stop the executor
- On **RETRIABLE/UNKNOWN** error: log warning, allow normal retry behavior

## Files Changed

- **New:** `ClickHouseErrorClassifier.java` — error code extraction and classification
- **Modified:** `ClickHouseBatchRunnable.java` — catch block uses classifier to stop on fatal errors
- **New:** `ClickHouseErrorClassifierTest.java` — 20 unit tests covering all classified codes, cause chain traversal, edge cases

## Testing

The new `ClickHouseErrorClassifierTest` covers:
- Error code extraction from simple messages and nested cause chains
- All fatal error codes (auth, schema, resource, data format)
- Retriable errors (network, timeout)
- Edge cases (null exception, no error code, deeply nested causes)
