### PR TITLE
Fix sink connector startup race by adding depends_on healthcheck

### DIFF
--- a/sink-connector-lightweight/docker/docker-compose-mysql.yml
+++ b/sink-connector-lightweight/docker/docker-compose-mysql.yml
@@ -29,6 +29,11 @@ services:
     extends:
       file: clickhouse-sink-connector-lt-service.yml
       service: clickhouse-sink-connector-lt
+    depends_on:
+      clickhouse:
+          condition: service_healthy
+      mysql-master:
+          condition: service_healthy
 
 
   ### MONITORING ####


### PR DESCRIPTION
### What
File: `/clickhouse-sink-connector/sink-connector-lightweight/docker/docker-compose-mysql.yml`
Adds `depends_on: condition: service_healthy` for `clickhouse` and `mysql-master` under the `clickhouse-sink-connector-lt` service in `docker-compose-mysql.yml`.

### Why
Fixes #1331

Without this, `clickhouse-sink-connector-lt` starts concurrently with its dependencies(clickhouse and mysql) instead of waiting for their healthchecks to pass. On a cold start, this can cause the container to fail DNS resolution against the `clickhouse` container (`UnknownHostException`), and crashes the connector process permanently. The container itself stays `Up`, giving no indication anything failed and no data replicates until it's manually restarted. Full crash log and root cause analysis in #1331.

### Fix
```yaml
clickhouse-sink-connector-lt:
    extends:
      file: clickhouse-sink-connector-lt-service.yml
      service: clickhouse-sink-connector-lt
    depends_on:
      clickhouse:
        condition: service_healthy
      mysql-master:
        condition: service_healthy
```

### Testing
Reproduced the crash on a clean `down -v` / `up` cycle without the fix (see #1331 for the crash log). Applied the `depends_on` change and repeated the same clean cycle. The connector waited for both healthchecks, started cleanly with no connection errors, completed the initial snapshot, and transitioned into live binlog streaming:

<details>
<summary>Log excerpt (successful startup, click to expand)</summary>

```
2026-07-11 11:59:39.153 INFO  - ***** Sink Connector Release version: *** 2.9.1-test
2026-07-11 11:59:40.167 INFO  - CREATING DEBEZIUM STORAGE Database: create database if not exists altinity_sink_connector
2026-07-11 11:59:51.325 INFO  - Successfully tested connection for jdbc:mysql://mysql-master:3306/... with user 'root'
2026-07-11 11:59:51.887 INFO  - Connector started for the first time.
...
2026-07-11 12:00:19.546 INFO  - Snapshot completed
2026-07-11 12:00:19.547 INFO  - Snapshot ended with SnapshotResult [status=COMPLETED, ...]
...
2026-07-11 12:00:22.752 INFO  - Starting streaming
2026-07-11 12:00:23.529 INFO  - Connected to binlog at mysql-master:3306, starting at BinlogOffsetContext{...}
2026-07-11 12:00:23.637 INFO  - Keepalive thread is running
```
</details>

Also verified ongoing CDC replication: created a new table (`foo`) in MySQL after startup, confirmed it was picked up via the DDL stream and replicated with matching data into ClickHouse:

```
2026-07-11 12:02:24.418 INFO  - Executed Source DB DDL: CREATE TABLE foo (id int PRIMARY KEY, value VARCHAR(100)) Snapshot:false
2026-07-11 12:02:24.419 INFO  - ClickHouse DDL: CREATE TABLE test.foo(id Int32 NOT NULL ,value Nullable(String),`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) ORDER BY id
2026-07-11 12:02:32.244 INFO  - *************** EXECUTED BATCH Successfully Records: 1************** ... Database: test Table: foo
```

No other behavior changed, this is a startup-ordering fix only.