### PR TITLE
fix(sink): gate Kafka Connect offset commit on durable ClickHouse insert

### DIFF
--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/ClickHouseSinkTask.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/ClickHouseSinkTask.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -58,6 +59,15 @@ public class ClickHouseSinkTask extends SinkTask {
      * Queue used to store batches of records to be processed.
      */
     private LinkedBlockingQueue<List<ClickHouseStruct>> records;
+
+    /**
+     * Highest Kafka offset per TopicPartition that has been DURABLY inserted
+     * into ClickHouse (fed by the ClickHouseBatchRunnable after each successful
+     * flush). preCommit() returns offsets derived from this map instead of the
+     * offsets Kafka Connect merely delivered to put(), so a crash/restart never
+     * skips records that were consumed but not yet persisted.
+     */
+    private ConcurrentHashMap<TopicPartition, Long> durablyInsertedOffsets;
 
     /**
      * A de-duplicator utility to detect and skip duplicate messages.
@@ -113,9 +123,11 @@ public class ClickHouseSinkTask extends SinkTask {
                 ClickHouseSinkConnectorConfigVariables.MAX_QUEUE_SIZE.toString());
 
         this.records = new LinkedBlockingQueue<>(maxQueueSize);
+        this.durablyInsertedOffsets = new ConcurrentHashMap<>();
 
         ClickHouseBatchRunnable runnable = new ClickHouseBatchRunnable(
-                this.records, this.config, topic2TableMap);
+                this.records, this.config, topic2TableMap,
+                this.durablyInsertedOffsets);
 
         ThreadFactory namedThreadFactory = new ThreadFactoryBuilder()
                 .setNameFormat("Sink Connector thread-pool-%d")
@@ -195,6 +207,19 @@ public class ClickHouseSinkTask extends SinkTask {
         List<ClickHouseStruct> batch = new ArrayList<>();
 
         for (SinkRecord record : records) {
+            // Establish the per-partition durable baseline the first time we see
+            // a partition in this run. Kafka delivers records to put() in offset
+            // order per partition, so the first record's offset is the resume
+            // point: everything strictly before it was already durably committed
+            // in a previous run. Seeding the watermark to (firstOffset - 1) means
+            // preCommit holds at the resume point until a real insert advances it,
+            // instead of blindly trusting the offsets Connect delivered (which
+            // would lose records consumed-but-not-yet-inserted, e.g. if CH is down
+            // right from task start).
+            TopicPartition tp = new TopicPartition(
+                    record.topic(), record.kafkaPartition());
+            this.durablyInsertedOffsets.putIfAbsent(tp, record.kafkaOffset() - 1L);
+
             if (this.deduplicator.isNew(record.topic(), record)) {
                 ClickHouseStruct c = converter.convert(record);
                 if (c != null) {
@@ -260,8 +285,23 @@ public class ClickHouseSinkTask extends SinkTask {
 
         try {
             currentOffsets.forEach((topicPartition, offsetAndMetadata) -> {
+                // Kafka commits the "next offset to consume" = lastOffset + 1.
+                Long durable = this.durablyInsertedOffsets.get(topicPartition);
+                long committed;
+                if (durable == null) {
+                    // No durable insert recorded for this partition yet in the
+                    // current run (e.g. right after a restart): trust the offset
+                    // Connect gives us — it already reflects the last durably
+                    // committed position from the previous run, because we only
+                    // ever commit durable offsets.
+                    committed = offsetAndMetadata.offset();
+                } else {
+                    // Only advance up to what was actually inserted into CH,
+                    // never beyond what Connect delivered.
+                    committed = Math.min(offsetAndMetadata.offset(), durable + 1);
+                }
                 committedOffsets.put(topicPartition,
-                        new OffsetAndMetadata(offsetAndMetadata.offset()));
+                        new OffsetAndMetadata(committed));
             });
         } catch (Exception e) {
             log.error("preCommit({}):{}", this.id, e.getMessage());

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchRunnable.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchRunnable.java
@@ -93,6 +93,13 @@ public class ClickHouseBatchRunnable implements Runnable {
     private List<ClickHouseStruct> currentBatch = null;
 
     /**
+     * Shared watermark (owned by ClickHouseSinkTask): highest Kafka offset per
+     * TopicPartition durably inserted into ClickHouse. Updated after each
+     * successful flush so preCommit() only commits persisted offsets.
+     */
+    private final Map<TopicPartition, Long> durablyInsertedOffsets;
+
+    /**
      * Map for overriding database names from source to destination.
      */
     private Map<String, String> databaseOverrideMap = new HashMap<>();
@@ -105,6 +112,11 @@ public class ClickHouseBatchRunnable implements Runnable {
     /**
      * Constructs a ClickHouseBatchRunnable (legacy mode without hash-based routing).
      *
+     * <p>Backward-compatible overload for callers that do not track durable
+     * offsets: a private (unshared) watermark is used, so the durable-offset
+     * gating in {@code ClickHouseSinkTask.preCommit()} is a no-op for this
+     * instance (pre-existing behaviour is preserved).</p>
+     *
      * @param records        the queue of record batches
      * @param config         the connector configuration
      * @param topic2TableMap a map of topic names to table names
@@ -113,7 +125,23 @@ public class ClickHouseBatchRunnable implements Runnable {
             LinkedBlockingQueue<List<ClickHouseStruct>> records,
             ClickHouseSinkConnectorConfig config,
             Map<String, String> topic2TableMap) {
-        this(records, null, -1, config, topic2TableMap);
+        this(records, null, -1, config, topic2TableMap, new ConcurrentHashMap<>());
+    }
+
+    /**
+     * Constructs a ClickHouseBatchRunnable (legacy mode without hash-based routing).
+     *
+     * @param records                the queue of record batches
+     * @param config                 the connector configuration
+     * @param topic2TableMap         a map of topic names to table names
+     * @param durablyInsertedOffsets shared watermark of durably-inserted offsets
+     */
+    public ClickHouseBatchRunnable(
+            LinkedBlockingQueue<List<ClickHouseStruct>> records,
+            ClickHouseSinkConnectorConfig config,
+            Map<String, String> topic2TableMap,
+            Map<TopicPartition, Long> durablyInsertedOffsets) {
+        this(records, null, -1, config, topic2TableMap, durablyInsertedOffsets);
     }
 
     /**
@@ -129,7 +157,8 @@ public class ClickHouseBatchRunnable implements Runnable {
             int threadId,
             ClickHouseSinkConnectorConfig config,
             Map<String, String> topic2TableMap) {
-        this(null, routedRecords, threadId, config, topic2TableMap);
+        this(null, routedRecords, threadId, config, topic2TableMap,
+                new ConcurrentHashMap<>());
     }
 
     /**
@@ -146,11 +175,13 @@ public class ClickHouseBatchRunnable implements Runnable {
             LinkedBlockingQueue<RoutedBatch> routedRecords,
             int threadId,
             ClickHouseSinkConnectorConfig config,
-            Map<String, String> topic2TableMap) {
+            Map<String, String> topic2TableMap,
+            Map<TopicPartition, Long> durablyInsertedOffsets) {
         this.records = records;
         this.routedRecords = routedRecords;
         this.threadId = threadId;
         this.config = config;
+        this.durablyInsertedOffsets = durablyInsertedOffsets;
         if (topic2TableMap == null) {
             this.topic2TableMap = new HashMap();
         } else {
@@ -649,6 +680,13 @@ public class ClickHouseBatchRunnable implements Runnable {
         result = flushRecordsToClickHouse(topicName, writer, queryToRecordsMap,
                 bmd, maxBufferSize, preparedStatementExecutor);
         if (result) {
+            // Records are now DURABLY in ClickHouse: advance the shared watermark
+            // (max offset per TopicPartition) so ClickHouseSinkTask.preCommit()
+            // only commits offsets that were actually persisted. Without this the
+            // offset advances on consume, and a crash/restart silently loses the
+            // records that were consumed but never inserted.
+            partitionToOffsetMap.forEach((tp, offset) ->
+                    this.durablyInsertedOffsets.merge(tp, offset, Math::max));
             // Remove the entry.
             queryToRecordsMap.remove(topicName);
         }


### PR DESCRIPTION
## Summary
Mirror of https://github.com/Altinity/clickhouse-sink-connector/pull/1330 so GitHub Actions can run with full permissions (fork PRs cannot).
Original author: @Airliquide76
ClickHouseSinkTask.preCommit() is a pass-through: it returns the offsets Kafka Connect delivered to put(), regardless of whether those records were actually inserted into ClickHouse. Inserts are asynchronous (ClickHouseBatchRunnable drains an in-memory queue on a schedule), so a task crash/restart after preCommit but before the durable insert silently skips the consumed-but-not-inserted records -> data loss, with no error surfaced.
Track, per TopicPartition, the highest offset durably inserted:
- ClickHouseBatchRunnable advances a shared watermark (merge max) after each successful flush
- ClickHouseSinkTask.put() seeds a per-partition baseline (firstOffset - 1)
- preCommit() returns min(deliveredOffset, durable + 1) per partition
## Test plan
- [ ] CI green on this mirror PR
- [ ] Review against original PR #1330