### PR TITLE
Guard against null JDBC params/settings in BaseDbWriter.createConnection

### DIFF
--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/BaseDbWriter.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/BaseDbWriter.java
@@ -248,7 +248,7 @@ public class BaseDbWriter {
         try {
             Properties properties = new Properties();
             properties.setProperty("client_name", clientName);
-            if(!jdbcSettings.isEmpty()) {
+            if(jdbcSettings != null && !jdbcSettings.isEmpty()) {
                 properties.setProperty("custom_settings", jdbcSettings);
             } else {
                 properties.setProperty("custom_settings", "allow_experimental_object_type=1,insert_allow_materialized_columns=1");
@@ -258,7 +258,7 @@ public class BaseDbWriter {
             if(!connectionPoolDisable) {
                 properties.setProperty("http_connection_provider", "HTTP_URL_CONNECTION");
             }
-            if (!jdbcParams.isEmpty()) {
+            if (jdbcParams != null && !jdbcParams.isEmpty()) {
                 log.info("**** JDBC PARAMS from configuration:" + jdbcParams);
                 Properties userProps = splitJdbcProperties(jdbcParams);
                 properties.putAll(userProps);

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/BaseDbWriterTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/BaseDbWriterTest.java
@@ -35,4 +35,26 @@ public class BaseDbWriterTest {
         Assert.assertEquals(properties.getProperty("max_buffer_size"), "1000000");
         Assert.assertEquals(properties.getProperty("socket_timeout"), "10000");
     }
+
+    @Test
+    public void testSplitJdbcPropertiesWithSsl() {
+        // Note: the parameters should not contain extra spaces.
+        String jdbcProperties = "ssl=true,sslmode=none";
+        Map props = new HashMap<>();
+        props.put(ClickHouseSinkConnectorConfigVariables.JDBC_PARAMETERS.toString(), jdbcProperties);
+        ClickHouseSinkConnectorConfig config = new ClickHouseSinkConnectorConfig(props);
+
+        Connection conn = BaseDbWriter.createConnection(
+                "localhost", BaseDbWriter.DATABASE_CLIENT_NAME,"default", "",BaseDbWriter.SYSTEM_DB, config);
+        Properties properties = new BaseDbWriter(
+                "localhost",
+                8123,
+                "default",
+                "default",
+                "",
+                config, conn
+        ).splitJdbcProperties(jdbcProperties);
+        Assert.assertEquals(properties.getProperty("ssl"), "true");
+        Assert.assertEquals(properties.getProperty("sslmode"), "none");
+    }
 }


### PR DESCRIPTION
## Summary

`config.getString()` can return `null` for `clickhouse.jdbc.params` and `clickhouse.jdbc.settings`. In the lightweight connector, a YAML config line with an empty value (`clickhouse.jdbc.params:`) parses to null. `createConnection` then throws a `NullPointerException` on `isEmpty()`, which is swallowed by the surrounding catch block, so the caller only sees a null connection with no obvious cause.

We ran into this while setting up TLS connections to ClickHouse via `clickhouse.jdbc.params: "ssl=true,sslmode=none"`, and have been running this fix in production.

## Changes

- Null-guard the `jdbcParams` and `jdbcSettings` checks in `BaseDbWriter.createConnection`.

## Tests

- Added `testSplitJdbcPropertiesWithSsl` covering TLS-style JDBC parameters (`ssl=true,sslmode=none`) in `splitJdbcProperties` — this configuration path previously had no test coverage.
- `BaseDbWriterTest`: 2 run, 0 failures.
- A direct NPE regression test through `createConnection` is not feasible: the method catches all exceptions and returns null, so the NPE is not observable from the outside.

## Files Changed

- `sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/BaseDbWriter.java`
- `sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/BaseDbWriterTest.java`