### PR TITLE
Fix sink-connector unit tests under clickhouse-jdbc 0.9.x (jdbc-v2)

### DIFF
--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DbKafkaOffsetWriter.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DbKafkaOffsetWriter.java
@@ -68,7 +68,7 @@ public class DbKafkaOffsetWriter extends BaseDbWriter {
                         this.getConnection(),
                         database
                 );
-        this.query = new QueryFormatter().getInsertQueryUsingInputFunction(
+        this.query = new QueryFormatter().getInsertQuery(
                 tableName, columnNamesToDataTypesMap
         );
     }

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/QueryFormatter.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/QueryFormatter.java
@@ -150,8 +150,16 @@ public class QueryFormatter {
         if (upperDataType.contains("DATETIME64")) {
             // Extract precision from DateTime64(precision) or DateTime64(precision, 'timezone')
             String precision = extractDateTime64Precision(dataType);
+            String timeZone = extractTimeZone(dataType);
+            if (timeZone != null) {
+                return "toDateTime64(?, " + precision + ", '" + timeZone + "')";
+            }
             return "toDateTime64(?, " + precision + ")";
         } else if (upperDataType.contains("DATETIME")) {
+            String timeZone = extractTimeZone(dataType);
+            if (timeZone != null) {
+                return "toDateTime(?, '" + timeZone + "')";
+            }
             return "toDateTime(?)";
         } else if (upperDataType.contains("DATE32")) {
             return "toDate32(?)";
@@ -185,6 +193,25 @@ public class QueryFormatter {
             return "3"; // Default precision
         }
         return dataType.substring(start + 1, end).trim();
+    }
+
+    /**
+     * Extracts the timezone from a DateTime/DateTime64 data type, e.g.
+     * "DateTime64(0, 'UTC')" or "DateTime('America/Chicago')".
+     *
+     * @param dataType the data type string
+     * @return the timezone, or null if the type does not carry one
+     */
+    private String extractTimeZone(String dataType) {
+        int start = dataType.indexOf('\'');
+        if (start == -1) {
+            return null;
+        }
+        int end = dataType.indexOf('\'', start + 1);
+        if (end == -1) {
+            return null;
+        }
+        return dataType.substring(start + 1, end);
     }
 
     /**
@@ -339,35 +366,39 @@ public class QueryFormatter {
     }
 
     /**
-     * Generates an INSERT SQL query using input functions for the specified table and columns.
+     * Generates a parameterized INSERT SQL query for the specified table and columns.
      * <p>
-     * This method constructs an INSERT query based on the provided column names and data types.
+     * Parameters are bound positionally in the iteration order of the supplied map.
+     * The query uses explicit {@code ?} placeholders instead of the
+     * {@code select ... from input('...')} form: clickhouse-jdbc 0.6.x special-cased
+     * parameter binding for input() statements, but the 0.9.x (jdbc-v2) driver
+     * derives parameters from {@code ?} placeholders only, so an input()-based
+     * statement has zero bindable parameters and any setXxx() call fails with
+     * ArrayIndexOutOfBoundsException (see ClickHouse/clickhouse-java#2726).
      * </p>
      *
      * @param tableName               the name of the ClickHouse table.
      * @param columnNameToDataTypeMap a map of column names to their corresponding data types.
      * @return the generated INSERT SQL query.
      */
-    public String getInsertQueryUsingInputFunction(String tableName, Map<String, String> columnNameToDataTypeMap) {
+    public String getInsertQuery(String tableName, Map<String, String> columnNameToDataTypeMap) {
         StringBuilder colNamesDelimited = new StringBuilder();
-        StringBuilder colNamesToDataTypes = new StringBuilder();
+        StringBuilder placeholders = new StringBuilder();
 
         // Loop over each column to generate the insert query
         for (Map.Entry<String, String> entry : columnNameToDataTypeMap.entrySet()) {
             String columnName = "`" + entry.getKey() + "`";
             colNamesDelimited.append(columnName).append(",");
-            // Escape single quotes in data types (e.g., DateTime64(3, 'UTC') -> DateTime64(3, ''UTC''))
-            String escapedDataType = ClickHouseUtils.escape(entry.getValue(), '\'');
-            colNamesToDataTypes.append(columnName).append(" ").append(escapedDataType).append(",");
+            placeholders.append(formatParameterPlaceholder(entry.getValue())).append(",");
         }
 
         // Remove the terminating commas
         removeTrailingComma(colNamesDelimited);
-        removeTrailingComma(colNamesToDataTypes);
+        removeTrailingComma(placeholders);
 
         // Construct the full insert query
         String tableWithBackTicks = "`" + tableName + "`";
-        return String.format("insert into %s select %s from input('%s')", tableWithBackTicks, colNamesDelimited, colNamesToDataTypes);
+        return String.format("insert into %s(%s) values (%s)", tableWithBackTicks, colNamesDelimited, placeholders);
     }
 
     /**

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/history/BinLogHistory.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/history/BinLogHistory.java
@@ -175,7 +175,7 @@ public class BinLogHistory {
         Map<String, String> columnToDataTypeMap = this.getColumnToDataTypeMap();
 
         // Generate insert query using QueryFormatter
-        String insertQuery = queryFormatter.getInsertQueryUsingInputFunction(historyTableName, columnToDataTypeMap);
+        String insertQuery = queryFormatter.getInsertQuery(historyTableName, columnToDataTypeMap);
 
         this.executeInsertWithStructs(config, conn, insertQuery, DDL, currentBatch, sourceTimeZone, serverTimeZone);
     }

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DbWriterTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DbWriterTest.java
@@ -130,10 +130,14 @@ public class DbWriterTest {
                 BaseDbWriter.SYSTEM_DB, new ClickHouseSinkConnectorConfig(new HashMap<>()));
         DbWriter writer2 = new DbWriter(dbHostName, port, database2, tableName, userName, password,
                 sinkConnectorConfig, null, conn2);
-        Map<String, String> columnDataTypesMap2 = metadata.getColumnsDataTypesForTable(conn, "employees", "employees");
+        Map<String, String> columnDataTypesMap2 = metadata.getColumnsDataTypesForTable(conn2, "employees", "employees2");
 
+        // employees2.employees has exactly 2 columns (emp1, _version_employees).
+        // clickhouse-jdbc 0.6.x ignored the schemaPattern argument and returned
+        // matching tables from every database (44 unique column names across the
+        // four employees tables); the 0.9.x driver filters by database correctly.
         Assert.assertTrue(columnDataTypesMap2.isEmpty() == false);
-        Assert.assertTrue(columnDataTypesMap2.size() ==44);
+        Assert.assertTrue(columnDataTypesMap2.size() == 2);
 
     }
 

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/operations/ClickHouseCreateDatabaseTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/operations/ClickHouseCreateDatabaseTest.java
@@ -39,6 +39,12 @@ public class ClickHouseCreateDatabaseTest {
             .waitingFor(new HttpWaitStrategy().forPort(8123));
     @BeforeAll
     static void initialize() throws Exception {
+        // Defensive: earlier test classes may have seeded the static
+        // HikariDbSource cache with a "system" pool pointing at config-default
+        // localhost:8123 (lazy connect under jdbc-v2 caches dead pools).
+        // Clear it so createConnection below builds a pool against the
+        // testcontainer instead of reusing a stale one.
+        HikariDbSource.close();
         clickHouseContainer.start();
 
         String hostName = clickHouseContainer.getHost();

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchRunnableTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchRunnableTest.java
@@ -2,12 +2,14 @@ package com.altinity.clickhouse.sink.connector.executor;
 
 import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
 import com.altinity.clickhouse.sink.connector.converters.ClickHouseConverter;
+import com.altinity.clickhouse.sink.connector.db.HikariDbSource;
 import com.altinity.clickhouse.sink.connector.model.ClickHouseStruct;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -23,6 +25,16 @@ public class ClickHouseBatchRunnableTest {
 
     LinkedBlockingQueue<List<ClickHouseStruct>> records = new LinkedBlockingQueue<>();
     Map<String, String> topic2TableMap = new HashMap<>();
+
+    @AfterAll
+    public static void cleanup() {
+        // The ClickHouseBatchRunnable constructor creates a "system" connection
+        // pool from config defaults (localhost:8123). With the jdbc-v2 driver,
+        // connection creation is lazy, so this dead pool gets cached in the
+        // static HikariDbSource map and poisons later containerized tests that
+        // look up pools by database name. Clear it.
+        HikariDbSource.close();
+    }
 
     @Before
     public void initTest() {


### PR DESCRIPTION
## Summary

Fixes the three java-tests-kafka failures on this branch (latest red run: 26858361419). Full `sink-connector` suite is green locally with these changes: `Tests run: 91, Failures: 0, Errors: 0, Skipped: 1`.

- **DbKafkaOffsetWriterTest / BinLogHistory — `ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0`.** The 0.6.x driver special-cased parameter binding for `insert into t select ... from input('schema')` statements. jdbc-v2 derives parameters from `?` placeholders only, so the input() form has zero bindable parameters and the first `setString()` throws (upstream: ClickHouse/clickhouse-java#2726). Replaced the map-based `getInsertQueryUsingInputFunction` overload with a parameterized `insert into t(cols) values (?, ...)` builder. To keep timestamp semantics identical to input(), the placeholder carries the column's declared timezone when present, e.g. `DateTime64(0, 'UTC')` → `toDateTime64(?, 0, 'UTC')` — a bare `toDateTime64(?, 0)` would parse bound strings in server tz instead. The batch-insert path (`MutablePair` overload + `GroupInsertQueryWithBatchRecords`) is still input()-based and not touched here; it has the same v2 incompatibility and probably wants its own pass once clickhouse-java#2726 settles.
- **DbWriterTest.testGetColumnsDataTypesForTable expected 44 columns.** 0.6.x `getColumns` ignored the schemaPattern argument and returned matching tables from every database, so the old expectation counted columns bled from four `employees` tables across databases. 0.9.x filters by database correctly. Pointed the assertion at `employees2.employees` and its actual 2 columns. Verified A/B against the same server: 0.6.0 returns 44 rows for this call, 0.9.8 returns 2.
- **ClickHouseCreateDatabaseTest — `Connection is closed` (passes in isolation, fails in the full run).** `HikariDbSource.instance` is a static map keyed only by database name. `ClickHouseBatchRunnableTest` constructs a `ClickHouseBatchRunnable`, whose constructor creates a `system` connection from config defaults (`localhost:8123`). Under 0.6.x connection creation was eager, so that pool failed at creation and was never cached; jdbc-v2 connects lazily, so the dead pool caches successfully. ClickHouseCreateDatabaseTest then gets the stale `system` pool back from `getInstance` (which ignores the fresh testcontainer dataSource when the key exists), every query dials localhost:8123, and the 10-retry loop in `getAliasAndMaterializedColumnsForTableAndDatabase` burns ~58s before failing. Bisected the suite to confirm the polluter, and the pair `ClickHouseBatchRunnableTest,ClickHouseCreateDatabaseTest` reproduces it alone. Fixed on both ends: `@AfterAll HikariDbSource.close()` in the polluter (matching DbWriterTest/DBMetadataTest precedent) and a defensive `close()` at the top of ClickHouseCreateDatabaseTest's `@BeforeAll`, since in CI the class order differs and any earlier class can seed the cache.

Also verified the driver upgrade itself against ClickHouse 25.11.9.34: 0.6.0 fails the handshake with `Magic is not correct` (#1214), 0.9.8 connects and inserts fine.