### PR TITLE
Fix NullPointerException on cold start when ClickHouse is not reachable

### DIFF
--- a/sink-connector-lightweight/docker/docker-compose-postgres.yml
+++ b/sink-connector-lightweight/docker/docker-compose-postgres.yml
@@ -31,7 +31,10 @@ services:
       file: clickhouse-sink-connector-lt-service.yml
       service: clickhouse-sink-connector-lt
     depends_on:
-      - clickhouse
+      clickhouse:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:

--- a/sink-connector-lightweight/docker/postgres-service.yml
+++ b/sink-connector-lightweight/docker/postgres-service.yml
@@ -4,6 +4,11 @@ services:
   postgres:
     image: debezium/postgres:15-alpine
     restart: always
+    healthcheck:
+      test: [ 'CMD-SHELL', 'pg_isready -U root -d public' ]
+      interval: 10s
+      timeout: 5s
+      retries: 6
     ports:
       - "5432:5432"
     environment:

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumJdbcStorageOperations.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumJdbcStorageOperations.java
@@ -304,6 +304,14 @@ public class DebeziumJdbcStorageOperations {
             throws SQLException {
         long result = -1;
         String latestRecordTs = this.debeziumOffsetStorage.getDebeziumLatestRecordTimestamp(props, conn);
+        if (latestRecordTs == null || latestRecordTs.isEmpty()) {
+            // The query returned no result, e.g. because ClickHouse was not
+            // reachable. Without this guard SimpleDateFormat.parse() below
+            // throws a NullPointerException, which the ParseException handler
+            // does not catch.
+            log.error("Latest record timestamp is not available");
+            return result;
+        }
         // Convert date string from "yyyy-MM-dd HH:mm:ss" format to milliseconds.
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         Date date = null;

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumJdbcStorageOperationsTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumJdbcStorageOperationsTest.java
@@ -47,4 +47,21 @@ public class DebeziumJdbcStorageOperationsTest {
 
         assertDoesNotThrow(() -> ops.createSchemaHistoryTable(null, props));
     }
+
+    @Test
+    @DisplayName("getLatestRecordTimestamp returns -1 without NPE when the query has no result")
+    void getLatestRecordTimestamp_returnsSentinelWhenQueryHasNoResult() {
+        DebeziumJdbcStorageOperations ops = new DebeziumJdbcStorageOperations();
+        Properties props = new Properties();
+        String offsetTableKey = JdbcOffsetBackingStoreConfig.OFFSET_STORAGE_PREFIX +
+                JdbcOffsetBackingStoreConfig.PROP_TABLE_NAME.name();
+        props.setProperty(offsetTableKey, "altinity_sink_connector.replica_source_info");
+
+        // A null connection makes the underlying query return no result. That
+        // reached SimpleDateFormat.parse(null) and threw a NullPointerException,
+        // which the surrounding ParseException handler does not catch.
+        long result = assertDoesNotThrow(() -> ops.getLatestRecordTimestamp(null, props));
+
+        assertEquals(-1L, result);
+    }
 }

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DBMetadata.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DBMetadata.java
@@ -622,6 +622,24 @@ public class DBMetadata {
     }
 
     /**
+     * Checks whether the connection pool is able to hand out a connection for
+     * the system database.
+     *
+     * @return true if pooling is enabled and a pool exists.
+     */
+    private boolean canReconnectFromPool() {
+        try {
+            if (config.getBoolean(String.valueOf(ClickHouseSinkConnectorConfigVariables.CONNECTION_POOL_DISABLE))) {
+                return false;
+            }
+            return HikariDbSource.getInstance(SYSTEM_DB) != null;
+        } catch (Exception e) {
+            log.error("Error checking the connection pool state", e);
+            return false;
+        }
+    }
+
+    /**
      * Executes a system query that returns a string result.
      *
      * @param conn The database connection.
@@ -636,9 +654,28 @@ public class DBMetadata {
         ResultSet rs = null;
         while (retryCount < MAX_RETRIES) {
             try {
+                if (conn == null) {
+                    // createConnection() returns null when ClickHouse is
+                    // unreachable. Report it as a SQLException so that the
+                    // retry below is applied and callers that already handle
+                    // SQLException are not hit by a NullPointerException.
+                    throw new SQLException(
+                            "ClickHouse connection is not available for query: "
+                                    + sql);
+                }
                 rs = conn.prepareStatement(sql).executeQuery();
                 break;
             } catch (SQLException sqle) {
+                // A missing connection can only be recovered from the pool. If
+                // no pool can supply one, the initial connection never
+                // succeeded and retrying would just sleep out the whole retry
+                // budget, so fail immediately instead.
+                if (conn == null && !canReconnectFromPool()) {
+                    log.error("ClickHouse connection is not available and no "
+                            + "connection pool can provide one, giving up on "
+                            + "query: {}", sql, sqle);
+                    break;
+                }
                 try {
                     log.error("Error executing query: Retrying ({}/{})" ,retryCount,MAX_RETRIES, sqle);
                     Thread.sleep(1000 * retryCount);

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/HikariDbSource.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/HikariDbSource.java
@@ -81,7 +81,10 @@ public class HikariDbSource {
         }
         HikariDataSource dbSource = instance.get(databaseName);
         if (dbSource == null) {
-            // No pool exists for the database.
+            // No pool exists for the database. This happens when the initial
+            // connection to ClickHouse failed, so the pool was never created.
+            throw new SQLException(
+                    "No connection pool exists for database: " + databaseName);
         }
         HikariDbSource.printConnectionInfo();
         return dbSource.getConnection();

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchRunnable.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchRunnable.java
@@ -255,7 +255,12 @@ public class ClickHouseBatchRunnable implements Runnable {
             log.error("Error creating database " + e);
         } finally {
             try {
-                systemConn.close();
+                // createConnection() returns null when ClickHouse is
+                // unreachable, closing it would throw a NullPointerException
+                // that the handler below does not catch.
+                if (systemConn != null) {
+                    systemConn.close();
+                }
             } catch (SQLException e) {
                 log.error("Error closing connection when creating database" + e);
             }
@@ -267,7 +272,12 @@ public class ClickHouseBatchRunnable implements Runnable {
                 BaseDbWriter.DATABASE_CLIENT_NAME,
                 this.dbCredentials.getUserName(),
                 this.dbCredentials.getPassword(), databaseName, config);
-        this.databaseToConnectionMap.put(databaseName, conn);
+        // Only cache a usable connection. containsKey() above returns true for
+        // a key mapped to null, so caching a failed connection would keep
+        // returning null for this database until the connector restarts.
+        if (conn != null) {
+            this.databaseToConnectionMap.put(databaseName, conn);
+        }
         return conn;
     }
 

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/ClickHouseUnavailableTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/ClickHouseUnavailableTest.java
@@ -1,0 +1,92 @@
+package com.altinity.clickhouse.sink.connector.db;
+
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests the behaviour of the ClickHouse metadata/connection helpers when
+ * ClickHouse is not reachable.
+ * <p>
+ * On a cold start, {@code BaseDbWriter.createConnection} logs the failure and
+ * returns null. The null connection is then passed down to DBMetadata, which
+ * used to dereference it directly and fail with a NullPointerException instead
+ * of a SQLException that callers already handle.
+ * </p>
+ */
+public class ClickHouseUnavailableTest {
+
+    /**
+     * The retry loop sleeps 1000 * attempt ms, so sleeping out the default 10
+     * retries would take 45s. A generous bound still shows that the retries
+     * are skipped when no pool can hand out a connection.
+     */
+    private static final long MAX_ACCEPTABLE_MILLIS = 10_000L;
+
+    private static ClickHouseSinkConnectorConfig emptyConfig() {
+        Map<String, String> props = new HashMap<>();
+        return new ClickHouseSinkConnectorConfig(props);
+    }
+
+    @Test
+    public void testExecuteSystemQueryWithNullConnection() throws SQLException {
+        int originalMaxRetries = DBMetadata.MAX_RETRIES;
+        DBMetadata.setMaxRetries(10);
+        // Make sure no pool exists, which is the cold start state.
+        HikariDbSource.close();
+        try {
+            DBMetadata dbMetadata = new DBMetadata(emptyConfig());
+
+            long start = System.currentTimeMillis();
+            String result = dbMetadata.executeSystemQuery(null,
+                    "create database if not exists altinity_sink_connector");
+            long elapsed = System.currentTimeMillis() - start;
+
+            Assert.assertNull(result);
+            Assert.assertTrue("executeSystemQuery slept through its retry "
+                            + "budget with no pool to reconnect from: " + elapsed + "ms",
+                    elapsed < MAX_ACCEPTABLE_MILLIS);
+        } finally {
+            DBMetadata.setMaxRetries(originalMaxRetries);
+        }
+    }
+
+    @Test
+    public void testGetClickHouseVersionWithNullConnection() throws SQLException {
+        int originalMaxRetries = DBMetadata.MAX_RETRIES;
+        DBMetadata.setMaxRetries(10);
+        HikariDbSource.close();
+        try {
+            DBMetadata dbMetadata = new DBMetadata(emptyConfig());
+
+            long start = System.currentTimeMillis();
+            String version = dbMetadata.getClickHouseVersion(null);
+            long elapsed = System.currentTimeMillis() - start;
+
+            Assert.assertNull(version);
+            Assert.assertTrue("getClickHouseVersion slept through its retry "
+                            + "budget with no pool to reconnect from: " + elapsed + "ms",
+                    elapsed < MAX_ACCEPTABLE_MILLIS);
+        } finally {
+            DBMetadata.setMaxRetries(originalMaxRetries);
+        }
+    }
+
+    @Test
+    public void testInitiateNewConnectionWithoutPool() {
+        // No pool exists for this database, which is the state after the
+        // initial connection to ClickHouse failed.
+        HikariDbSource.close();
+
+        SQLException exception = assertThrows(SQLException.class,
+                () -> HikariDbSource.initiateNewConnectionIfClosed("db_without_pool"));
+
+        Assert.assertTrue(exception.getMessage().contains("db_without_pool"));
+    }
+}


### PR DESCRIPTION
BaseDbWriter.createConnection() logs the failure and returns null when ClickHouse cannot be reached, which is what happens on a cold start where the connector comes up before ClickHouse is ready. That null connection is then passed down and dereferenced in several places. Both the retry loop in DBMetadata.executeSystemQuery() and the caller in
setupDebeziumEventCapture() catch only SQLException, so the resulting NullPointerException escapes main() and the replication pipeline dies while the container itself stays up.

Handle the missing connection along that path:

- DBMetadata.executeSystemQuery() reports an unavailable connection as a SQLException, so the existing retry-and-reacquire path applies and callers that already handle SQLException are no longer bypassed. When no pool can supply a replacement it gives up immediately instead of sleeping out the whole retry budget, which is 45s at the default of 10 retries.
- HikariDbSource.initiateNewConnectionIfClosed() had an empty "if (dbSource == null)" block and dereferenced the data source on the next line. It is reached from that retry path when no pool was ever created.
- DebeziumJdbcStorageOperations.getLatestRecordTimestamp() passed the query result straight to SimpleDateFormat.parse(), which throws a NullPointerException that the surrounding ParseException handler does not catch.
- ClickHouseBatchRunnable.getClickHouseConnection() closed a possibly-null connection in its finally block, guarded only by catch (SQLException), and cached a failed connection. Since the lookup uses containsKey(), a cached null was then returned for that database until the connector restarted.

Extend the startup ordering added in #1332 to the PostgreSQL quickstart, which still gated clickhouse-sink-connector-lt on container start rather than health and did not wait for postgres at all. This needs the standard pg_isready healthcheck, as postgres-service.yml had none.