### PR TITLE
Default MODIFY/CHANGE COLUMN to Nullable when schema metadata is unavailable

### DIFF
--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
@@ -781,6 +781,10 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
         } else if (tree instanceof MySqlParser.AlterByModifyColumnContext) {
             modifier = Constants.MODIFY_COLUMN;
             modifierWithNull = Constants.MODIFY_COLUMN_NULLABLE;
+            // In MySQL, MODIFY COLUMN without an explicit NULL/NOT NULL constraint
+            // makes the column nullable, so default to Nullable when the current
+            // schema cannot be retrieved from ClickHouse.
+            isNullColumn = true;
         } else if (tree instanceof MySqlParser.AlterByRenameColumnContext) {
             modifier = Constants.RENAME_COLUMN;
             modifierWithNull = Constants.RENAME_COLUMN_NULLABLE;
@@ -789,6 +793,7 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
             isAlterChangeColumn = true;
             modifier = Constants.MODIFY_COLUMN;
             modifierWithNull = Constants.MODIFY_COLUMN_NULLABLE;
+            isNullColumn = true;
         } else if (tree instanceof MySqlParser.AlterByAddIndexContext) {
             modifier = Constants.ADD_INDEX;
         } else {

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
@@ -793,6 +793,7 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
             isAlterChangeColumn = true;
             modifier = Constants.MODIFY_COLUMN;
             modifierWithNull = Constants.MODIFY_COLUMN_NULLABLE;
+            // Same MySQL semantics as MODIFY COLUMN above.
             isNullColumn = true;
         } else if (tree instanceof MySqlParser.AlterByAddIndexContext) {
             modifier = Constants.ADD_INDEX;

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java
@@ -529,7 +529,7 @@ public class MySqlDDLParserListenerImplTest {
         String alterTableModifyColumn = "ALTER TABLE employees.add_test MODIFY COLUMN col1 INT;";
         mySQLDDLParserService.parseSql(alterTableModifyColumn, "add_test", clickHouseQuery);
 
-        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE employees.add_test MODIFY COLUMN col1 Int32"));
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE employees.add_test MODIFY COLUMN col1 Nullable(Int32)"));
     }
 
     @Test
@@ -556,7 +556,7 @@ public class MySqlDDLParserListenerImplTest {
         mySQLDDLParserService.parseSql(alterDBAddColumnNonNullable, "contacts", clickHouseQueryNonNullable);
         //Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE contacts MODIFY COLUMN last_name Nullable(String)"));
         log.info("CLICKHOUSE QUERY" + clickHouseQueryNonNullable);
-        Assert.assertTrue(clickHouseQueryNonNullable.toString().equalsIgnoreCase("ALTER TABLE employees.`table_fcdd63fd_0c60_11ef_a293_cfcc8bfdbf55` MODIFY COLUMN col1 String\n" +
+        Assert.assertTrue(clickHouseQueryNonNullable.toString().equalsIgnoreCase("ALTER TABLE employees.`table_fcdd63fd_0c60_11ef_a293_cfcc8bfdbf55` MODIFY COLUMN col1 Nullable(String) \n" +
                 "ALTER TABLE database_1.`table_fcdd63fd_0c60_11ef_a293_cfcc8bfdbf55` RENAME COLUMN col1 to new_col"));
     }
 
@@ -612,7 +612,7 @@ public class MySqlDDLParserListenerImplTest {
     public void testChangeColumn() {
         StringBuffer clickHouseQuery = new StringBuffer();
 
-        String expectedCHQuery = "ALTER TABLE employees.add_test MODIFY COLUMN stocks Bool\n" +
+        String expectedCHQuery = "ALTER TABLE employees.add_test MODIFY COLUMN stocks Nullable(Bool) \n" +
                 "ALTER TABLE employees.add_test RENAME COLUMN stocks to options";
         String sql = "alter table add_test change column stocks options bool";
         mySQLDDLParserService.parseSql(sql, "t2", clickHouseQuery);
@@ -624,7 +624,7 @@ public class MySqlDDLParserListenerImplTest {
     public void testChangeColumnFirst() {
         StringBuffer clickHouseQuery = new StringBuffer();
 
-        String expectedCHQuery = "ALTER TABLE employees.add_test MODIFY COLUMN stocks Bool first\n" +
+        String expectedCHQuery = "ALTER TABLE employees.add_test MODIFY COLUMN stocks Nullable(Bool)  first\n" +
                 "ALTER TABLE employees.add_test RENAME COLUMN stocks to options";
         String sql = "alter table add_test change column stocks options bool first";
         mySQLDDLParserService.parseSql(sql, "t2", clickHouseQuery);
@@ -636,7 +636,7 @@ public class MySqlDDLParserListenerImplTest {
     public void testChangeColumnAfter() {
         StringBuffer clickHouseQuery = new StringBuffer();
 
-        String expectedCHQuery = "ALTER TABLE employees.add_test MODIFY COLUMN stocks Bool after col1\n" +
+        String expectedCHQuery = "ALTER TABLE employees.add_test MODIFY COLUMN stocks Nullable(Bool)  after col1\n" +
                 "ALTER TABLE employees.add_test RENAME COLUMN stocks to options";
         String sql = "alter table add_test change column stocks options bool after col1";
         mySQLDDLParserService.parseSql(sql, "t2", clickHouseQuery);
@@ -650,9 +650,39 @@ public class MySqlDDLParserListenerImplTest {
 
         StringBuffer clickHouseQuery = new StringBuffer();
 
-        String expectedCHQuery = "ALTER TABLE employees.ship_class MODIFY COLUMN tonange Decimal(10,10)\n" +
+        String expectedCHQuery = "ALTER TABLE employees.ship_class MODIFY COLUMN tonange Nullable(Decimal(10,10)) \n" +
                 "ALTER TABLE employees.ship_class RENAME COLUMN tonange to tonange_new";
 
+        mySQLDDLParserService.parseSql(sql, "t2", clickHouseQuery);
+
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(expectedCHQuery));
+    }
+
+    @Test
+    public void testModifyColumnWithNotNull() {
+        StringBuffer clickHouseQuery = new StringBuffer();
+        String sql = "ALTER TABLE employees.add_test MODIFY COLUMN col1 INT NOT NULL;";
+        mySQLDDLParserService.parseSql(sql, "add_test", clickHouseQuery);
+
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE employees.add_test MODIFY COLUMN col1 Int32"));
+    }
+
+    @Test
+    public void testModifyColumnWithExplicitNull() {
+        StringBuffer clickHouseQuery = new StringBuffer();
+        String sql = "ALTER TABLE employees.add_test MODIFY COLUMN col1 INT NULL;";
+        mySQLDDLParserService.parseSql(sql, "add_test", clickHouseQuery);
+
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE employees.add_test MODIFY COLUMN col1 Nullable(Int32)"));
+    }
+
+    @Test
+    public void testChangeColumnWithNotNull() {
+        StringBuffer clickHouseQuery = new StringBuffer();
+
+        String expectedCHQuery = "ALTER TABLE employees.add_test MODIFY COLUMN stocks Bool\n" +
+                "ALTER TABLE employees.add_test RENAME COLUMN stocks to options";
+        String sql = "alter table add_test change column stocks options bool not null";
         mySQLDDLParserService.parseSql(sql, "t2", clickHouseQuery);
 
         Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(expectedCHQuery));

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java
@@ -687,6 +687,19 @@ public class MySqlDDLParserListenerImplTest {
 
         Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(expectedCHQuery));
     }
+
+    @Test
+    public void testChangeColumnWithExplicitNull() {
+        StringBuffer clickHouseQuery = new StringBuffer();
+
+        String expectedCHQuery = "ALTER TABLE employees.add_test MODIFY COLUMN stocks Nullable(Bool) \n" +
+                "ALTER TABLE employees.add_test RENAME COLUMN stocks to options";
+        String sql = "alter table add_test change column stocks options bool null";
+        mySQLDDLParserService.parseSql(sql, "t2", clickHouseQuery);
+
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(expectedCHQuery));
+    }
+
     @Test
     public void testAddConstraints() {
         StringBuffer clickHouseQuery = new StringBuffer();


### PR DESCRIPTION
## Summary

When a `MODIFY COLUMN` or `CHANGE COLUMN` DDL has no explicit `NULL`/`NOT NULL` constraint, `MySqlDDLParserListenerImpl` determines nullability by looking up the column's current state in ClickHouse. If that lookup is unavailable (broken DB connection or query error), the column falls back to **non-Nullable**.

In MySQL, omitting the nullability constraint on `MODIFY`/`CHANGE COLUMN` makes the column nullable. Replicating it as non-Nullable caused stuck mutations in our production environment: a `MODIFY COLUMN` DDL was translated to a non-Nullable ClickHouse mutation on a column that contained NULL values, and the mutation could never complete. We have been running this fix in production and verified it resolves the issue.

## Changes

- Set `isNullColumn = true` in the `AlterByModifyColumnContext` and `AlterByChangeColumnContext` branches, consistent with the existing `AlterByAddColumnContext` behavior.
- Explicit `NULL`/`NOT NULL` constraints and the ClickHouse metadata lookup still take precedence. Only the fallback path (lookup unavailable or failed) changes.

## Known trade-off

If the modified column is part of the ClickHouse table's ORDER BY / primary key **and** the schema lookup is unavailable at the same time, the generated `MODIFY COLUMN ... Nullable(...)` DDL will be rejected by ClickHouse ("Sorting key cannot contain nullable columns"). The old fallback happened to be correct for that narrow case, but silently produced stuck mutations for ordinary nullable columns. The new fallback fails loudly at DDL time instead of corrupting replication silently. The normal path is unaffected: when the metadata lookup succeeds, sorting-key columns still resolve to non-Nullable.

## Tests

- Updated 6 unit test expectations in `MySqlDDLParserListenerImplTest` that pinned the old non-Nullable fallback (unit tests run without a DB connection, so they exercise exactly this path).
- Added 4 new unit tests verifying explicit constraints still win over the new default: `testModifyColumnWithNotNull`, `testModifyColumnWithExplicitNull`, `testChangeColumnWithNotNull`, `testChangeColumnWithExplicitNull`.
- `MySqlDDLParserListenerImplTest`: 99 run, 0 failures.
- `AlterTableModifyColumnIT` (testcontainers, live MySQL + ClickHouse): passes unchanged, confirming the live-connection path is unaffected.

## Files Changed

- `sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java` (2 branches)
- `sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java` (6 updated expectations, 4 new tests)
