### PR TITLE
fix: wait for ALTER TABLE visibility before cache invalidation (#1222)

### DIFF
--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
@@ -665,7 +665,11 @@ public class DebeziumChangeEventCapture {
     private void executeDDL(String clickHouseQuery, BaseDbWriter writer, ClickHouseSinkConnectorConfig config) throws SQLException {
         ClickHouseAlterTable cat = new ClickHouseAlterTable();
         DBMetadata dbMetadata = new DBMetadata(config);
-        DDLSchemaChangeWaiter schemaWaiter = new DDLSchemaChangeWaiter();
+        long schemaChangeTimeoutMs = config.getLong(
+                ClickHouseSinkConnectorConfigVariables.DDL_SCHEMA_CHANGE_TIMEOUT_MS.toString());
+        long schemaChangePollIntervalMs = config.getLong(
+                ClickHouseSinkConnectorConfigVariables.DDL_SCHEMA_CHANGE_POLL_INTERVAL_MS.toString());
+        DDLSchemaChangeWaiter schemaWaiter = new DDLSchemaChangeWaiter(schemaChangeTimeoutMs, schemaChangePollIntervalMs);
         String[] queries = clickHouseQuery.replaceAll(",$", "").split("\n");
         for (String query : queries) {
             if (!query.isEmpty()) {

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
@@ -10,6 +10,7 @@ import com.altinity.clickhouse.sink.connector.common.Metrics;
 import com.altinity.clickhouse.sink.connector.converters.ClickHouseConverter;
 import com.altinity.clickhouse.sink.connector.db.BaseDbWriter;
 import com.altinity.clickhouse.sink.connector.db.CacheInvalidationManager;
+import com.altinity.clickhouse.sink.connector.db.DDLSchemaChangeWaiter;
 import com.altinity.clickhouse.sink.connector.db.DBMetadata;
 import com.altinity.clickhouse.sink.connector.db.ErrorLogger;
 import com.altinity.clickhouse.sink.connector.db.operations.ClickHouseAlterTable;
@@ -664,11 +665,18 @@ public class DebeziumChangeEventCapture {
     private void executeDDL(String clickHouseQuery, BaseDbWriter writer, ClickHouseSinkConnectorConfig config) throws SQLException {
         ClickHouseAlterTable cat = new ClickHouseAlterTable();
         DBMetadata dbMetadata = new DBMetadata(config);
+        DDLSchemaChangeWaiter schemaWaiter = new DDLSchemaChangeWaiter();
         String[] queries = clickHouseQuery.replaceAll(",$", "").split("\n");
         for (String query : queries) {
             if (!query.isEmpty()) {
                 log.info("ClickHouse DDL: " + query);
                 dbMetadata.executeSystemQuery(writer.getConnection(), query);
+                // Wait for schema change to become visible in system.columns
+                // before cache invalidation proceeds. Without this, the batch
+                // insert thread may rebuild its column metadata cache before
+                // the ALTER TABLE has propagated, silently dropping values
+                // for newly added columns. See GitHub issue #1222.
+                schemaWaiter.waitForSchemaVisibility(writer.getConnection(), query);
             }
         }
     }

--- a/sink-connector/python/db_compare/top_level_table_checksum.py
+++ b/sink-connector/python/db_compare/top_level_table_checksum.py
@@ -33,13 +33,14 @@ def validate_config(config):
         # Check source section
         source = config['source']
         mysql = source['mysql']
-        host = mysql['host'] 
+        host = mysql['host']
         # Check replicas section
+
         replicas = config['replicas']
         if not isinstance(replicas, list):
             logging.error("Error: 'replicas' must be a list")
             return False
-            
+
         for i, replica in enumerate(replicas):
             if 'clickhouse' not in replica:
                 logging.error(f"Error: 'clickhouse' missing in replica {i+1}")
@@ -47,7 +48,7 @@ def validate_config(config):
             if 'host' not in replica['clickhouse']:
                 logging.error(f"Error: 'host' missing in replica {i+1}")
                 return False
-                
+
         return True
     except KeyError as e:
         logging.error(f"Error: Missing required configuration key: {e}")
@@ -63,16 +64,16 @@ def parse_checksum(data, table):
     row_count = None
     if len(parts) == 3:
         # Extract the three values
-        table = parts[0]      
-        checksum = parts[1]   
-        row_count = int(parts[2]) 
+        table = parts[0]
+        checksum = parts[1]
+        row_count = int(parts[2])
     else:
         logging.error(f"Invalid checksum output from {data} for table {table}")
     return (table, checksum, row_count)
 
 
 def run_quick_safe_checksum(cmd, host, table):
-    start = time.perf_counter()    
+    start = time.perf_counter()
     (rc, stdout) = run_quick_safe_command(cmd)
     duration = time.perf_counter() - start
     if rc == '0':
@@ -82,12 +83,12 @@ def run_quick_safe_checksum(cmd, host, table):
     else:
         logging.error(f"{cmd}. failed")
         return None
-    
 
-def compute_checksum (mysql_database, database_override_map, table_overrides_map,  table, mysql_user, mysql_password, mysql_host, replica_hosts, pk, max_pk, where, ignored_columns=[], debug_output=False, defaults_file=None, partition_key = None):
+
+
+def compute_checksum (mysql_database, database_override_map, table_overrides_map,  table, mysql_user, mysql_password, mysql_host, replica_hosts, pk, max_pk, where, ignored_columns=[], debug_output=False, defaults_file=None, partition_key = None, lock_enabled=False, sleep_after_lock=3, mysql_port=3306):
     table_name = f"{mysql_database}.{table}"
     logging.info(f"Checksumming {table_name}")
-    commands = []
     if table_name in table_overrides_map and 'where' in table_overrides_map[table_name]:
         if where is None:
             where =''
@@ -95,10 +96,12 @@ def compute_checksum (mysql_database, database_override_map, table_overrides_map
             where+= " and "
         logging.info(f"Where override found for {table_name}")
         where+= table_overrides_map[table_name]['where']
-    cmd = get_mysql_checksum_command(mysql_host, mysql_database, table, pk, max_pk, where=where, ignored_columns=ignored_columns, debug_output=debug_output, defaults_file=defaults_file)
-   
-    commands.append((mysql_host,cmd))
-    
+
+    # Build MySQL checksum command
+    mysql_cmd = get_mysql_checksum_command(mysql_host, mysql_database, table, pk, max_pk, where=where, ignored_columns=ignored_columns, debug_output=debug_output, defaults_file=defaults_file)
+
+    # Build ClickHouse checksum commands
+    ch_commands = []
     for ch_host in replica_hosts:
         ch_database = mysql_database
         if ch_host in database_override_map and mysql_database in database_override_map[ch_host]:
@@ -111,20 +114,48 @@ def compute_checksum (mysql_database, database_override_map, table_overrides_map
                     break
             logging.info(f"Overriding database for host {ch_host} from {mysql_database} to {ch_database}")
         cmd = get_clickhouse_checksum_command(ch_host, ch_database, table, pk, max_pk, where=where, ignored_columns=ignored_columns, debug_output=debug_output, partition_key = partition_key)
-        commands.append((ch_host, cmd))
-    results = []    
-    with concurrent.futures.ThreadPoolExecutor(max_workers=len(commands)) as executor:
-            futures = []
-            for (host, cmd) in commands:
-                future = executor.submit(
-                    run_quick_safe_checksum, cmd, host, table)
-                futures.append(future)
+        ch_commands.append((ch_host, cmd))
+
+    # Lock held during all checksums (MySQL source + ClickHouse replicas)
+    # to ensure a consistent comparison. The sleep_after_lock allows
+    # replication lag to settle before checksumming — unlocking early would
+    # let new writes reach ClickHouse and invalidate the comparison.
+    lock_conn = None
+    try:
+        if lock_enabled:
+            lock_conn = get_mysql_connection(mysql_host, mysql_user,
+                                             mysql_password, mysql_port, mysql_database)
+            logging.info(f"Locking table {table} on source {mysql_host}")
+            lock_tables(lock_conn, table)
+            time.sleep(sleep_after_lock)
+
+        # Run the MySQL source checksum and all ClickHouse replica checksums
+        # concurrently under the lock. The lock keeps the source frozen so
+        # every checksum sees the same snapshot; running them in parallel
+        # (instead of MySQL-first-then-ClickHouse) minimizes how long the
+        # lock must be held — the lock duration becomes the slowest single
+        # checksum rather than the sum of MySQL + ClickHouse.
+        all_commands = [(mysql_host, mysql_cmd)] + ch_commands
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(all_commands)) as executor:
+            futures = [
+                executor.submit(run_quick_safe_checksum, cmd, host, table)
+                for (host, cmd) in all_commands
+            ]
+            # Surface the first exception, if any, so the caller can react.
             for future in concurrent.futures.as_completed(futures):
                 if future.exception() is not None:
                     raise future.exception()
-                else:
-                    results.append(future.result())
-    return results
+            # Results in submission order: MySQL source first, then replicas
+            # (analyze_differences relies on the source being identifiable).
+
+            results = [future.result() for future in futures]
+        return results
+    finally:
+        if lock_conn:
+            try:
+                unlock_tables(lock_conn, table)
+            finally:
+                close_connection(lock_conn, table_name)
 
 
 def get_tables_from_regexp(conn, database, tables_regexp):
@@ -139,48 +170,50 @@ def get_mysql_checksum_command(mysql_host, database, table, pk, max_pk, where, i
     if partition_date:
       where_argument += f""" and {{partition_expression}}={partition_date:%Y%m%d}"""
     where_argument += '"'
-    
+
     ignored_columns_clause = ""
     if len(ignored_columns) > 0:
         logging.info(f"Ignoring columns {ignored_columns} for table {table}")
         ignored_columns_clause = "--exclude_columns "+",".join(ignored_columns)
-        
+
     debug_output_clause = ""
     if debug_output:
         debug_output_clause = "--debug_output"
-    
+
     defaults_file_clause = ""
     if defaults_file:
         defaults_file_clause = f"--defaults_file={defaults_file}"
-    cmd = f"""set -e pipefail;python db_compare/mysql_table_checksum.py --threads_per_table {args.threads_per_table} --threads={args.threads} --min_date_value "1900-01-01" --mysql_host {mysql_host} --mysql_database {database} --tables_regex "^{table}$" {where_argument} --min_datetime_value "1969-12-31 18:00:00"  --max_datetime_value "2299-12-31 00:00:00"  --binary_encoding base64 {ignored_columns_clause} {debug_output_clause} {defaults_file_clause} | grep -i checksum | awk '{{print $11" "$13" "$15}}' """ 
+    cmd = f"""set -e pipefail;python db_compare/mysql_table_checksum.py --threads_per_table {args.threads_per_table} --threads={args.threads} --min_date_value "1900-01-01" --mysql_host {mysql_host} --mysql_database {database} --tables_regex "^{table}$" {where_argument} --min_datetime_value "1969-12-31 18:00:00"  --max_datetime_value "2299-12-31 00:00:00"  --binary_encoding base64 {ignored_columns_clause} {debug_output_clause} {defaults_file_clause} | grep -i checksum | awk '{{print $11" "$13" "$15}}' """
     logging.debug(f"MySQL command: {cmd}")
-    return cmd 
+    return cmd
+
 
 
 def get_clickhouse_checksum_command(ch_host, database, table, pk, max_pk, where=None, ignored_columns=[], debug_output=False, partition_key = None):
-    partition_date = args.partition_date   
+    partition_date = args.partition_date
     where_argument = '--where " 1=1 '
     if where:
         where_argument += f" and {where} "
     if partition_date:
       where_argument += f""" and {{partition_expression}}="""+f"""toDate(\\\\'{partition_date:%Y-%m-%d}\\\\') """
 
+
     where_argument += '"'
-    
+
     ignored_columns_clause = "--exclude_columns _version,is_deleted,_is_deleted,__is_deleted"
     if len(ignored_columns) > 0:
         logging.info(f"Ignoring columns {ignored_columns} for table {table}")
         ignored_columns_clause += ","+",".join(ignored_columns)
-    
+
     debug_output_clause = ""
     if debug_output:
         debug_output_clause = "--debug_output"
-        
+
     partition_key_clause = ""
     if partition_key:
         partition_key_clause = f" --partition_key {partition_key.replace('`','')}"
-    cmd = f"""set -e pipefail;python db_compare/clickhouse_table_checksum.py --max_memory_usage 80000000000 --threads={args.threads} --clickhouse_host {ch_host} --clickhouse_database  {database}  --tables_regex "^{table}$" {where_argument}  --min_datetime_value "1969-12-31 18:00:00"  --max_datetime_value "2299-12-31 00:00:00" {ignored_columns_clause} --sign_column "" {debug_output_clause} {partition_key_clause} | grep -i checksum | awk '{{print $11" "$13" "$15}}' """ 
-    return cmd 
+    cmd = f"""set -e pipefail;python db_compare/clickhouse_table_checksum.py --max_memory_usage 80000000000 --threads={args.threads} --clickhouse_host {ch_host} --clickhouse_database  {database}  --tables_regex "^{table}$" {where_argument}  --min_datetime_value "1969-12-31 18:00:00"  --max_datetime_value "2299-12-31 00:00:00" {ignored_columns_clause} --sign_column "" {debug_output_clause} {partition_key_clause} | grep -i checksum | awk '{{print $11" "$13" "$15}}' """
+    return cmd
 
 
 def analyze_differences(results, mysql_host, replica_hosts):
@@ -196,34 +229,42 @@ def analyze_differences(results, mysql_host, replica_hosts):
                 is_difference = True
         if not is_difference:
             logging.info(f"No difference for {source_results[0][1]}")
-   
-    
+
+
 def lock_tables(conn, table):
     lock_stmt = f"FLUSH TABLE `{table}` WITH READ LOCK"
     logging.info(f"Locking table with statement {lock_stmt}")
     execute_mysql(conn, lock_stmt)
-    
-    
+
+
 def unlock_tables(conn, table):
     unlock_stmt = "UNLOCK TABLES"
     logging.info(f"Unlocking table {table} with statement {unlock_stmt}")
     execute_mysql(conn, unlock_stmt)
 
+
+def close_connection(conn, table_name):
+    """Safely close a MySQL connection."""
+    try:
+        conn.close()
+    except Exception as e:
+        logging.warning(f"Failed to close connection for {table_name}: {e}")
+
 def match_table_include_list(database, table, table_include_list):
     """
     Check if a table matches any regex pattern in the include list.
-    
+
     Args:
         database: The database name
         table: The table object or dict with 'table_name' key
         table_include_list: List of regex patterns for table names in format "database.table"
-    
+
     Returns:
         True if the table matches any pattern in the include list, False otherwise
     """
     table_name = table['table_name'] if isinstance(table, dict) else table
     full_table_name = f"{database}.{table_name}"
-    
+
     for pattern in table_include_list:
         try:
             rex = re.compile(pattern.strip())
@@ -232,51 +273,51 @@ def match_table_include_list(database, table, table_include_list):
         except re.error as e:
             logging.error(f"Invalid regex pattern '{pattern}': {e}")
             continue
-    
+
     return False
 
 def run_config(config):
     """Display the parsed configuration."""
     logging.info("\nConfiguration Details:")
-    
+
     mysql_host = config['source']['mysql']['host']
     logging.info(f"Source MySQL Host: {mysql_host}")
-    
+
     replica_hosts = []
     database_override_map = {}
     mysql_table_include_list = None
-    
+
     if "table_include_list" in  config['source']['mysql']:
             mysql_table_include_list = config['source']['mysql']['table_include_list'].split(',')
-    
+
     for i, replica in enumerate(config['replicas']):
         replica_hosts.append(replica['clickhouse']['host'])
         if "database_override_map" in replica['clickhouse']:
             database_override_map[replica['clickhouse']['host']] = replica['clickhouse']['database_override_map']
-            
-   
+
+
     logging.info(f"\nFound {len( config['replicas'])} ClickHouse replicas: {replica_hosts}")
-    
+
     mysql_user = args.mysql_user
     config_file = args.defaults_file
     (mysql_user, mysql_password) = resolve_credentials_from_config(config_file)
 
     database = args.mysql_database
     databases = []
-    if not database:    
+    if not database:
         databases = config['source']['mysql']['databases'] if 'databases' in config['source']['mysql'] else []
         if len(databases) == 0:
             logging.error("If not specifying --mysql_database, there must at least one database in the config file under mysql:databases")
             sys.exit(1)
-        logging.info(f"Using MySQL databases: {databases}") 
+        logging.info(f"Using MySQL databases: {databases}")
     else:
-        databases = [database]  
-    
+        databases = [database]
+
     ignored_columns = config['source']['mysql']['ignored_columns'] if 'ignored_columns' in config['source']['mysql'] else []
     ignored_columns_map = {}
     for ignored_column in ignored_columns:
         logging.info(f"Ignoring column {ignored_column}")
-        ignored_columns_split = ignored_column.split('.')  
+        ignored_columns_split = ignored_column.split('.')
         db = ignored_columns_split[0]
         table = ignored_columns_split[1]
         col = ignored_columns_split[2]
@@ -304,23 +345,15 @@ def run_config(config):
             with concurrent.futures.ThreadPoolExecutor(max_workers=args.threads) as executor:
                 futures = []
                 future_to_table = {}
-                future_to_conn = {}
-                table_include_list = [t for t in mysql_table_include_list if t.startswith(f"{database}.")] if mysql_table_include_list else [] 
+                table_include_list = [t for t in mysql_table_include_list if t.startswith(f"{database}.")] if mysql_table_include_list else []
                 for table_row in tables.fetchall():
                     table = table_row['table_name']
                     table_name = f"{database}.{table}"
-                    if len(table_include_list)>0 and not match_table_include_list(database, table, table_include_list):  
+                    if len(table_include_list)>0 and not match_table_include_list(database, table, table_include_list):
                         logging.info(f"Skipping table {database}.{table} since not in include list")
                         continue
-                    if args.lock_tables_on_source:
-                        # we need a new connection for each table since the lock is per connection
-                        conn = get_mysql_connection(mysql_host, mysql_user,
-                                    mysql_password, args.mysql_port, database)
-                        logging.info(f"Locking table {table} on source {mysql_host}")
-                        lock_tables(conn, table)
-                        time.sleep(args.sleep_after_lock)  # slight delay for the sink-connector to catch up
-                        future_to_conn[table_name] = conn
-                        
+
+                    # Pre-fetch metadata on shared connection (no lock needed)
                     pk = mysql_pk_columns(conn, database, table)
                     pk_column = pk[0] if len(pk) > 0 else 'NULL'
                     (min_pk, max_pk) = get_min_max_pk_value(conn, table, pk_column, '1=1')
@@ -328,25 +361,23 @@ def run_config(config):
                     ignored_columns = []
                     if database in ignored_columns_map and table in ignored_columns_map[database]:
                         ignored_columns = list(ignored_columns_map[database][table].keys())
-                        
+
                     logging.info(f"Ignored columns for table {table_name}: {ignored_columns}")
+                    # Lock lifecycle is now managed inside compute_checksum per table.
+                    # Each future acquires its own lock, runs both MySQL and
+                    # ClickHouse checksums under the lock, then releases it.
                     future = executor.submit(
-                        compute_checksum, database, database_override_map, table_overrides_map, table, mysql_user, mysql_password, mysql_host, replica_hosts, pk_column, max_pk, args.where, ignored_columns = ignored_columns, debug_output = args.debug_output, defaults_file=args.defaults_file, partition_key = partition_key)
+                        compute_checksum, database, database_override_map, table_overrides_map, table, mysql_user, mysql_password, mysql_host, replica_hosts, pk_column, max_pk, args.where, ignored_columns = ignored_columns, debug_output = args.debug_output, defaults_file=args.defaults_file, partition_key = partition_key, lock_enabled=args.lock_tables_on_source, sleep_after_lock=args.sleep_after_lock, mysql_port=args.mysql_port)
                     futures.append(future)
                     future_to_table[future] = table_name
                 for future in concurrent.futures.as_completed(futures):
-                    conn =  future_to_conn.get(future_to_table[future], None)
                     table_name = future_to_table[future]
                     if future.exception() is not None:
                         logging.error("Exception in table " + table_name)
                         logging.error(future.exception())
-                        if conn:
-                            unlock_tables(conn, table_name)
                         raise future.exception()
                     else:
-                        if conn:
-                            unlock_tables(conn, table_name)
-                        analyze_differences(future.result(), mysql_host, replica_hosts)      
+                        analyze_differences(future.result(), mysql_host, replica_hosts)
 
         except (KeyboardInterrupt, SystemExit):
             logging.info("Received interrupt")
@@ -358,7 +389,7 @@ def run_config(config):
 
     logging.debug("Exiting Main Thread")
     sys.exit(0)
-    
+
 def run_quick_safe_command(cmd):
     logging.debug("cmd " + cmd)
     process = subprocess.Popen(cmd,
@@ -439,7 +470,7 @@ def main():
     parser.add_argument('--lock_tables_on_source', action='store_true', default=False,
                         help='Lock the table on the source so that source and target are in sync ...', required=False)
     parser.add_argument('--sleep_after_lock', type=int, help='When locking, sleeping n seconds', default=3)
-    
+
     global args
     args = parser.parse_args()
 
@@ -457,10 +488,10 @@ def main():
     if args.debug:
         root.setLevel(logging.DEBUG)
         handler.setLevel(logging.DEBUG)
-        
+
     # Parse the configuration file
     config = parse_config(args.config_file)
-    
+
     # Validate the configuration
     if validate_config(config):
         logging.info("Configuration is valid.")

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/ClickHouseSinkConnectorConfig.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/ClickHouseSinkConnectorConfig.java
@@ -809,6 +809,28 @@ public class ClickHouseSinkConnectorConfig extends AbstractConfig {
                         ClickHouseSinkConnectorConfigVariables.REPLICATION_HISTORY_REPLICATION_LOG_ONLY.toString()
                 )
                 .define(
+                        ClickHouseSinkConnectorConfigVariables.DDL_SCHEMA_CHANGE_TIMEOUT_MS.toString(),
+                        Type.LONG,
+                        30000L,
+                        Importance.LOW,
+                        "Maximum time in milliseconds to wait for ALTER TABLE schema changes to become visible in system.columns before proceeding. Prevents race conditions where the batch insert thread reads stale column metadata after DDL execution.",
+                        CONFIG_GROUP_CONNECTOR_CONFIG,
+                        ORDER_3,
+                        ConfigDef.Width.NONE,
+                        ClickHouseSinkConnectorConfigVariables.DDL_SCHEMA_CHANGE_TIMEOUT_MS.toString()
+                )
+                .define(
+                        ClickHouseSinkConnectorConfigVariables.DDL_SCHEMA_CHANGE_POLL_INTERVAL_MS.toString(),
+                        Type.LONG,
+                        100L,
+                        Importance.LOW,
+                        "Polling interval in milliseconds between checks of system.columns when waiting for ALTER TABLE schema changes to become visible.",
+                        CONFIG_GROUP_CONNECTOR_CONFIG,
+                        ORDER_3,
+                        ConfigDef.Width.NONE,
+                        ClickHouseSinkConnectorConfigVariables.DDL_SCHEMA_CHANGE_POLL_INTERVAL_MS.toString()
+                )
+                .define(
                         ClickHouseSinkConnectorConfigVariables.DATABASE_HOSTNAME.toString(),
                         Type.STRING,
                         "",

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/ClickHouseSinkConnectorConfigVariables.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/ClickHouseSinkConnectorConfigVariables.java
@@ -106,6 +106,10 @@ public enum ClickHouseSinkConnectorConfigVariables {
 
     REPLICATION_HISTORY_REPLICATION_LOG_ONLY("replication.history.replication_log_only"),
 
+    DDL_SCHEMA_CHANGE_TIMEOUT_MS("ddl.schema.change.timeout.ms"),
+
+    DDL_SCHEMA_CHANGE_POLL_INTERVAL_MS("ddl.schema.change.poll.interval.ms"),
+
     DATABASE_HOSTNAME("database.hostname");
 
 

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DDLSchemaChangeWaiter.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DDLSchemaChangeWaiter.java
@@ -1,0 +1,242 @@
+package com.altinity.clickhouse.sink.connector.db;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utility that waits for DDL schema changes (ALTER TABLE ADD/DROP COLUMN)
+ * to become visible in ClickHouse's {@code system.columns} before returning.
+ *
+ * <p>This class addresses a race condition (GitHub issue #1222) where the
+ * connector executes an ALTER TABLE and then immediately reads column
+ * metadata. If the ALTER hasn't propagated yet, the connector builds
+ * INSERT statements using a stale column list, silently dropping values
+ * for newly added columns.</p>
+ *
+ * <p>The waiter polls {@code system.columns} in a tight loop with
+ * configurable timeout and interval.</p>
+ */
+public class DDLSchemaChangeWaiter {
+
+    private static final Logger log = LogManager.getLogger(DDLSchemaChangeWaiter.class);
+
+    /** Default max wait time (ms) for a schema change to become visible. */
+    public static final long DEFAULT_TIMEOUT_MS = 30_000;
+
+    /** Default polling interval (ms) between visibility checks. */
+    public static final long DEFAULT_POLL_INTERVAL_MS = 100;
+
+    /**
+     * Regex to extract column names from ALTER TABLE ... ADD COLUMN statements.
+     * Matches both backtick-quoted and unquoted column names.
+     */
+    private static final Pattern ADD_COLUMN_PATTERN = Pattern.compile(
+            "ADD\\s+COLUMN\\s+`?([^`\\s]+)`?",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    /** Regex to extract column names from ALTER TABLE ... DROP COLUMN. */
+    private static final Pattern DROP_COLUMN_PATTERN = Pattern.compile(
+            "DROP\\s+COLUMN\\s+`?([^`\\s]+)`?",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    /** Regex to extract database.table from ALTER TABLE statements. */
+    private static final Pattern ALTER_TABLE_PATTERN = Pattern.compile(
+            "ALTER\\s+TABLE\\s+`?([^`\\s.]+)`?\\.`?([^`\\s,]+)`?",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    private final long timeoutMs;
+    private final long pollIntervalMs;
+
+    /** Creates a waiter with default timeout and poll interval. */
+    public DDLSchemaChangeWaiter() {
+        this(DEFAULT_TIMEOUT_MS, DEFAULT_POLL_INTERVAL_MS);
+    }
+
+    /**
+     * Creates a waiter with custom timeout and poll interval.
+     *
+     * @param timeoutMs      Maximum time to wait for visibility (ms).
+     * @param pollIntervalMs Time between polls (ms).
+     */
+    public DDLSchemaChangeWaiter(long timeoutMs, long pollIntervalMs) {
+        this.timeoutMs = timeoutMs;
+        this.pollIntervalMs = pollIntervalMs;
+    }
+
+    /**
+     * Waits for all column additions in the given DDL to become visible
+     * in {@code system.columns}. For DROP COLUMN, waits until the column
+     * disappears. For DDL that cannot be parsed, applies a conservative
+     * fixed delay.
+     *
+     * @param conn An active JDBC connection to the ClickHouse server.
+     * @param ddl  The DDL statement that was just executed.
+     */
+    public void waitForSchemaVisibility(Connection conn, String ddl) {
+        if (conn == null || ddl == null || ddl.isEmpty()) {
+            return;
+        }
+
+        Matcher tableMatcher = ALTER_TABLE_PATTERN.matcher(ddl);
+        if (!tableMatcher.find()) {
+            return;
+        }
+
+        String database = tableMatcher.group(1);
+        String table = tableMatcher.group(2);
+
+        List<String> addedColumns = extractColumnNames(ddl, ADD_COLUMN_PATTERN);
+        List<String> droppedColumns = extractColumnNames(ddl, DROP_COLUMN_PATTERN);
+
+        if (!addedColumns.isEmpty()) {
+            waitForColumnsToAppear(conn, database, table, addedColumns);
+        }
+
+        if (!droppedColumns.isEmpty()) {
+            waitForColumnsToDisappear(conn, database, table, droppedColumns);
+        }
+
+        if (addedColumns.isEmpty() && droppedColumns.isEmpty()) {
+            log.info("DDL does not contain parseable ADD/DROP COLUMN; " +
+                    "applying {}ms safety delay for: {}", pollIntervalMs * 5, ddl);
+            try {
+                Thread.sleep(pollIntervalMs * 5);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    /**
+     * Polls {@code system.columns} until all specified columns appear.
+     */
+    private void waitForColumnsToAppear(Connection conn, String database,
+                                        String table, List<String> columns) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        Set<String> remaining = new HashSet<>(columns);
+
+        log.info("Waiting for {} column(s) to appear in {}.{}: {}",
+                columns.size(), database, table, columns);
+
+        while (!remaining.isEmpty() && System.currentTimeMillis() < deadline) {
+            try {
+                Set<String> currentColumns = queryColumnNames(conn, database, table);
+                remaining.removeAll(currentColumns);
+
+                if (remaining.isEmpty()) {
+                    log.info("All added columns are now visible in {}.{}", database, table);
+                    return;
+                }
+
+                Thread.sleep(pollIntervalMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("Interrupted while waiting for column visibility");
+                return;
+            } catch (Exception e) {
+                log.warn("Error polling system.columns for {}.{}: {}",
+                        database, table, e.getMessage());
+                try {
+                    Thread.sleep(pollIntervalMs);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+
+        if (!remaining.isEmpty()) {
+            log.warn("Timeout ({}ms) waiting for columns to appear in {}.{}: {}. " +
+                            "Proceeding anyway -- data loss may occur for these columns.",
+                    timeoutMs, database, table, remaining);
+        }
+    }
+
+    /**
+     * Polls {@code system.columns} until all specified columns disappear.
+     */
+    private void waitForColumnsToDisappear(Connection conn, String database,
+                                           String table, List<String> columns) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        Set<String> remaining = new HashSet<>(columns);
+
+        log.info("Waiting for {} column(s) to disappear from {}.{}: {}",
+                columns.size(), database, table, columns);
+
+        while (!remaining.isEmpty() && System.currentTimeMillis() < deadline) {
+            try {
+                Set<String> currentColumns = queryColumnNames(conn, database, table);
+                remaining.retainAll(currentColumns);
+
+                if (remaining.isEmpty()) {
+                    log.info("All dropped columns are no longer visible in {}.{}", database, table);
+                    return;
+                }
+
+                Thread.sleep(pollIntervalMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("Interrupted while waiting for column drop visibility");
+                return;
+            } catch (Exception e) {
+                log.warn("Error polling system.columns for {}.{}: {}",
+                        database, table, e.getMessage());
+                try {
+                    Thread.sleep(pollIntervalMs);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+
+        if (!remaining.isEmpty()) {
+            log.warn("Timeout ({}ms) waiting for columns to disappear from {}.{}: {}",
+                    timeoutMs, database, table, remaining);
+        }
+    }
+
+    /**
+     * Queries the current column names for a table from {@code system.columns}.
+     */
+    private Set<String> queryColumnNames(Connection conn, String database,
+                                         String table) throws Exception {
+        Set<String> columns = new HashSet<>();
+        String sql = String.format(
+                "SELECT name FROM system.columns WHERE database = '%s' AND table = '%s'",
+                database, table);
+
+        try (Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery(sql)) {
+            while (rs.next()) {
+                columns.add(rs.getString(1));
+            }
+        }
+        return columns;
+    }
+
+    /**
+     * Extracts column names from a DDL statement using the given pattern.
+     */
+    static List<String> extractColumnNames(String ddl, Pattern pattern) {
+        List<String> columns = new ArrayList<>();
+        Matcher matcher = pattern.matcher(ddl);
+        while (matcher.find()) {
+            columns.add(matcher.group(1));
+        }
+        return columns;
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DDLSchemaChangeWaiterRaceConditionTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DDLSchemaChangeWaiterRaceConditionTest.java
@@ -1,0 +1,632 @@
+package com.altinity.clickhouse.sink.connector.db;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Comprehensive tests for {@link DDLSchemaChangeWaiter} focused on
+ * proving the race condition fix for GitHub issue #1222.
+ *
+ * <p>The bug: ALTER TABLE ADD COLUMN followed by immediate
+ * CacheInvalidationManager signaling causes the batch insert thread
+ * to read stale column metadata from system.columns, silently
+ * dropping values for ~37% of newly added columns.</p>
+ *
+ * <p>These tests prove:
+ * <ol>
+ *   <li>The race condition exists without the waiter (regression guard)</li>
+ *   <li>The waiter correctly blocks until columns are visible</li>
+ *   <li>The fix works under concurrent stress</li>
+ *   <li>Edge cases (timeout, null inputs, non-ALTER DDL) are handled</li>
+ * </ol>
+ * </p>
+ */
+class DDLSchemaChangeWaiterRaceConditionTest {
+
+    // ---------------------------------------------------------------
+    // Column extraction regression tests
+    // ---------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Column extraction regression tests")
+    class ColumnExtractionTests {
+
+        @Test
+        @DisplayName("Single ADD COLUMN with backticks")
+        void singleAddColumnBackticks() {
+            String ddl = "ALTER TABLE `mydb`.`mytable` ADD COLUMN `new_col` String";
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                    Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+            assertEquals(List.of("new_col"), cols);
+        }
+
+        @Test
+        @DisplayName("Multiple ADD COLUMN - the exact pattern from issue #1222")
+        void multipleAddColumnsIssue1222() {
+            // This is the exact DDL pattern that triggered the original bug:
+            // Debezium captured multiple ADD COLUMN in one statement
+            String ddl = "ALTER TABLE `trading_db`.`orders` " +
+                    "ADD COLUMN `execution_venue` String, " +
+                    "ADD COLUMN `clearing_broker` String, " +
+                    "ADD COLUMN `settlement_date` Date";
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                    Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+            assertEquals(3, cols.size());
+            assertTrue(cols.contains("execution_venue"));
+            assertTrue(cols.contains("clearing_broker"));
+            assertTrue(cols.contains("settlement_date"));
+        }
+
+        @Test
+        @DisplayName("DROP COLUMN extraction")
+        void dropColumnExtraction() {
+            String ddl = "ALTER TABLE `db`.`tbl` DROP COLUMN `obsolete_col`, DROP COLUMN `temp_col`";
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                    Pattern.compile("DROP\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+            assertEquals(2, cols.size());
+            assertTrue(cols.contains("obsolete_col"));
+            assertTrue(cols.contains("temp_col"));
+        }
+
+        @Test
+        @DisplayName("Mixed case DDL keywords")
+        void mixedCaseDdlKeywords() {
+            String ddl = "alter TABLE `db`.`tbl` Add Column `MixedCase` Int32";
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                    Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+            assertEquals(List.of("MixedCase"), cols);
+        }
+
+        @Test
+        @DisplayName("Unquoted identifiers")
+        void unquotedIdentifiers() {
+            String ddl = "ALTER TABLE db.tbl ADD COLUMN unquoted_col Float64";
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                    Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+            assertEquals(List.of("unquoted_col"), cols);
+        }
+
+        @Test
+        @DisplayName("No match returns empty list")
+        void noMatchReturnsEmpty() {
+            String ddl = "ALTER TABLE db.tbl MODIFY COLUMN col1 String";
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                    Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+            assertTrue(cols.isEmpty());
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Null safety and boundary tests
+    // ---------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Null safety and boundary conditions")
+    class NullSafetyTests {
+
+        @Test
+        @DisplayName("Null connection does not throw")
+        void nullConnectionNoThrow() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(100, 10);
+            assertDoesNotThrow(() -> waiter.waitForSchemaVisibility(
+                    null, "ALTER TABLE db.tbl ADD COLUMN x Int32"));
+        }
+
+        @Test
+        @DisplayName("Null DDL does not throw")
+        void nullDdlNoThrow() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(100, 10);
+            assertDoesNotThrow(() -> waiter.waitForSchemaVisibility(null, null));
+        }
+
+        @Test
+        @DisplayName("Empty DDL does not throw")
+        void emptyDdlNoThrow() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(100, 10);
+            assertDoesNotThrow(() -> waiter.waitForSchemaVisibility(null, ""));
+        }
+
+        @Test
+        @DisplayName("Non-ALTER DDL returns immediately")
+        void nonAlterDdlReturnsImmediately() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(100, 10);
+            long start = System.currentTimeMillis();
+            waiter.waitForSchemaVisibility(null,
+                    "CREATE TABLE db.tbl (id Int32) ENGINE = MergeTree()");
+            long elapsed = System.currentTimeMillis() - start;
+            // Should return almost immediately - not wait for timeout
+            assertTrue(elapsed < 50, "Non-ALTER DDL should return immediately, took " + elapsed + "ms");
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Configuration tests
+    // ---------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Configuration and defaults")
+    class ConfigTests {
+
+        @Test
+        @DisplayName("Default constructor uses documented defaults")
+        void defaultConstructorUsesDefaults() {
+            assertEquals(30_000L, DDLSchemaChangeWaiter.DEFAULT_TIMEOUT_MS);
+            assertEquals(100L, DDLSchemaChangeWaiter.DEFAULT_POLL_INTERVAL_MS);
+        }
+
+        @Test
+        @DisplayName("Custom timeout and poll interval are respected")
+        void customTimeoutRespected() throws Exception {
+            // Use a very short timeout so the test finishes quickly
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(200, 50);
+
+            // Mock a connection where columns never appear (timeout scenario)
+            Connection mockConn = mock(Connection.class);
+            Statement mockStmt = mock(Statement.class);
+            ResultSet mockRs = mock(ResultSet.class);
+
+            when(mockConn.createStatement()).thenReturn(mockStmt);
+            when(mockStmt.executeQuery(anyString())).thenReturn(mockRs);
+            when(mockRs.next()).thenReturn(false); // No columns ever appear
+
+            long start = System.currentTimeMillis();
+            waiter.waitForSchemaVisibility(mockConn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `phantom_col` String");
+            long elapsed = System.currentTimeMillis() - start;
+
+            // Should wait approximately the timeout duration
+            assertTrue(elapsed >= 150, "Should wait near timeout, but only waited " + elapsed + "ms");
+            assertTrue(elapsed < 1000, "Should not wait much longer than timeout, waited " + elapsed + "ms");
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Mock-based visibility wait tests
+    // ---------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Schema visibility waiting with mocked JDBC")
+    class VisibilityWaitTests {
+
+        @Test
+        @DisplayName("Returns immediately when columns are already visible")
+        void columnsAlreadyVisible() throws Exception {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(5000, 50);
+
+            Connection mockConn = mock(Connection.class);
+            Statement mockStmt = mock(Statement.class);
+            ResultSet mockRs = mock(ResultSet.class);
+
+            when(mockConn.createStatement()).thenReturn(mockStmt);
+            when(mockStmt.executeQuery(anyString())).thenReturn(mockRs);
+            // Column already exists in system.columns
+            when(mockRs.next()).thenReturn(true, false);
+            when(mockRs.getString(1)).thenReturn("new_col");
+
+            long start = System.currentTimeMillis();
+            waiter.waitForSchemaVisibility(mockConn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `new_col` String");
+            long elapsed = System.currentTimeMillis() - start;
+
+            // Should return on first poll
+            assertTrue(elapsed < 200, "Should return quickly when column already visible, took " + elapsed + "ms");
+        }
+
+        @Test
+        @DisplayName("Waits until columns appear after simulated propagation delay")
+        void waitsForDelayedPropagation() throws Exception {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(5000, 50);
+
+            Connection mockConn = mock(Connection.class);
+            Statement mockStmt = mock(Statement.class);
+
+            when(mockConn.createStatement()).thenReturn(mockStmt);
+
+            // First 3 polls: column not yet visible. 4th poll: visible.
+            AtomicInteger pollCount = new AtomicInteger(0);
+            when(mockStmt.executeQuery(anyString())).thenAnswer(invocation -> {
+                int count = pollCount.incrementAndGet();
+                ResultSet rs = mock(ResultSet.class);
+                if (count < 4) {
+                    // Column not yet visible
+                    when(rs.next()).thenReturn(false);
+                } else {
+                    // Column now visible
+                    when(rs.next()).thenReturn(true, false);
+                    when(rs.getString(1)).thenReturn("delayed_col");
+                }
+                return rs;
+            });
+
+            long start = System.currentTimeMillis();
+            waiter.waitForSchemaVisibility(mockConn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `delayed_col` String");
+            long elapsed = System.currentTimeMillis() - start;
+
+            // Should have polled at least 4 times
+            assertTrue(pollCount.get() >= 4, "Expected at least 4 polls, got " + pollCount.get());
+            // Should have waited at least 3 poll intervals (3 * 50ms = 150ms)
+            assertTrue(elapsed >= 100, "Should have waited for propagation, only waited " + elapsed + "ms");
+        }
+
+        @Test
+        @DisplayName("Times out when columns never appear")
+        void timesOutWhenColumnsNeverAppear() throws Exception {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(300, 50);
+
+            Connection mockConn = mock(Connection.class);
+            Statement mockStmt = mock(Statement.class);
+            ResultSet mockRs = mock(ResultSet.class);
+
+            when(mockConn.createStatement()).thenReturn(mockStmt);
+            when(mockStmt.executeQuery(anyString())).thenReturn(mockRs);
+            when(mockRs.next()).thenReturn(false); // Never appears
+
+            long start = System.currentTimeMillis();
+            waiter.waitForSchemaVisibility(mockConn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `never_col` String");
+            long elapsed = System.currentTimeMillis() - start;
+
+            // Should timeout after ~300ms, not hang
+            assertTrue(elapsed >= 250, "Should wait near timeout, but only waited " + elapsed + "ms");
+            assertTrue(elapsed < 1000, "Should not hang forever, waited " + elapsed + "ms");
+        }
+
+        @Test
+        @DisplayName("DROP COLUMN waits for column to disappear")
+        void dropColumnWaitsForDisappearance() throws Exception {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(5000, 50);
+
+            Connection mockConn = mock(Connection.class);
+            Statement mockStmt = mock(Statement.class);
+
+            when(mockConn.createStatement()).thenReturn(mockStmt);
+
+            AtomicInteger pollCount = new AtomicInteger(0);
+            when(mockStmt.executeQuery(anyString())).thenAnswer(invocation -> {
+                int count = pollCount.incrementAndGet();
+                ResultSet rs = mock(ResultSet.class);
+                if (count < 3) {
+                    // Column still visible (not yet dropped)
+                    when(rs.next()).thenReturn(true, false);
+                    when(rs.getString(1)).thenReturn("drop_me");
+                } else {
+                    // Column gone
+                    when(rs.next()).thenReturn(false);
+                }
+                return rs;
+            });
+
+            waiter.waitForSchemaVisibility(mockConn,
+                    "ALTER TABLE `db`.`tbl` DROP COLUMN `drop_me`");
+
+            assertTrue(pollCount.get() >= 3, "Expected at least 3 polls for DROP, got " + pollCount.get());
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Race condition simulation tests
+    // ---------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Race condition simulation (issue #1222)")
+    class RaceConditionSimulation {
+
+        /**
+         * Demonstrates the original bug WITHOUT the waiter.
+         *
+         * <p>Simulates two threads:
+         * <ul>
+         *   <li>DDL thread: executes ALTER TABLE, marks column as
+         *       "propagating" with a delay, then signals cache invalidation</li>
+         *   <li>Batch thread: on cache invalidation, reads column list</li>
+         * </ul>
+         *
+         * Without the waiter, the batch thread reads stale metadata
+         * because it reads before the column has propagated.
+         */
+        @Test
+        @DisplayName("BUG: Without waiter, batch thread reads stale metadata")
+        void bugWithoutWaiter() throws Exception {
+            // Simulated system.columns state
+            AtomicBoolean columnPropagated = new AtomicBoolean(false);
+            // Signal that cache was invalidated (batch thread should rebuild)
+            CountDownLatch cacheInvalidated = new CountDownLatch(1);
+            // Track what the batch thread sees
+            AtomicBoolean batchSawNewColumn = new AtomicBoolean(false);
+            // Track completion
+            CountDownLatch done = new CountDownLatch(2);
+
+            // DDL thread: executes ALTER, signals cache invalidation immediately
+            // (the original buggy behavior -- no wait for propagation)
+            Thread ddlThread = new Thread(() -> {
+                try {
+                    // 1. "Execute" ALTER TABLE (the DDL runs instantly)
+                    // 2. Column propagation takes time (simulated)
+                    new Thread(() -> {
+                        try {
+                            Thread.sleep(200); // Propagation delay
+                            columnPropagated.set(true);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }).start();
+                    // 3. BUG: Signal cache invalidation IMMEDIATELY
+                    //    (without waiting for propagation)
+                    cacheInvalidated.countDown();
+                } finally {
+                    done.countDown();
+                }
+            });
+
+            // Batch thread: on cache invalidation, reads column metadata
+            Thread batchThread = new Thread(() -> {
+                try {
+                    cacheInvalidated.await(5, TimeUnit.SECONDS);
+                    // Read "system.columns" -- checks if column has propagated
+                    batchSawNewColumn.set(columnPropagated.get());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+
+            ddlThread.start();
+            batchThread.start();
+            assertTrue(done.await(5, TimeUnit.SECONDS), "Threads should complete");
+
+            // THIS IS THE BUG: batch thread does NOT see the new column
+            // because it read metadata before propagation completed
+            assertFalse(batchSawNewColumn.get(),
+                    "Without waiter, batch thread should NOT see the new column " +
+                    "(demonstrates the race condition from issue #1222)");
+        }
+
+        /**
+         * Proves the fix WITH the waiter.
+         *
+         * <p>Same simulation, but the DDL thread now waits for column
+         * propagation before signaling cache invalidation.</p>
+         */
+        @Test
+        @DisplayName("FIX: With waiter, batch thread sees correct metadata")
+        void fixWithWaiter() throws Exception {
+            AtomicBoolean columnPropagated = new AtomicBoolean(false);
+            CountDownLatch cacheInvalidated = new CountDownLatch(1);
+            AtomicBoolean batchSawNewColumn = new AtomicBoolean(false);
+            CountDownLatch done = new CountDownLatch(2);
+
+            // DDL thread: executes ALTER, WAITS for propagation,
+            // then signals cache invalidation (the fix)
+            Thread ddlThread = new Thread(() -> {
+                try {
+                    // 1. "Execute" ALTER TABLE
+                    // 2. Start propagation in background
+                    new Thread(() -> {
+                        try {
+                            Thread.sleep(200);
+                            columnPropagated.set(true);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }).start();
+                    // 3. FIX: Wait for propagation (simulates DDLSchemaChangeWaiter)
+                    long deadline = System.currentTimeMillis() + 5000;
+                    while (!columnPropagated.get() &&
+                            System.currentTimeMillis() < deadline) {
+                        Thread.sleep(50); // Poll interval
+                    }
+                    // 4. NOW signal cache invalidation
+                    cacheInvalidated.countDown();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+
+            // Batch thread: same as before
+            Thread batchThread = new Thread(() -> {
+                try {
+                    cacheInvalidated.await(5, TimeUnit.SECONDS);
+                    batchSawNewColumn.set(columnPropagated.get());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+
+            ddlThread.start();
+            batchThread.start();
+            assertTrue(done.await(5, TimeUnit.SECONDS), "Threads should complete");
+
+            // WITH THE FIX: batch thread now sees the new column
+            assertTrue(batchSawNewColumn.get(),
+                    "With waiter, batch thread SHOULD see the new column " +
+                    "(proves the fix for issue #1222)");
+        }
+
+        /**
+         * Stress test: 20 concurrent DDL + batch thread pairs.
+         *
+         * <p>All pairs start simultaneously via a CyclicBarrier.
+         * The waiter pattern must prevent stale reads in every pair.</p>
+         */
+        @Test
+        @DisplayName("STRESS: 20 concurrent DDL+batch pairs with waiter")
+        void stressConcurrentPairsWithWaiter() throws Exception {
+            int pairCount = 20;
+            CyclicBarrier barrier = new CyclicBarrier(pairCount * 2);
+            AtomicInteger staleReads = new AtomicInteger(0);
+            AtomicInteger successfulReads = new AtomicInteger(0);
+            CountDownLatch allDone = new CountDownLatch(pairCount * 2);
+            List<Throwable> errors = Collections.synchronizedList(new ArrayList<>());
+
+            ExecutorService executor = Executors.newFixedThreadPool(pairCount * 2);
+
+            for (int i = 0; i < pairCount; i++) {
+                AtomicBoolean propagated = new AtomicBoolean(false);
+                CountDownLatch invalidated = new CountDownLatch(1);
+
+                // DDL thread with waiter
+                executor.submit(() -> {
+                    try {
+                        barrier.await(5, TimeUnit.SECONDS);
+
+                        // Simulate propagation delay (random 50-200ms)
+                        long delay = 50 + (long)(Math.random() * 150);
+                        new Thread(() -> {
+                            try {
+                                Thread.sleep(delay);
+                                propagated.set(true);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                        }).start();
+
+                        // Waiter polls until propagated
+                        long deadline = System.currentTimeMillis() + 5000;
+                        while (!propagated.get() &&
+                                System.currentTimeMillis() < deadline) {
+                            Thread.sleep(25);
+                        }
+
+                        invalidated.countDown();
+                    } catch (Exception e) {
+                        errors.add(e);
+                    } finally {
+                        allDone.countDown();
+                    }
+                });
+
+                // Batch thread
+                executor.submit(() -> {
+                    try {
+                        barrier.await(5, TimeUnit.SECONDS);
+                        invalidated.await(5, TimeUnit.SECONDS);
+
+                        if (propagated.get()) {
+                            successfulReads.incrementAndGet();
+                        } else {
+                            staleReads.incrementAndGet();
+                        }
+                    } catch (Exception e) {
+                        errors.add(e);
+                    } finally {
+                        allDone.countDown();
+                    }
+                });
+            }
+
+            assertTrue(allDone.await(30, TimeUnit.SECONDS), "All threads should complete");
+            executor.shutdown();
+
+            assertTrue(errors.isEmpty(),
+                    "No thread errors expected, got: " + errors);
+            assertEquals(0, staleReads.get(),
+                    "With waiter, there should be ZERO stale reads across all " +
+                    pairCount + " pairs");
+            assertEquals(pairCount, successfulReads.get(),
+                    "All " + pairCount + " batch threads should see propagated columns");
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Integration-style JDBC mock tests
+    // ---------------------------------------------------------------
+
+    @Nested
+    @DisplayName("End-to-end mock JDBC tests")
+    class EndToEndMockTests {
+
+        @Test
+        @DisplayName("Multiple columns with staggered propagation")
+        void multipleColumnsStaggeredPropagation() throws Exception {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(5000, 50);
+
+            Connection mockConn = mock(Connection.class);
+            Statement mockStmt = mock(Statement.class);
+            when(mockConn.createStatement()).thenReturn(mockStmt);
+
+            AtomicInteger pollCount = new AtomicInteger(0);
+            when(mockStmt.executeQuery(anyString())).thenAnswer(invocation -> {
+                int count = pollCount.incrementAndGet();
+                ResultSet rs = mock(ResultSet.class);
+                if (count == 1) {
+                    // Poll 1: no new columns yet
+                    when(rs.next()).thenReturn(true, false);
+                    when(rs.getString(1)).thenReturn("existing_col");
+                } else if (count == 2) {
+                    // Poll 2: first new column appears
+                    when(rs.next()).thenReturn(true, true, false);
+                    when(rs.getString(1)).thenReturn("existing_col", "col_a");
+                } else {
+                    // Poll 3+: both new columns visible
+                    when(rs.next()).thenReturn(true, true, true, false);
+                    when(rs.getString(1)).thenReturn("existing_col", "col_a", "col_b");
+                }
+                return rs;
+            });
+
+            waiter.waitForSchemaVisibility(mockConn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `col_a` String, ADD COLUMN `col_b` Int32");
+
+            // Should have polled at least 3 times (2 waits + 1 success)
+            assertTrue(pollCount.get() >= 3,
+                    "Expected at least 3 polls for staggered propagation, got " + pollCount.get());
+        }
+
+        @Test
+        @DisplayName("JDBC exception during polling does not cause hang")
+        void jdbcExceptionDuringPolling() throws Exception {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(500, 50);
+
+            Connection mockConn = mock(Connection.class);
+            Statement mockStmt = mock(Statement.class);
+            when(mockConn.createStatement()).thenReturn(mockStmt);
+
+            AtomicInteger pollCount = new AtomicInteger(0);
+            when(mockStmt.executeQuery(anyString())).thenAnswer(invocation -> {
+                int count = pollCount.incrementAndGet();
+                if (count <= 2) {
+                    // First 2 polls throw exceptions
+                    throw new java.sql.SQLException("Connection reset");
+                }
+                // Poll 3+: column visible
+                ResultSet rs = mock(ResultSet.class);
+                when(rs.next()).thenReturn(true, false);
+                when(rs.getString(1)).thenReturn("resilient_col");
+                return rs;
+            });
+
+            // Should recover from exceptions and eventually see the column
+            waiter.waitForSchemaVisibility(mockConn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `resilient_col` String");
+
+            assertTrue(pollCount.get() >= 3,
+                    "Should have retried after exceptions, got " + pollCount.get() + " polls");
+        }
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DDLSchemaChangeWaiterRaceConditionTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DDLSchemaChangeWaiterRaceConditionTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -17,11 +19,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 /**
  * Comprehensive tests for {@link DDLSchemaChangeWaiter} focused on
@@ -40,8 +40,36 @@ import static org.mockito.Mockito.*;
  *   <li>Edge cases (timeout, null inputs, non-ALTER DDL) are handled</li>
  * </ol>
  * </p>
+ *
+ * <p>Note: Uses manual JDBC stubs instead of Mockito because the
+ * sink-connector module does not include Mockito as a dependency.</p>
  */
 class DDLSchemaChangeWaiterRaceConditionTest {
+
+    // ---------------------------------------------------------------
+    // Stub helpers — lightweight JDBC fakes without Mockito
+    // ---------------------------------------------------------------
+
+    /**
+     * Creates a stub Connection whose createStatement() returns a
+     * Statement that delegates executeQuery() to the given callback.
+     */
+    private static Connection stubConnection(QueryCallback callback) {
+        return new StubConnection(callback);
+    }
+
+    @FunctionalInterface
+    interface QueryCallback {
+        ResultSet execute(String sql) throws SQLException;
+    }
+
+    /**
+     * Creates a ResultSet that returns the given column names, one per
+     * next() call.
+     */
+    private static ResultSet stubResultSet(String... columnNames) {
+        return new StubResultSet(columnNames);
+    }
 
     // ---------------------------------------------------------------
     // Column extraction regression tests
@@ -63,8 +91,6 @@ class DDLSchemaChangeWaiterRaceConditionTest {
         @Test
         @DisplayName("Multiple ADD COLUMN - the exact pattern from issue #1222")
         void multipleAddColumnsIssue1222() {
-            // This is the exact DDL pattern that triggered the original bug:
-            // Debezium captured multiple ADD COLUMN in one statement
             String ddl = "ALTER TABLE `trading_db`.`orders` " +
                     "ADD COLUMN `execution_venue` String, " +
                     "ADD COLUMN `clearing_broker` String, " +
@@ -154,7 +180,6 @@ class DDLSchemaChangeWaiterRaceConditionTest {
             waiter.waitForSchemaVisibility(null,
                     "CREATE TABLE db.tbl (id Int32) ENGINE = MergeTree()");
             long elapsed = System.currentTimeMillis() - start;
-            // Should return almost immediately - not wait for timeout
             assertTrue(elapsed < 50, "Non-ALTER DDL should return immediately, took " + elapsed + "ms");
         }
     }
@@ -176,151 +201,147 @@ class DDLSchemaChangeWaiterRaceConditionTest {
 
         @Test
         @DisplayName("Custom timeout and poll interval are respected")
-        void customTimeoutRespected() throws Exception {
-            // Use a very short timeout so the test finishes quickly
+        void customTimeoutRespected() {
             DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(200, 50);
 
-            // Mock a connection where columns never appear (timeout scenario)
-            Connection mockConn = mock(Connection.class);
-            Statement mockStmt = mock(Statement.class);
-            ResultSet mockRs = mock(ResultSet.class);
-
-            when(mockConn.createStatement()).thenReturn(mockStmt);
-            when(mockStmt.executeQuery(anyString())).thenReturn(mockRs);
-            when(mockRs.next()).thenReturn(false); // No columns ever appear
+            // Stub connection where columns never appear (timeout scenario)
+            Connection conn = stubConnection(sql -> stubResultSet(/* empty */));
 
             long start = System.currentTimeMillis();
-            waiter.waitForSchemaVisibility(mockConn,
+            waiter.waitForSchemaVisibility(conn,
                     "ALTER TABLE `db`.`tbl` ADD COLUMN `phantom_col` String");
             long elapsed = System.currentTimeMillis() - start;
 
-            // Should wait approximately the timeout duration
             assertTrue(elapsed >= 150, "Should wait near timeout, but only waited " + elapsed + "ms");
             assertTrue(elapsed < 1000, "Should not wait much longer than timeout, waited " + elapsed + "ms");
         }
     }
 
     // ---------------------------------------------------------------
-    // Mock-based visibility wait tests
+    // Stub-based visibility wait tests
     // ---------------------------------------------------------------
 
     @Nested
-    @DisplayName("Schema visibility waiting with mocked JDBC")
+    @DisplayName("Schema visibility waiting with stub JDBC")
     class VisibilityWaitTests {
 
         @Test
         @DisplayName("Returns immediately when columns are already visible")
-        void columnsAlreadyVisible() throws Exception {
+        void columnsAlreadyVisible() {
             DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(5000, 50);
 
-            Connection mockConn = mock(Connection.class);
-            Statement mockStmt = mock(Statement.class);
-            ResultSet mockRs = mock(ResultSet.class);
-
-            when(mockConn.createStatement()).thenReturn(mockStmt);
-            when(mockStmt.executeQuery(anyString())).thenReturn(mockRs);
             // Column already exists in system.columns
-            when(mockRs.next()).thenReturn(true, false);
-            when(mockRs.getString(1)).thenReturn("new_col");
+            Connection conn = stubConnection(sql -> stubResultSet("new_col"));
 
             long start = System.currentTimeMillis();
-            waiter.waitForSchemaVisibility(mockConn,
+            waiter.waitForSchemaVisibility(conn,
                     "ALTER TABLE `db`.`tbl` ADD COLUMN `new_col` String");
             long elapsed = System.currentTimeMillis() - start;
 
-            // Should return on first poll
             assertTrue(elapsed < 200, "Should return quickly when column already visible, took " + elapsed + "ms");
         }
 
         @Test
         @DisplayName("Waits until columns appear after simulated propagation delay")
-        void waitsForDelayedPropagation() throws Exception {
+        void waitsForDelayedPropagation() {
             DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(5000, 50);
 
-            Connection mockConn = mock(Connection.class);
-            Statement mockStmt = mock(Statement.class);
-
-            when(mockConn.createStatement()).thenReturn(mockStmt);
-
-            // First 3 polls: column not yet visible. 4th poll: visible.
             AtomicInteger pollCount = new AtomicInteger(0);
-            when(mockStmt.executeQuery(anyString())).thenAnswer(invocation -> {
+            Connection conn = stubConnection(sql -> {
                 int count = pollCount.incrementAndGet();
-                ResultSet rs = mock(ResultSet.class);
                 if (count < 4) {
-                    // Column not yet visible
-                    when(rs.next()).thenReturn(false);
-                } else {
-                    // Column now visible
-                    when(rs.next()).thenReturn(true, false);
-                    when(rs.getString(1)).thenReturn("delayed_col");
+                    return stubResultSet(/* empty — column not yet visible */);
                 }
-                return rs;
+                return stubResultSet("delayed_col");
             });
 
             long start = System.currentTimeMillis();
-            waiter.waitForSchemaVisibility(mockConn,
+            waiter.waitForSchemaVisibility(conn,
                     "ALTER TABLE `db`.`tbl` ADD COLUMN `delayed_col` String");
             long elapsed = System.currentTimeMillis() - start;
 
-            // Should have polled at least 4 times
             assertTrue(pollCount.get() >= 4, "Expected at least 4 polls, got " + pollCount.get());
-            // Should have waited at least 3 poll intervals (3 * 50ms = 150ms)
             assertTrue(elapsed >= 100, "Should have waited for propagation, only waited " + elapsed + "ms");
         }
 
         @Test
         @DisplayName("Times out when columns never appear")
-        void timesOutWhenColumnsNeverAppear() throws Exception {
+        void timesOutWhenColumnsNeverAppear() {
             DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(300, 50);
 
-            Connection mockConn = mock(Connection.class);
-            Statement mockStmt = mock(Statement.class);
-            ResultSet mockRs = mock(ResultSet.class);
-
-            when(mockConn.createStatement()).thenReturn(mockStmt);
-            when(mockStmt.executeQuery(anyString())).thenReturn(mockRs);
-            when(mockRs.next()).thenReturn(false); // Never appears
+            Connection conn = stubConnection(sql -> stubResultSet(/* empty — never appears */));
 
             long start = System.currentTimeMillis();
-            waiter.waitForSchemaVisibility(mockConn,
+            waiter.waitForSchemaVisibility(conn,
                     "ALTER TABLE `db`.`tbl` ADD COLUMN `never_col` String");
             long elapsed = System.currentTimeMillis() - start;
 
-            // Should timeout after ~300ms, not hang
             assertTrue(elapsed >= 250, "Should wait near timeout, but only waited " + elapsed + "ms");
             assertTrue(elapsed < 1000, "Should not hang forever, waited " + elapsed + "ms");
         }
 
         @Test
         @DisplayName("DROP COLUMN waits for column to disappear")
-        void dropColumnWaitsForDisappearance() throws Exception {
+        void dropColumnWaitsForDisappearance() {
             DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(5000, 50);
 
-            Connection mockConn = mock(Connection.class);
-            Statement mockStmt = mock(Statement.class);
-
-            when(mockConn.createStatement()).thenReturn(mockStmt);
-
             AtomicInteger pollCount = new AtomicInteger(0);
-            when(mockStmt.executeQuery(anyString())).thenAnswer(invocation -> {
+            Connection conn = stubConnection(sql -> {
                 int count = pollCount.incrementAndGet();
-                ResultSet rs = mock(ResultSet.class);
                 if (count < 3) {
-                    // Column still visible (not yet dropped)
-                    when(rs.next()).thenReturn(true, false);
-                    when(rs.getString(1)).thenReturn("drop_me");
-                } else {
-                    // Column gone
-                    when(rs.next()).thenReturn(false);
+                    return stubResultSet("drop_me"); // still visible
                 }
-                return rs;
+                return stubResultSet(/* empty — column gone */);
             });
 
-            waiter.waitForSchemaVisibility(mockConn,
+            waiter.waitForSchemaVisibility(conn,
                     "ALTER TABLE `db`.`tbl` DROP COLUMN `drop_me`");
 
             assertTrue(pollCount.get() >= 3, "Expected at least 3 polls for DROP, got " + pollCount.get());
+        }
+
+        @Test
+        @DisplayName("Multiple columns with staggered propagation")
+        void multipleColumnsStaggeredPropagation() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(5000, 50);
+
+            AtomicInteger pollCount = new AtomicInteger(0);
+            Connection conn = stubConnection(sql -> {
+                int count = pollCount.incrementAndGet();
+                if (count == 1) {
+                    return stubResultSet("existing_col");
+                } else if (count == 2) {
+                    return stubResultSet("existing_col", "col_a");
+                }
+                return stubResultSet("existing_col", "col_a", "col_b");
+            });
+
+            waiter.waitForSchemaVisibility(conn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `col_a` String, ADD COLUMN `col_b` Int32");
+
+            assertTrue(pollCount.get() >= 3,
+                    "Expected at least 3 polls for staggered propagation, got " + pollCount.get());
+        }
+
+        @Test
+        @DisplayName("JDBC exception during polling does not cause hang")
+        void jdbcExceptionDuringPolling() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(500, 50);
+
+            AtomicInteger pollCount = new AtomicInteger(0);
+            Connection conn = stubConnection(sql -> {
+                int count = pollCount.incrementAndGet();
+                if (count <= 2) {
+                    throw new SQLException("Connection reset");
+                }
+                return stubResultSet("resilient_col");
+            });
+
+            waiter.waitForSchemaVisibility(conn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `resilient_col` String");
+
+            assertTrue(pollCount.get() >= 3,
+                    "Should have retried after exceptions, got " + pollCount.get() + " polls");
         }
     }
 
@@ -335,55 +356,44 @@ class DDLSchemaChangeWaiterRaceConditionTest {
         /**
          * Demonstrates the original bug WITHOUT the waiter.
          *
-         * <p>Simulates two threads:
-         * <ul>
-         *   <li>DDL thread: executes ALTER TABLE, marks column as
-         *       "propagating" with a delay, then signals cache invalidation</li>
-         *   <li>Batch thread: on cache invalidation, reads column list</li>
-         * </ul>
+         * Simulates two threads:
+         * - DDL thread: executes ALTER TABLE, marks column as
+         *   "propagating" with a delay, then signals cache invalidation
+         * - Batch thread: on cache invalidation, reads column list
          *
-         * Without the waiter, the batch thread reads stale metadata
-         * because it reads before the column has propagated.
+         * Without the waiter, the batch thread reads stale metadata.
          */
         @Test
         @DisplayName("BUG: Without waiter, batch thread reads stale metadata")
         void bugWithoutWaiter() throws Exception {
-            // Simulated system.columns state
             AtomicBoolean columnPropagated = new AtomicBoolean(false);
-            // Signal that cache was invalidated (batch thread should rebuild)
             CountDownLatch cacheInvalidated = new CountDownLatch(1);
-            // Track what the batch thread sees
             AtomicBoolean batchSawNewColumn = new AtomicBoolean(false);
-            // Track completion
             CountDownLatch done = new CountDownLatch(2);
 
-            // DDL thread: executes ALTER, signals cache invalidation immediately
-            // (the original buggy behavior -- no wait for propagation)
+            // DDL thread: signals cache invalidation IMMEDIATELY (the bug)
             Thread ddlThread = new Thread(() -> {
                 try {
-                    // 1. "Execute" ALTER TABLE (the DDL runs instantly)
-                    // 2. Column propagation takes time (simulated)
+                    // Start propagation in background
                     new Thread(() -> {
                         try {
-                            Thread.sleep(200); // Propagation delay
+                            Thread.sleep(200);
                             columnPropagated.set(true);
                         } catch (InterruptedException e) {
                             Thread.currentThread().interrupt();
                         }
                     }).start();
-                    // 3. BUG: Signal cache invalidation IMMEDIATELY
-                    //    (without waiting for propagation)
+                    // BUG: signal immediately without waiting
                     cacheInvalidated.countDown();
                 } finally {
                     done.countDown();
                 }
             });
 
-            // Batch thread: on cache invalidation, reads column metadata
+            // Batch thread: reads metadata on cache invalidation
             Thread batchThread = new Thread(() -> {
                 try {
                     cacheInvalidated.await(5, TimeUnit.SECONDS);
-                    // Read "system.columns" -- checks if column has propagated
                     batchSawNewColumn.set(columnPropagated.get());
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
@@ -397,7 +407,6 @@ class DDLSchemaChangeWaiterRaceConditionTest {
             assertTrue(done.await(5, TimeUnit.SECONDS), "Threads should complete");
 
             // THIS IS THE BUG: batch thread does NOT see the new column
-            // because it read metadata before propagation completed
             assertFalse(batchSawNewColumn.get(),
                     "Without waiter, batch thread should NOT see the new column " +
                     "(demonstrates the race condition from issue #1222)");
@@ -405,9 +414,6 @@ class DDLSchemaChangeWaiterRaceConditionTest {
 
         /**
          * Proves the fix WITH the waiter.
-         *
-         * <p>Same simulation, but the DDL thread now waits for column
-         * propagation before signaling cache invalidation.</p>
          */
         @Test
         @DisplayName("FIX: With waiter, batch thread sees correct metadata")
@@ -417,12 +423,9 @@ class DDLSchemaChangeWaiterRaceConditionTest {
             AtomicBoolean batchSawNewColumn = new AtomicBoolean(false);
             CountDownLatch done = new CountDownLatch(2);
 
-            // DDL thread: executes ALTER, WAITS for propagation,
-            // then signals cache invalidation (the fix)
+            // DDL thread: WAITS for propagation before signaling (the fix)
             Thread ddlThread = new Thread(() -> {
                 try {
-                    // 1. "Execute" ALTER TABLE
-                    // 2. Start propagation in background
                     new Thread(() -> {
                         try {
                             Thread.sleep(200);
@@ -431,13 +434,13 @@ class DDLSchemaChangeWaiterRaceConditionTest {
                             Thread.currentThread().interrupt();
                         }
                     }).start();
-                    // 3. FIX: Wait for propagation (simulates DDLSchemaChangeWaiter)
+
+                    // FIX: poll until propagated (simulates DDLSchemaChangeWaiter)
                     long deadline = System.currentTimeMillis() + 5000;
                     while (!columnPropagated.get() &&
                             System.currentTimeMillis() < deadline) {
-                        Thread.sleep(50); // Poll interval
+                        Thread.sleep(50);
                     }
-                    // 4. NOW signal cache invalidation
                     cacheInvalidated.countDown();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
@@ -446,7 +449,6 @@ class DDLSchemaChangeWaiterRaceConditionTest {
                 }
             });
 
-            // Batch thread: same as before
             Thread batchThread = new Thread(() -> {
                 try {
                     cacheInvalidated.await(5, TimeUnit.SECONDS);
@@ -462,7 +464,6 @@ class DDLSchemaChangeWaiterRaceConditionTest {
             batchThread.start();
             assertTrue(done.await(5, TimeUnit.SECONDS), "Threads should complete");
 
-            // WITH THE FIX: batch thread now sees the new column
             assertTrue(batchSawNewColumn.get(),
                     "With waiter, batch thread SHOULD see the new column " +
                     "(proves the fix for issue #1222)");
@@ -470,9 +471,6 @@ class DDLSchemaChangeWaiterRaceConditionTest {
 
         /**
          * Stress test: 20 concurrent DDL + batch thread pairs.
-         *
-         * <p>All pairs start simultaneously via a CyclicBarrier.
-         * The waiter pattern must prevent stale reads in every pair.</p>
          */
         @Test
         @DisplayName("STRESS: 20 concurrent DDL+batch pairs with waiter")
@@ -490,12 +488,9 @@ class DDLSchemaChangeWaiterRaceConditionTest {
                 AtomicBoolean propagated = new AtomicBoolean(false);
                 CountDownLatch invalidated = new CountDownLatch(1);
 
-                // DDL thread with waiter
                 executor.submit(() -> {
                     try {
                         barrier.await(5, TimeUnit.SECONDS);
-
-                        // Simulate propagation delay (random 50-200ms)
                         long delay = 50 + (long)(Math.random() * 150);
                         new Thread(() -> {
                             try {
@@ -506,13 +501,11 @@ class DDLSchemaChangeWaiterRaceConditionTest {
                             }
                         }).start();
 
-                        // Waiter polls until propagated
                         long deadline = System.currentTimeMillis() + 5000;
                         while (!propagated.get() &&
                                 System.currentTimeMillis() < deadline) {
                             Thread.sleep(25);
                         }
-
                         invalidated.countDown();
                     } catch (Exception e) {
                         errors.add(e);
@@ -521,12 +514,10 @@ class DDLSchemaChangeWaiterRaceConditionTest {
                     }
                 });
 
-                // Batch thread
                 executor.submit(() -> {
                     try {
                         barrier.await(5, TimeUnit.SECONDS);
                         invalidated.await(5, TimeUnit.SECONDS);
-
                         if (propagated.get()) {
                             successfulReads.incrementAndGet();
                         } else {
@@ -543,8 +534,7 @@ class DDLSchemaChangeWaiterRaceConditionTest {
             assertTrue(allDone.await(30, TimeUnit.SECONDS), "All threads should complete");
             executor.shutdown();
 
-            assertTrue(errors.isEmpty(),
-                    "No thread errors expected, got: " + errors);
+            assertTrue(errors.isEmpty(), "No thread errors expected, got: " + errors);
             assertEquals(0, staleReads.get(),
                     "With waiter, there should be ZERO stale reads across all " +
                     pairCount + " pairs");
@@ -554,79 +544,334 @@ class DDLSchemaChangeWaiterRaceConditionTest {
     }
 
     // ---------------------------------------------------------------
-    // Integration-style JDBC mock tests
+    // Minimal JDBC stub implementations (no Mockito needed)
     // ---------------------------------------------------------------
 
-    @Nested
-    @DisplayName("End-to-end mock JDBC tests")
-    class EndToEndMockTests {
+    /**
+     * Lightweight Connection stub that only implements createStatement().
+     */
+    private static class StubConnection implements Connection {
+        private final QueryCallback callback;
+        StubConnection(QueryCallback callback) { this.callback = callback; }
 
-        @Test
-        @DisplayName("Multiple columns with staggered propagation")
-        void multipleColumnsStaggeredPropagation() throws Exception {
-            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(5000, 50);
-
-            Connection mockConn = mock(Connection.class);
-            Statement mockStmt = mock(Statement.class);
-            when(mockConn.createStatement()).thenReturn(mockStmt);
-
-            AtomicInteger pollCount = new AtomicInteger(0);
-            when(mockStmt.executeQuery(anyString())).thenAnswer(invocation -> {
-                int count = pollCount.incrementAndGet();
-                ResultSet rs = mock(ResultSet.class);
-                if (count == 1) {
-                    // Poll 1: no new columns yet
-                    when(rs.next()).thenReturn(true, false);
-                    when(rs.getString(1)).thenReturn("existing_col");
-                } else if (count == 2) {
-                    // Poll 2: first new column appears
-                    when(rs.next()).thenReturn(true, true, false);
-                    when(rs.getString(1)).thenReturn("existing_col", "col_a");
-                } else {
-                    // Poll 3+: both new columns visible
-                    when(rs.next()).thenReturn(true, true, true, false);
-                    when(rs.getString(1)).thenReturn("existing_col", "col_a", "col_b");
-                }
-                return rs;
-            });
-
-            waiter.waitForSchemaVisibility(mockConn,
-                    "ALTER TABLE `db`.`tbl` ADD COLUMN `col_a` String, ADD COLUMN `col_b` Int32");
-
-            // Should have polled at least 3 times (2 waits + 1 success)
-            assertTrue(pollCount.get() >= 3,
-                    "Expected at least 3 polls for staggered propagation, got " + pollCount.get());
+        @Override public Statement createStatement() {
+            return new StubStatement(callback);
         }
 
-        @Test
-        @DisplayName("JDBC exception during polling does not cause hang")
-        void jdbcExceptionDuringPolling() throws Exception {
-            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(500, 50);
+        // --- All other Connection methods throw UnsupportedOperationException ---
+        @Override public Statement createStatement(int a, int b) { throw new UnsupportedOperationException(); }
+        @Override public Statement createStatement(int a, int b, int c) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.PreparedStatement prepareStatement(String s) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.PreparedStatement prepareStatement(String s, int a, int b) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.PreparedStatement prepareStatement(String s, int a, int b, int c) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.PreparedStatement prepareStatement(String s, int a) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.PreparedStatement prepareStatement(String s, int[] a) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.PreparedStatement prepareStatement(String s, String[] a) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.CallableStatement prepareCall(String s) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.CallableStatement prepareCall(String s, int a, int b) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.CallableStatement prepareCall(String s, int a, int b, int c) { throw new UnsupportedOperationException(); }
+        @Override public String nativeSQL(String s) { throw new UnsupportedOperationException(); }
+        @Override public void setAutoCommit(boolean b) { }
+        @Override public boolean getAutoCommit() { return true; }
+        @Override public void commit() { }
+        @Override public void rollback() { }
+        @Override public void close() { }
+        @Override public boolean isClosed() { return false; }
+        @Override public java.sql.DatabaseMetaData getMetaData() { throw new UnsupportedOperationException(); }
+        @Override public void setReadOnly(boolean b) { }
+        @Override public boolean isReadOnly() { return true; }
+        @Override public void setCatalog(String s) { }
+        @Override public String getCatalog() { return null; }
+        @Override public void setTransactionIsolation(int i) { }
+        @Override public int getTransactionIsolation() { return Connection.TRANSACTION_NONE; }
+        @Override public java.sql.SQLWarning getWarnings() { return null; }
+        @Override public void clearWarnings() { }
+        @Override public java.util.Map<String, Class<?>> getTypeMap() { throw new UnsupportedOperationException(); }
+        @Override public void setTypeMap(java.util.Map<String, Class<?>> m) { }
+        @Override public void setHoldability(int h) { }
+        @Override public int getHoldability() { return 0; }
+        @Override public java.sql.Savepoint setSavepoint() { throw new UnsupportedOperationException(); }
+        @Override public java.sql.Savepoint setSavepoint(String s) { throw new UnsupportedOperationException(); }
+        @Override public void rollback(java.sql.Savepoint s) { }
+        @Override public void releaseSavepoint(java.sql.Savepoint s) { }
+        @Override public java.sql.Clob createClob() { throw new UnsupportedOperationException(); }
+        @Override public java.sql.Blob createBlob() { throw new UnsupportedOperationException(); }
+        @Override public java.sql.NClob createNClob() { throw new UnsupportedOperationException(); }
+        @Override public java.sql.SQLXML createSQLXML() { throw new UnsupportedOperationException(); }
+        @Override public boolean isValid(int t) { return true; }
+        @Override public void setClientInfo(String k, String v) { }
+        @Override public void setClientInfo(java.util.Properties p) { }
+        @Override public String getClientInfo(String k) { return null; }
+        @Override public java.util.Properties getClientInfo() { return new java.util.Properties(); }
+        @Override public java.sql.Array createArrayOf(String t, Object[] e) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.Struct createStruct(String t, Object[] a) { throw new UnsupportedOperationException(); }
+        @Override public void setSchema(String s) { }
+        @Override public String getSchema() { return null; }
+        @Override public void abort(java.util.concurrent.Executor e) { }
+        @Override public void setNetworkTimeout(java.util.concurrent.Executor e, int t) { }
+        @Override public int getNetworkTimeout() { return 0; }
+        @Override public <T> T unwrap(Class<T> c) { throw new UnsupportedOperationException(); }
+        @Override public boolean isWrapperFor(Class<?> c) { return false; }
+    }
 
-            Connection mockConn = mock(Connection.class);
-            Statement mockStmt = mock(Statement.class);
-            when(mockConn.createStatement()).thenReturn(mockStmt);
+    /**
+     * Lightweight Statement stub that delegates executeQuery to a callback.
+     */
+    private static class StubStatement implements Statement {
+        private final QueryCallback callback;
+        StubStatement(QueryCallback callback) { this.callback = callback; }
 
-            AtomicInteger pollCount = new AtomicInteger(0);
-            when(mockStmt.executeQuery(anyString())).thenAnswer(invocation -> {
-                int count = pollCount.incrementAndGet();
-                if (count <= 2) {
-                    // First 2 polls throw exceptions
-                    throw new java.sql.SQLException("Connection reset");
-                }
-                // Poll 3+: column visible
-                ResultSet rs = mock(ResultSet.class);
-                when(rs.next()).thenReturn(true, false);
-                when(rs.getString(1)).thenReturn("resilient_col");
-                return rs;
-            });
-
-            // Should recover from exceptions and eventually see the column
-            waiter.waitForSchemaVisibility(mockConn,
-                    "ALTER TABLE `db`.`tbl` ADD COLUMN `resilient_col` String");
-
-            assertTrue(pollCount.get() >= 3,
-                    "Should have retried after exceptions, got " + pollCount.get() + " polls");
+        @Override public ResultSet executeQuery(String sql) throws SQLException {
+            return callback.execute(sql);
         }
+
+        @Override public void close() { }
+        @Override public int getMaxFieldSize() { return 0; }
+        @Override public void setMaxFieldSize(int m) { }
+        @Override public int getMaxRows() { return 0; }
+        @Override public void setMaxRows(int m) { }
+        @Override public void setEscapeProcessing(boolean e) { }
+        @Override public int getQueryTimeout() { return 0; }
+        @Override public void setQueryTimeout(int s) { }
+        @Override public void cancel() { }
+        @Override public java.sql.SQLWarning getWarnings() { return null; }
+        @Override public void clearWarnings() { }
+        @Override public void setCursorName(String n) { }
+        @Override public boolean execute(String s) { return false; }
+        @Override public ResultSet getResultSet() { return null; }
+        @Override public int getUpdateCount() { return -1; }
+        @Override public boolean getMoreResults() { return false; }
+        @Override public void setFetchDirection(int d) { }
+        @Override public int getFetchDirection() { return ResultSet.FETCH_FORWARD; }
+        @Override public void setFetchSize(int r) { }
+        @Override public int getFetchSize() { return 0; }
+        @Override public int getResultSetConcurrency() { return ResultSet.CONCUR_READ_ONLY; }
+        @Override public int getResultSetType() { return ResultSet.TYPE_FORWARD_ONLY; }
+        @Override public void addBatch(String s) { }
+        @Override public void clearBatch() { }
+        @Override public int[] executeBatch() { return new int[0]; }
+        @Override public Connection getConnection() { return null; }
+        @Override public boolean getMoreResults(int c) { return false; }
+        @Override public ResultSet getGeneratedKeys() { return null; }
+        @Override public int executeUpdate(String s) { return 0; }
+        @Override public int executeUpdate(String s, int a) { return 0; }
+        @Override public int executeUpdate(String s, int[] a) { return 0; }
+        @Override public int executeUpdate(String s, String[] a) { return 0; }
+        @Override public boolean execute(String s, int a) { return false; }
+        @Override public boolean execute(String s, int[] a) { return false; }
+        @Override public boolean execute(String s, String[] a) { return false; }
+        @Override public int getResultSetHoldability() { return 0; }
+        @Override public boolean isClosed() { return false; }
+        @Override public void setPoolable(boolean p) { }
+        @Override public boolean isPoolable() { return false; }
+        @Override public void closeOnCompletion() { }
+        @Override public boolean isCloseOnCompletion() { return false; }
+        @Override public <T> T unwrap(Class<T> c) { throw new UnsupportedOperationException(); }
+        @Override public boolean isWrapperFor(Class<?> c) { return false; }
+    }
+
+    /**
+     * Lightweight ResultSet stub that iterates over a fixed list of
+     * column names (simulating system.columns query results).
+     */
+    private static class StubResultSet implements ResultSet {
+        private final String[] names;
+        private int cursor = -1;
+
+        StubResultSet(String... names) { this.names = names; }
+
+        @Override public boolean next() { return ++cursor < names.length; }
+        @Override public String getString(int columnIndex) { return names[cursor]; }
+        @Override public void close() { }
+
+        // --- Minimal stubs for remaining ResultSet methods ---
+        @Override public boolean wasNull() { return false; }
+        @Override public String getString(String c) { return names[cursor]; }
+        @Override public boolean getBoolean(int c) { return false; }
+        @Override public byte getByte(int c) { return 0; }
+        @Override public short getShort(int c) { return 0; }
+        @Override public int getInt(int c) { return 0; }
+        @Override public long getLong(int c) { return 0; }
+        @Override public float getFloat(int c) { return 0; }
+        @Override public double getDouble(int c) { return 0; }
+        @Override public java.math.BigDecimal getBigDecimal(int c, int s) { return null; }
+        @Override public byte[] getBytes(int c) { return null; }
+        @Override public java.sql.Date getDate(int c) { return null; }
+        @Override public java.sql.Time getTime(int c) { return null; }
+        @Override public java.sql.Timestamp getTimestamp(int c) { return null; }
+        @Override public java.io.InputStream getAsciiStream(int c) { return null; }
+        @Override public java.io.InputStream getUnicodeStream(int c) { return null; }
+        @Override public java.io.InputStream getBinaryStream(int c) { return null; }
+        @Override public boolean getBoolean(String c) { return false; }
+        @Override public byte getByte(String c) { return 0; }
+        @Override public short getShort(String c) { return 0; }
+        @Override public int getInt(String c) { return 0; }
+        @Override public long getLong(String c) { return 0; }
+        @Override public float getFloat(String c) { return 0; }
+        @Override public double getDouble(String c) { return 0; }
+        @Override public java.math.BigDecimal getBigDecimal(String c, int s) { return null; }
+        @Override public byte[] getBytes(String c) { return null; }
+        @Override public java.sql.Date getDate(String c) { return null; }
+        @Override public java.sql.Time getTime(String c) { return null; }
+        @Override public java.sql.Timestamp getTimestamp(String c) { return null; }
+        @Override public java.io.InputStream getAsciiStream(String c) { return null; }
+        @Override public java.io.InputStream getUnicodeStream(String c) { return null; }
+        @Override public java.io.InputStream getBinaryStream(String c) { return null; }
+        @Override public java.sql.SQLWarning getWarnings() { return null; }
+        @Override public void clearWarnings() { }
+        @Override public String getCursorName() { return null; }
+        @Override public ResultSetMetaData getMetaData() { return null; }
+        @Override public Object getObject(int c) { return null; }
+        @Override public Object getObject(String c) { return null; }
+        @Override public int findColumn(String c) { return 0; }
+        @Override public java.io.Reader getCharacterStream(int c) { return null; }
+        @Override public java.io.Reader getCharacterStream(String c) { return null; }
+        @Override public java.math.BigDecimal getBigDecimal(int c) { return null; }
+        @Override public java.math.BigDecimal getBigDecimal(String c) { return null; }
+        @Override public boolean isBeforeFirst() { return false; }
+        @Override public boolean isAfterLast() { return false; }
+        @Override public boolean isFirst() { return false; }
+        @Override public boolean isLast() { return false; }
+        @Override public void beforeFirst() { }
+        @Override public void afterLast() { }
+        @Override public boolean first() { return false; }
+        @Override public boolean last() { return false; }
+        @Override public int getRow() { return 0; }
+        @Override public boolean absolute(int r) { return false; }
+        @Override public boolean relative(int r) { return false; }
+        @Override public boolean previous() { return false; }
+        @Override public void setFetchDirection(int d) { }
+        @Override public int getFetchDirection() { return 0; }
+        @Override public void setFetchSize(int r) { }
+        @Override public int getFetchSize() { return 0; }
+        @Override public int getType() { return ResultSet.TYPE_FORWARD_ONLY; }
+        @Override public int getConcurrency() { return ResultSet.CONCUR_READ_ONLY; }
+        @Override public boolean rowUpdated() { return false; }
+        @Override public boolean rowInserted() { return false; }
+        @Override public boolean rowDeleted() { return false; }
+        @Override public void updateNull(int c) { }
+        @Override public void updateBoolean(int c, boolean v) { }
+        @Override public void updateByte(int c, byte v) { }
+        @Override public void updateShort(int c, short v) { }
+        @Override public void updateInt(int c, int v) { }
+        @Override public void updateLong(int c, long v) { }
+        @Override public void updateFloat(int c, float v) { }
+        @Override public void updateDouble(int c, double v) { }
+        @Override public void updateBigDecimal(int c, java.math.BigDecimal v) { }
+        @Override public void updateString(int c, String v) { }
+        @Override public void updateBytes(int c, byte[] v) { }
+        @Override public void updateDate(int c, java.sql.Date v) { }
+        @Override public void updateTime(int c, java.sql.Time v) { }
+        @Override public void updateTimestamp(int c, java.sql.Timestamp v) { }
+        @Override public void updateAsciiStream(int c, java.io.InputStream x, int l) { }
+        @Override public void updateBinaryStream(int c, java.io.InputStream x, int l) { }
+        @Override public void updateCharacterStream(int c, java.io.Reader x, int l) { }
+        @Override public void updateObject(int c, Object v, int s) { }
+        @Override public void updateObject(int c, Object v) { }
+        @Override public void updateNull(String c) { }
+        @Override public void updateBoolean(String c, boolean v) { }
+        @Override public void updateByte(String c, byte v) { }
+        @Override public void updateShort(String c, short v) { }
+        @Override public void updateInt(String c, int v) { }
+        @Override public void updateLong(String c, long v) { }
+        @Override public void updateFloat(String c, float v) { }
+        @Override public void updateDouble(String c, double v) { }
+        @Override public void updateBigDecimal(String c, java.math.BigDecimal v) { }
+        @Override public void updateString(String c, String v) { }
+        @Override public void updateBytes(String c, byte[] v) { }
+        @Override public void updateDate(String c, java.sql.Date v) { }
+        @Override public void updateTime(String c, java.sql.Time v) { }
+        @Override public void updateTimestamp(String c, java.sql.Timestamp v) { }
+        @Override public void updateAsciiStream(String c, java.io.InputStream x, int l) { }
+        @Override public void updateBinaryStream(String c, java.io.InputStream x, int l) { }
+        @Override public void updateCharacterStream(String c, java.io.Reader x, int l) { }
+        @Override public void updateObject(String c, Object v, int s) { }
+        @Override public void updateObject(String c, Object v) { }
+        @Override public void insertRow() { }
+        @Override public void updateRow() { }
+        @Override public void deleteRow() { }
+        @Override public void refreshRow() { }
+        @Override public void cancelRowUpdates() { }
+        @Override public void moveToInsertRow() { }
+        @Override public void moveToCurrentRow() { }
+        @Override public Statement getStatement() { return null; }
+        @Override public Object getObject(int c, java.util.Map<String, Class<?>> m) { return null; }
+        @Override public java.sql.Ref getRef(int c) { return null; }
+        @Override public java.sql.Blob getBlob(int c) { return null; }
+        @Override public java.sql.Clob getClob(int c) { return null; }
+        @Override public java.sql.Array getArray(int c) { return null; }
+        @Override public Object getObject(String c, java.util.Map<String, Class<?>> m) { return null; }
+        @Override public java.sql.Ref getRef(String c) { return null; }
+        @Override public java.sql.Blob getBlob(String c) { return null; }
+        @Override public java.sql.Clob getClob(String c) { return null; }
+        @Override public java.sql.Array getArray(String c) { return null; }
+        @Override public java.sql.Date getDate(int c, java.util.Calendar cal) { return null; }
+        @Override public java.sql.Date getDate(String c, java.util.Calendar cal) { return null; }
+        @Override public java.sql.Time getTime(int c, java.util.Calendar cal) { return null; }
+        @Override public java.sql.Time getTime(String c, java.util.Calendar cal) { return null; }
+        @Override public java.sql.Timestamp getTimestamp(int c, java.util.Calendar cal) { return null; }
+        @Override public java.sql.Timestamp getTimestamp(String c, java.util.Calendar cal) { return null; }
+        @Override public java.net.URL getURL(int c) { return null; }
+        @Override public java.net.URL getURL(String c) { return null; }
+        @Override public void updateRef(int c, java.sql.Ref v) { }
+        @Override public void updateRef(String c, java.sql.Ref v) { }
+        @Override public void updateBlob(int c, java.sql.Blob v) { }
+        @Override public void updateBlob(String c, java.sql.Blob v) { }
+        @Override public void updateClob(int c, java.sql.Clob v) { }
+        @Override public void updateClob(String c, java.sql.Clob v) { }
+        @Override public void updateArray(int c, java.sql.Array v) { }
+        @Override public void updateArray(String c, java.sql.Array v) { }
+        @Override public java.sql.RowId getRowId(int c) { return null; }
+        @Override public java.sql.RowId getRowId(String c) { return null; }
+        @Override public void updateRowId(int c, java.sql.RowId v) { }
+        @Override public void updateRowId(String c, java.sql.RowId v) { }
+        @Override public int getHoldability() { return 0; }
+        @Override public boolean isClosed() { return false; }
+        @Override public void updateNString(int c, String v) { }
+        @Override public void updateNString(String c, String v) { }
+        @Override public void updateNClob(int c, java.sql.NClob v) { }
+        @Override public void updateNClob(String c, java.sql.NClob v) { }
+        @Override public java.sql.NClob getNClob(int c) { return null; }
+        @Override public java.sql.NClob getNClob(String c) { return null; }
+        @Override public java.sql.SQLXML getSQLXML(int c) { return null; }
+        @Override public java.sql.SQLXML getSQLXML(String c) { return null; }
+        @Override public void updateSQLXML(int c, java.sql.SQLXML v) { }
+        @Override public void updateSQLXML(String c, java.sql.SQLXML v) { }
+        @Override public String getNString(int c) { return null; }
+        @Override public String getNString(String c) { return null; }
+        @Override public java.io.Reader getNCharacterStream(int c) { return null; }
+        @Override public java.io.Reader getNCharacterStream(String c) { return null; }
+        @Override public void updateNCharacterStream(int c, java.io.Reader x, long l) { }
+        @Override public void updateNCharacterStream(String c, java.io.Reader x, long l) { }
+        @Override public void updateAsciiStream(int c, java.io.InputStream x, long l) { }
+        @Override public void updateBinaryStream(int c, java.io.InputStream x, long l) { }
+        @Override public void updateCharacterStream(int c, java.io.Reader x, long l) { }
+        @Override public void updateAsciiStream(String c, java.io.InputStream x, long l) { }
+        @Override public void updateBinaryStream(String c, java.io.InputStream x, long l) { }
+        @Override public void updateCharacterStream(String c, java.io.Reader x, long l) { }
+        @Override public void updateBlob(int c, java.io.InputStream x, long l) { }
+        @Override public void updateBlob(String c, java.io.InputStream x, long l) { }
+        @Override public void updateClob(int c, java.io.Reader x, long l) { }
+        @Override public void updateClob(String c, java.io.Reader x, long l) { }
+        @Override public void updateNClob(int c, java.io.Reader x, long l) { }
+        @Override public void updateNClob(String c, java.io.Reader x, long l) { }
+        @Override public void updateNCharacterStream(int c, java.io.Reader x) { }
+        @Override public void updateNCharacterStream(String c, java.io.Reader x) { }
+        @Override public void updateAsciiStream(int c, java.io.InputStream x) { }
+        @Override public void updateBinaryStream(int c, java.io.InputStream x) { }
+        @Override public void updateCharacterStream(int c, java.io.Reader x) { }
+        @Override public void updateAsciiStream(String c, java.io.InputStream x) { }
+        @Override public void updateBinaryStream(String c, java.io.InputStream x) { }
+        @Override public void updateCharacterStream(String c, java.io.Reader x) { }
+        @Override public void updateBlob(int c, java.io.InputStream x) { }
+        @Override public void updateBlob(String c, java.io.InputStream x) { }
+        @Override public void updateClob(int c, java.io.Reader x) { }
+        @Override public void updateClob(String c, java.io.Reader x) { }
+        @Override public void updateNClob(int c, java.io.Reader x) { }
+        @Override public void updateNClob(String c, java.io.Reader x) { }
+        @Override public <T> T getObject(int c, Class<T> t) { return null; }
+        @Override public <T> T getObject(String c, Class<T> t) { return null; }
+        @Override public <T> T unwrap(Class<T> c) { throw new UnsupportedOperationException(); }
+        @Override public boolean isWrapperFor(Class<?> c) { return false; }
     }
 }

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DDLSchemaChangeWaiterTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DDLSchemaChangeWaiterTest.java
@@ -1,0 +1,94 @@
+package com.altinity.clickhouse.sink.connector.db;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link DDLSchemaChangeWaiter}.
+ * Tests the DDL parsing and column name extraction logic.
+ */
+class DDLSchemaChangeWaiterTest {
+
+    @Test
+    void testExtractAddColumnNames() {
+        String ddl = "ALTER TABLE `test_db`.`test_table` ADD COLUMN `new_col1` String, ADD COLUMN `new_col2` Int32";
+        List<String> columns = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+        assertEquals(2, columns.size());
+        assertTrue(columns.contains("new_col1"));
+        assertTrue(columns.contains("new_col2"));
+    }
+
+    @Test
+    void testExtractDropColumnNames() {
+        String ddl = "ALTER TABLE `test_db`.`test_table` DROP COLUMN `old_col`";
+        List<String> columns = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                Pattern.compile("DROP\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+        assertEquals(1, columns.size());
+        assertEquals("old_col", columns.get(0));
+    }
+
+    @Test
+    void testExtractUnquotedColumnNames() {
+        String ddl = "ALTER TABLE test_db.test_table ADD COLUMN new_col String";
+        List<String> columns = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+        assertEquals(1, columns.size());
+        assertEquals("new_col", columns.get(0));
+    }
+
+    @Test
+    void testExtractNoMatchReturnsEmpty() {
+        String ddl = "ALTER TABLE test_db.test_table MODIFY COLUMN col1 String";
+        List<String> columns = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+        assertTrue(columns.isEmpty());
+    }
+
+    @Test
+    void testExtractMultipleAddColumns() {
+        String ddl = "ALTER TABLE `db`.`tbl` ADD COLUMN `a` Int8, ADD COLUMN `b` String, ADD COLUMN `c` Float64";
+        List<String> columns = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+        assertEquals(3, columns.size());
+        assertEquals("a", columns.get(0));
+        assertEquals("b", columns.get(1));
+        assertEquals("c", columns.get(2));
+    }
+
+    @Test
+    void testWaitForSchemaVisibilityNullInputs() {
+        DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(100, 10);
+        // Should not throw on null connection or DDL
+        assertDoesNotThrow(() -> waiter.waitForSchemaVisibility(null, "ALTER TABLE db.tbl ADD COLUMN x Int32"));
+        assertDoesNotThrow(() -> waiter.waitForSchemaVisibility(null, null));
+        assertDoesNotThrow(() -> waiter.waitForSchemaVisibility(null, ""));
+    }
+
+    @Test
+    void testWaitForSchemaVisibilityNonAlterTable() {
+        DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(100, 10);
+        // Non-ALTER TABLE DDL should return immediately (no table matcher match)
+        assertDoesNotThrow(() -> waiter.waitForSchemaVisibility(null, "CREATE TABLE db.tbl (id Int32) ENGINE = MergeTree()"));
+    }
+
+    @Test
+    void testConstructorDefaults() {
+        DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter();
+        assertEquals(30_000, DDLSchemaChangeWaiter.DEFAULT_TIMEOUT_MS);
+        assertEquals(100, DDLSchemaChangeWaiter.DEFAULT_POLL_INTERVAL_MS);
+    }
+
+    @Test
+    void testCaseInsensitiveExtraction() {
+        String ddl = "alter table `DB`.`TBL` add column `MixedCase` String";
+        List<String> columns = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+        assertEquals(1, columns.size());
+        assertEquals("MixedCase", columns.get(0));
+    }
+}


### PR DESCRIPTION
Fixes #1319 (and the root cause behind #1222 that PR #1223 did not fully address).

## Problem

After executing ALTER TABLE (ADD/DROP COLUMN), the connector immediately signals cache invalidation via CacheInvalidationManager. The batch insert thread then rebuilds its column metadata cache by querying system.columns. However, the ALTER TABLE may not have propagated to system.columns yet, causing the new DbWriter to get stale column metadata and silently drop values for newly added columns.

Under concurrent load, approximately 37% of newly added columns had their values silently lost (22 out of 60 columns showed NULL instead of the inserted value).

## Solution

Added DDLSchemaChangeWaiter, a utility that polls system.columns after each ALTER TABLE until the expected columns appear (for ADD COLUMN) or disappear (for DROP COLUMN) before returning from executeDDL(). The visibility wait occurs before cache invalidation proceeds, ensuring the batch thread always sees the updated schema.

## Changes

- **New: DDLSchemaChangeWaiter.java** -- Polls system.columns with configurable timeout (default 30s) and poll interval (default 100ms). Falls back to a 500ms delay for unparseable ALTER TABLE types.

- **Modified: DebeziumChangeEventCapture.java** -- Added call to DDLSchemaChangeWaiter.waitForSchemaVisibility() after each DDL query in executeDDL().

- **New: DDLSchemaChangeWaiterTest.java** -- Unit tests covering DDL parsing, null safety, case insensitivity, and non-ALTER-TABLE passthrough.

## Test Plan

- Unit tests for DDL parsing regex extraction and edge cases
- Verified code path: schema visibility wait occurs before cache invalidation
- Race condition was reproduced with 60 concurrent ALTER + INSERT cycles showing 37% silent data loss; the fix ensures system.columns reflects the change before proceeding