### PR TITLE
[split 1/22] python: remove eval() from checksum fstr(), fix silent error swallowing, per-table LOCK TABLES READ lifecycle

### DIFF
--- a/sink-connector/python/db/clickhouse.py
+++ b/sink-connector/python/db/clickhouse.py
@@ -22,9 +22,12 @@ def clickhouse_connection(host, database='default', user='default',  password=''
 def clickhouse_execute_conn(conn, sql):
     logging.debug(sql)
     cursor = conn.cursor()
-    cursor.execute(sql)
-    result = cursor.fetchall()
-    return result
+    try:
+        cursor.execute(sql)
+        result = cursor.fetchall()
+        return result
+    finally:
+        cursor.close()
 
 def get_table_partition_key(conn, database, table):
    sql = f"SELECT partition_key FROM system.tables WHERE name = '{table}'  AND database = '{database}' FORMAT TabSeparated"
@@ -62,8 +65,8 @@ def resolve_credentials_from_config(config_file):
         clickhouse_password = root.findtext('password')
     elif config_file.endswith(".yml") or config_file.endswith(".yaml"):
         with open(config_file, 'r') as f:
-            valuesYaml = yaml.load(f, Loader=yaml.FullLoader)
+            valuesYaml = yaml.safe_load(f)
             clickhouse_user = valuesYaml['config']['user']
             clickhouse_password = valuesYaml['config']['password']
-    logging.debug(f"clickhouse_user {clickhouse_user} clickhouse_password {clickhouse_password}")
+    logging.debug(f"clickhouse_user {clickhouse_user} clickhouse_password ****")
     return (clickhouse_user, clickhouse_password)

--- a/sink-connector/python/db/mysql.py
+++ b/sink-connector/python/db/mysql.py
@@ -1,4 +1,5 @@
 from sqlalchemy import create_engine, text
+from urllib.parse import quote_plus
 import logging
 import warnings
 import os
@@ -19,7 +20,7 @@ def is_binary_datatype(datatype):
 
 def get_mysql_connection(mysql_host, mysql_user, mysql_passwd, mysql_port, mysql_database):
     url = 'mysql+pymysql://{user}:{passwd}@{host}:{port}/{db}?charset=utf8mb4'.format(
-        host=mysql_host, user=mysql_user, passwd=mysql_passwd, port=int(mysql_port), db=mysql_database)
+        host=mysql_host, user=quote_plus(mysql_user), passwd=quote_plus(mysql_passwd), port=int(mysql_port), db=mysql_database)
     # Ensure session wait_timeout is large enough for long-running flushes
     engine = create_engine(url, connect_args={"init_command": "SET SESSION wait_timeout=28000"})
     conn = engine.connect()

--- a/sink-connector/python/db_compare/clickhouse_table_checksum.py
+++ b/sink-connector/python/db_compare/clickhouse_table_checksum.py
@@ -210,9 +210,12 @@ def get_table_checksum_query(conn, table):
     logging.debug("order by columns "+order_by_columns)
     return (query, select, order_by_columns, external_column_types)
 
-@staticmethod
 def fstr(template, partition_expression):
-        return eval(f"f'{template}'")
+        # Safe substitution: only replace {partition_expression} placeholder
+        # instead of eval() which allows arbitrary code execution
+        if partition_expression is not None:
+            return template.replace('{partition_expression}', str(partition_expression))
+        return template
 
 def select_table_statements(table, query, select_query, order_by, external_column_types, _where):
     statements = []
@@ -359,7 +362,7 @@ def main():
     parser.add_argument('--include_floating_point_columns', action='store_true', default=False,
                         help='Floating point data types like float or double can not be compared, we do not include them by default', required=False)
     parser.add_argument('--include_json_columns', action='store_true', default=True,
-                        help='JSON data types can not easily be compared, we include them by default, please ignore them explicitly', required=False)
+                        help='JSON data types are included by default. This flag is a no-op (always True). Use --exclude_columns to skip JSON columns.', required=False)
     global args
     args = parser.parse_args()
 

--- a/sink-connector/python/db_compare/mysql_table_checksum.py
+++ b/sink-connector/python/db_compare/mysql_table_checksum.py
@@ -44,8 +44,8 @@ def compute_checksum(table, statements, conn):
                         debug_out.write(str(line)+'\n')
                 if args.debug_output:
                         debug_out.close()
-    finally:
-        conn.close()
+    except Exception:
+        raise  # propagate to caller which owns connection lifecycle
 
     return result
 
@@ -161,9 +161,12 @@ def get_table_checksum_query(table, conn, binary_encoding, where, excluded_colum
     return (query, select, order_by_columns, external_column_types)
 
 
-@staticmethod
 def fstr(template, partition_expression):
-        return eval(f"f'{template}'")
+        # Safe substitution: only replace {partition_expression} placeholder
+        # instead of eval() which allows arbitrary code execution
+        if partition_expression is not None:
+            return template.replace('{partition_expression}', str(partition_expression))
+        return template
 
 
 def select_table_statements(table, query, select_query, order_by, external_column_types, _where):
@@ -289,10 +292,11 @@ def calculate_checksum(mysql_table, mysql_user, mysql_password, excluded_columns
                 futures.append(executor.submit(
                     calculate_checksum_single_thread, mysql_table, mysql_user, mysql_password, chunk, pk, where, excluded_columns, include_floating_point_columns, include_json_columns))
             for future in concurrent.futures.as_completed(futures):
-                result.append(future.result())
-                if future.exception() is not None:
-                    logging.info(f"{mysql_table}")
-                    raise future.exception()
+                try:
+                    result.append(future.result())
+                except Exception:
+                    logging.error(f"Checksum failed for {mysql_table}")
+                    raise
     if args.debug_output:
         # checksum is not output in debug_output mode
         return
@@ -373,7 +377,7 @@ def main():
     parser.add_argument('--include_floating_point_columns', action='store_true', default=False,
                         help='Floating point data types like float or double can not be compared, we do not include them by default', required=False)
     parser.add_argument('--include_json_columns', action='store_true', default=True,
-                        help='JSON data types can not easily be compared, we do not include them by default', required=False)
+                        help='JSON data types are included by default. This flag is a no-op (always True). Use --exclude_columns to skip JSON columns.', required=False)
     global args
     args = parser.parse_args()
 

--- a/sink-connector/python/db_compare/mysql_table_count.py
+++ b/sink-connector/python/db_compare/mysql_table_count.py
@@ -38,9 +38,12 @@ def compute_count(table, statements, mysql_user, mysql_password):
         conn.close()
     return count
 
-@staticmethod
 def fstr(template, partition_expression):
-        return eval(f"f'{template}'")
+        # Safe substitution: only replace {partition_expression} placeholder
+        # instead of eval() which allows arbitrary code execution
+        if partition_expression is not None:
+            return template.replace('{partition_expression}', str(partition_expression))
+        return template
 
 def select_table_statements(conn, table):
     # TODO adjust the number as a parameter
@@ -99,10 +102,12 @@ def calculate_sql_count(conn, table, mysql_user, mysql_password):
                 futures.append(executor.submit(
                     compute_count, table, queries, mysql_user, mysql_password))
             for future in concurrent.futures.as_completed(futures):
-                result = future.result()
-                row_count += result
-                if future.exception() is not None:
-                    raise future.exception()
+                try:
+                    result = future.result()
+                    row_count += result
+                except Exception:
+                    logging.error(f"Count failed for {table}")
+                    raise
             logging.info("Count for table "+args.mysql_database + "."+table+" = "+str(row_count))
     finally:
         conn.close()

--- a/sink-connector/python/db_compare/tests/mysql_table_checksum_test.py
+++ b/sink-connector/python/db_compare/tests/mysql_table_checksum_test.py
@@ -1,10 +1,67 @@
+import os
+import sys
 import unittest
 
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+)
 
-class MyTestCase(unittest.TestCase):
-    def test_something(self):
-        self.assertEqual(True, False)  # add assertion here
+from db_compare.mysql_table_checksum import fstr
 
 
-if __name__ == '__main__':
+class FstrTestCase(unittest.TestCase):
+    """Tests for fstr(), which replaced an eval() call.
+
+    fstr() used to be implemented with eval() on an f-string template, so any
+    attacker-influenced text reaching the template executed as Python. It is now
+    a literal placeholder substitution. These tests pin that behaviour so the
+    eval() cannot quietly come back.
+
+    This file previously contained a single placeholder assertEqual(True, False)
+    that failed on every run.
+    """
+
+    def test_substitutes_placeholder(self):
+        self.assertEqual(
+            fstr("where {partition_expression} = 1", "toDate(ts)"),
+            "where toDate(ts) = 1",
+        )
+
+    def test_substitutes_every_occurrence(self):
+        self.assertEqual(
+            fstr("{partition_expression} and {partition_expression}", "p"),
+            "p and p",
+        )
+
+    def test_none_expression_returns_template_unchanged(self):
+        template = "where {partition_expression} = 1"
+        self.assertEqual(fstr(template, None), template)
+
+    def test_template_without_placeholder_is_unchanged(self):
+        self.assertEqual(fstr("where 1=1", "toDate(ts)"), "where 1=1")
+
+    def test_non_string_expression_is_coerced(self):
+        self.assertEqual(fstr("v = {partition_expression}", 42), "v = 42")
+
+    def test_does_not_evaluate_python_in_template(self):
+        # The old eval()-based implementation would have executed this.
+        # Substitution must treat it as inert text.
+        template = "{__import__('os').system('touch /tmp/pwned')}"
+        self.assertEqual(fstr(template, "x"), template)
+
+    def test_does_not_evaluate_python_in_expression(self):
+        # A hostile partition expression must be inserted literally, never run.
+        payload = "__import__('os').system('touch /tmp/pwned')"
+        self.assertEqual(
+            fstr("where {partition_expression}", payload),
+            "where " + payload,
+        )
+
+    def test_braces_other_than_placeholder_survive(self):
+        # A real f-string/eval would choke on or interpret these; plain
+        # substitution must leave them intact.
+        self.assertEqual(fstr("json = '{\"a\": 1}'", "x"), "json = '{\"a\": 1}'")
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/sink-connector/python/db_compare/tests/test_table_locking.py
+++ b/sink-connector/python/db_compare/tests/test_table_locking.py
@@ -1,0 +1,669 @@
+#!/usr/bin/env python3
+"""Tests for table locking improvements in top_level_table_checksum.py.
+
+Tests cover:
+1. Lock lifecycle safety (try/finally guarantees unlock even on exception)
+2. Connection cleanup after unlock
+3. Per-table lock isolation (locks are not held across tables)
+4. Lock held during all checksums (MySQL + ClickHouse) for consistency
+5. MySQL and ClickHouse checksums run concurrently under the lock
+6. LOCK TABLES ... READ statement correctness
+7. Performance: old approach (lock-all-then-checksum) vs new (per-table lock)
+"""
+import unittest
+from unittest.mock import MagicMock, patch, call
+import time
+import threading
+import concurrent.futures
+import sys
+import os
+
+# Add parent directory to path so we can import the module under test
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+
+class TestLockStatement(unittest.TestCase):
+    """Test that the lock statement uses LOCK TABLES ... READ."""
+
+    @patch('db_compare.top_level_table_checksum.execute_mysql')
+    def test_lock_uses_lock_tables_read(self, mock_execute):
+        """LOCK TABLES ... READ blocks writes on the source for a consistent
+        read lock during the checksum comparison, without the disk flush that
+        FLUSH TABLE ... WITH READ LOCK incurs."""
+        from db_compare.top_level_table_checksum import lock_tables
+
+        mock_conn = MagicMock()
+        lock_tables(mock_conn, 'my_table')
+
+        mock_execute.assert_called_once_with(mock_conn, 'LOCK TABLES `my_table` READ')
+
+    @patch('db_compare.top_level_table_checksum.execute_mysql')
+    def test_lock_statement_uses_lock_tables(self, mock_execute):
+        """Verify LOCK TABLES ... READ is used (not FLUSH TABLE)."""
+        from db_compare.top_level_table_checksum import lock_tables
+
+        mock_conn = MagicMock()
+        lock_tables(mock_conn, 'test_table')
+
+        sql_arg = mock_execute.call_args[0][1]
+        self.assertIn('LOCK TABLES', sql_arg.upper())
+        self.assertIn('READ', sql_arg.upper())
+        self.assertNotIn('FLUSH', sql_arg.upper())
+
+    @patch('db_compare.top_level_table_checksum.execute_mysql')
+    def test_unlock_uses_unlock_tables(self, mock_execute):
+        from db_compare.top_level_table_checksum import unlock_tables
+
+        mock_conn = MagicMock()
+        unlock_tables(mock_conn, 'my_table')
+
+        mock_execute.assert_called_once_with(mock_conn, 'UNLOCK TABLES')
+
+    @patch('db_compare.top_level_table_checksum.execute_mysql')
+    def test_lock_escapes_table_name(self, mock_execute):
+        """Table name should be backtick-escaped in the lock statement."""
+        from db_compare.top_level_table_checksum import lock_tables
+
+        mock_conn = MagicMock()
+        lock_tables(mock_conn, 'table-with-dashes')
+
+        sql_arg = mock_execute.call_args[0][1]
+        self.assertIn('`table-with-dashes`', sql_arg)
+
+
+class TestCloseConnection(unittest.TestCase):
+    """Test the close_connection helper."""
+
+    def test_close_connection_calls_close(self):
+        from db_compare.top_level_table_checksum import close_connection
+
+        mock_conn = MagicMock()
+        close_connection(mock_conn, 'db.table')
+        mock_conn.close.assert_called_once()
+
+    def test_close_connection_swallows_exception(self):
+        """close_connection should not raise even if conn.close() fails."""
+        from db_compare.top_level_table_checksum import close_connection
+
+        mock_conn = MagicMock()
+        mock_conn.close.side_effect = Exception("connection already closed")
+        # Should not raise
+        close_connection(mock_conn, 'db.table')
+
+
+class TestComputeChecksumLockLifecycle(unittest.TestCase):
+    """Test that compute_checksum properly manages lock lifecycle."""
+
+    def _make_mock_checksum_result(self, host, table):
+        return (host, table, 'abc123', 100)
+
+    @patch('db_compare.top_level_table_checksum.run_quick_safe_checksum')
+    @patch('db_compare.top_level_table_checksum.close_connection')
+    @patch('db_compare.top_level_table_checksum.unlock_tables')
+    @patch('db_compare.top_level_table_checksum.lock_tables')
+    @patch('db_compare.top_level_table_checksum.get_mysql_connection')
+    @patch('db_compare.top_level_table_checksum.get_clickhouse_checksum_command', return_value='ch_cmd')
+    @patch('db_compare.top_level_table_checksum.get_mysql_checksum_command', return_value='mysql_cmd')
+    def test_lock_acquired_and_released_on_success(
+        self, mock_mysql_cmd, mock_ch_cmd, mock_get_conn, mock_lock,
+        mock_unlock, mock_close, mock_checksum
+    ):
+        """Lock is acquired before MySQL checksum and released after, even on success."""
+        from db_compare.top_level_table_checksum import compute_checksum
+
+        mock_conn = MagicMock()
+        mock_get_conn.return_value = mock_conn
+        mock_checksum.return_value = ('host', 'tbl', 'hash', 100)
+
+        # Set up minimal args global
+        import db_compare.top_level_table_checksum as mod
+        mock_args = MagicMock()
+        mock_args.partition_date = None
+        mock_args.threads_per_table = 1
+        mock_args.threads = 1
+        mod.args = mock_args
+
+        compute_checksum(
+            'test_db', {}, {}, 'test_table', 'user', 'pass',
+            'mysql-host', ['ch-host1'], 'id', 1000, None,
+            lock_enabled=True, sleep_after_lock=0, mysql_port=3306
+        )
+
+        mock_lock.assert_called_once_with(mock_conn, 'test_table')
+        mock_unlock.assert_called_once_with(mock_conn, 'test_table')
+        mock_close.assert_called_once_with(mock_conn, 'test_db.test_table')
+
+    @patch('db_compare.top_level_table_checksum.run_quick_safe_checksum')
+    @patch('db_compare.top_level_table_checksum.close_connection')
+    @patch('db_compare.top_level_table_checksum.unlock_tables')
+    @patch('db_compare.top_level_table_checksum.lock_tables')
+    @patch('db_compare.top_level_table_checksum.get_mysql_connection')
+    @patch('db_compare.top_level_table_checksum.get_clickhouse_checksum_command', return_value='ch_cmd')
+    @patch('db_compare.top_level_table_checksum.get_mysql_checksum_command', return_value='mysql_cmd')
+    def test_lock_released_on_mysql_checksum_exception(
+        self, mock_mysql_cmd, mock_ch_cmd, mock_get_conn, mock_lock,
+        mock_unlock, mock_close, mock_checksum
+    ):
+        """Lock MUST be released even if the MySQL checksum subprocess fails."""
+        from db_compare.top_level_table_checksum import compute_checksum
+
+        mock_conn = MagicMock()
+        mock_get_conn.return_value = mock_conn
+        mock_checksum.side_effect = RuntimeError("checksum subprocess crashed")
+
+        import db_compare.top_level_table_checksum as mod
+        mock_args = MagicMock()
+        mock_args.partition_date = None
+        mock_args.threads_per_table = 1
+        mock_args.threads = 1
+        mod.args = mock_args
+
+        with self.assertRaises(RuntimeError):
+            compute_checksum(
+                'test_db', {}, {}, 'test_table', 'user', 'pass',
+                'mysql-host', ['ch-host1'], 'id', 1000, None,
+                lock_enabled=True, sleep_after_lock=0, mysql_port=3306
+            )
+
+        # Lock must still have been released despite the exception
+        mock_unlock.assert_called_once_with(mock_conn, 'test_table')
+        mock_close.assert_called_once_with(mock_conn, 'test_db.test_table')
+
+    @patch('db_compare.top_level_table_checksum.run_quick_safe_checksum')
+    @patch('db_compare.top_level_table_checksum.close_connection')
+    @patch('db_compare.top_level_table_checksum.unlock_tables')
+    @patch('db_compare.top_level_table_checksum.lock_tables')
+    @patch('db_compare.top_level_table_checksum.get_mysql_connection')
+    @patch('db_compare.top_level_table_checksum.get_clickhouse_checksum_command', return_value='ch_cmd')
+    @patch('db_compare.top_level_table_checksum.get_mysql_checksum_command', return_value='mysql_cmd')
+    def test_connection_closed_even_if_unlock_fails(
+        self, mock_mysql_cmd, mock_ch_cmd, mock_get_conn, mock_lock,
+        mock_unlock, mock_close, mock_checksum
+    ):
+        """Connection must be closed even if UNLOCK TABLES fails."""
+        from db_compare.top_level_table_checksum import compute_checksum
+
+        mock_conn = MagicMock()
+        mock_get_conn.return_value = mock_conn
+        mock_checksum.return_value = ('host', 'tbl', 'hash', 100)
+        mock_unlock.side_effect = Exception("MySQL gone away")
+
+        import db_compare.top_level_table_checksum as mod
+        mock_args = MagicMock()
+        mock_args.partition_date = None
+        mock_args.threads_per_table = 1
+        mock_args.threads = 1
+        mod.args = mock_args
+
+        # Should not raise — unlock failure is handled gracefully
+        try:
+            compute_checksum(
+                'test_db', {}, {}, 'test_table', 'user', 'pass',
+                'mysql-host', ['ch-host1'], 'id', 1000, None,
+                lock_enabled=True, sleep_after_lock=0, mysql_port=3306
+            )
+        except Exception:
+            pass  # unlock exception may propagate, but close must still happen
+
+        # Connection closed even though unlock failed
+        mock_close.assert_called_once_with(mock_conn, 'test_db.test_table')
+
+    @patch('db_compare.top_level_table_checksum.run_quick_safe_checksum')
+    @patch('db_compare.top_level_table_checksum.close_connection')
+    @patch('db_compare.top_level_table_checksum.unlock_tables')
+    @patch('db_compare.top_level_table_checksum.lock_tables')
+    @patch('db_compare.top_level_table_checksum.get_mysql_connection')
+    @patch('db_compare.top_level_table_checksum.get_clickhouse_checksum_command', return_value='ch_cmd')
+    @patch('db_compare.top_level_table_checksum.get_mysql_checksum_command', return_value='mysql_cmd')
+    def test_no_lock_when_disabled(
+        self, mock_mysql_cmd, mock_ch_cmd, mock_get_conn, mock_lock,
+        mock_unlock, mock_close, mock_checksum
+    ):
+        """When lock_enabled=False (default), no lock/unlock/connection should happen."""
+        from db_compare.top_level_table_checksum import compute_checksum
+
+        mock_checksum.return_value = ('host', 'tbl', 'hash', 100)
+
+        import db_compare.top_level_table_checksum as mod
+        mock_args = MagicMock()
+        mock_args.partition_date = None
+        mock_args.threads_per_table = 1
+        mock_args.threads = 1
+        mod.args = mock_args
+
+        compute_checksum(
+            'test_db', {}, {}, 'test_table', 'user', 'pass',
+            'mysql-host', ['ch-host1'], 'id', 1000, None,
+            lock_enabled=False
+        )
+
+        mock_get_conn.assert_not_called()
+        mock_lock.assert_not_called()
+        mock_unlock.assert_not_called()
+        mock_close.assert_not_called()
+
+
+class TestLockHoldDuration(unittest.TestCase):
+    """Test that locks are held during both MySQL and ClickHouse checksums.
+    The source must stay frozen until both sides are checksummed for a
+    valid comparison — the 3s sleep allows replication lag to settle,
+    and unlocking early would let new writes reach ClickHouse."""
+
+    @patch('db_compare.top_level_table_checksum.run_quick_safe_checksum')
+    @patch('db_compare.top_level_table_checksum.close_connection')
+    @patch('db_compare.top_level_table_checksum.unlock_tables')
+    @patch('db_compare.top_level_table_checksum.lock_tables')
+    @patch('db_compare.top_level_table_checksum.get_mysql_connection')
+    @patch('db_compare.top_level_table_checksum.get_clickhouse_checksum_command', return_value='ch_cmd')
+    @patch('db_compare.top_level_table_checksum.get_mysql_checksum_command', return_value='mysql_cmd')
+    def test_lock_held_during_both_checksums(
+        self, mock_mysql_cmd, mock_ch_cmd, mock_get_conn, mock_lock,
+        mock_unlock, mock_close, mock_checksum
+    ):
+        """Lock must be held during BOTH MySQL and ClickHouse checksums.
+        Unlocking before the ClickHouse checksum would allow new writes
+        to flow from MySQL to ClickHouse, invalidating the comparison."""
+        from db_compare.top_level_table_checksum import compute_checksum
+
+        call_order = []
+
+        mock_conn = MagicMock()
+        mock_get_conn.return_value = mock_conn
+
+        def track_lock(conn, table):
+            call_order.append('LOCK')
+
+        def track_unlock(conn, table):
+            call_order.append('UNLOCK')
+
+        def track_checksum(cmd, host, table):
+            if host == 'mysql-host':
+                call_order.append('MYSQL_CHECKSUM')
+            else:
+                call_order.append(f'CH_CHECKSUM_{host}')
+            return (host, table, 'hash', 100)
+
+        mock_lock.side_effect = track_lock
+        mock_unlock.side_effect = track_unlock
+        mock_checksum.side_effect = track_checksum
+
+        import db_compare.top_level_table_checksum as mod
+        mock_args = MagicMock()
+        mock_args.partition_date = None
+        mock_args.threads_per_table = 1
+        mock_args.threads = 1
+        mod.args = mock_args
+
+        compute_checksum(
+            'test_db', {}, {}, 'test_table', 'user', 'pass',
+            'mysql-host', ['ch-host1', 'ch-host2'], 'id', 1000, None,
+            lock_enabled=True, sleep_after_lock=0, mysql_port=3306
+        )
+
+        # Verify ordering: LOCK first, then all checksums (MySQL + CH run
+        # concurrently in one pool, order between them is nondeterministic),
+        # then UNLOCK last. LOCK is appended in the main thread before the
+        # executor starts; UNLOCK in the finally block after it exits.
+        lock_idx = call_order.index('LOCK')
+        mysql_idx = call_order.index('MYSQL_CHECKSUM')
+        unlock_idx = call_order.index('UNLOCK')
+
+        self.assertEqual(lock_idx, 0, "LOCK must be the first event")
+        self.assertEqual(unlock_idx, len(call_order) - 1, "UNLOCK must be the last event")
+
+        # MySQL checksum must run while the lock is held
+        self.assertLess(lock_idx, mysql_idx, "LOCK must come before MySQL checksum")
+        self.assertLess(mysql_idx, unlock_idx, "MySQL checksum must come before UNLOCK")
+
+        # CH checksums must also run while the lock is held
+        for entry in call_order:
+            if entry.startswith('CH_CHECKSUM_'):
+                ch_idx = call_order.index(entry)
+                self.assertLess(lock_idx, ch_idx,
+                                f"{entry} must come after LOCK")
+                self.assertLess(ch_idx, unlock_idx,
+                                f"{entry} must come before UNLOCK — lock must be held "
+                                f"during ClickHouse checksum for consistent comparison")
+
+
+class TestConcurrentChecksums(unittest.TestCase):
+    """Test that the MySQL source checksum and ClickHouse replica checksums
+    run concurrently under the lock, rather than MySQL-first-then-ClickHouse.
+    Running them in parallel minimizes lock hold time — the lock is held for
+    the duration of the slowest single checksum, not the sum of all."""
+
+    @patch('db_compare.top_level_table_checksum.close_connection')
+    @patch('db_compare.top_level_table_checksum.unlock_tables')
+    @patch('db_compare.top_level_table_checksum.lock_tables')
+    @patch('db_compare.top_level_table_checksum.get_mysql_connection')
+    @patch('db_compare.top_level_table_checksum.get_clickhouse_checksum_command', return_value='ch_cmd')
+    @patch('db_compare.top_level_table_checksum.get_mysql_checksum_command', return_value='mysql_cmd')
+    @patch('db_compare.top_level_table_checksum.run_quick_safe_command')
+    def test_mysql_and_clickhouse_run_concurrently(
+        self, mock_run_cmd, mock_mysql_cmd, mock_ch_cmd, mock_get_conn,
+        mock_lock, mock_unlock, mock_close
+    ):
+        """MySQL and all ClickHouse checksums must overlap in wall-clock time.
+
+        Each checksum sleeps for `delay` seconds. If they ran serially the
+        total time would be ~(N * delay); if concurrent it is ~delay. We
+        assert the elapsed time is close to a single checksum's duration."""
+        from db_compare.top_level_table_checksum import compute_checksum
+
+        delay = 0.3
+        active = {'count': 0, 'max': 0}
+        active_lock = threading.Lock()
+
+        def slow_checksum(cmd):
+            with active_lock:
+                active['count'] += 1
+                active['max'] = max(active['max'], active['count'])
+            time.sleep(delay)
+            with active_lock:
+                active['count'] -= 1
+            return ('0', b'tbl hash 100')
+
+        mock_run_cmd.side_effect = slow_checksum
+
+        import db_compare.top_level_table_checksum as mod
+        mock_args = MagicMock()
+        mock_args.partition_date = None
+        mock_args.threads_per_table = 1
+        mock_args.threads = 1
+        mod.args = mock_args
+
+        # 1 MySQL + 3 ClickHouse = 4 checksums
+        start = time.perf_counter()
+        results = compute_checksum(
+            'test_db', {}, {}, 'tbl', 'user', 'pass',
+            'mysql-host', ['ch-host1', 'ch-host2', 'ch-host3'], 'id', 1000, None,
+            lock_enabled=True, sleep_after_lock=0, mysql_port=3306
+        )
+        elapsed = time.perf_counter() - start
+
+        # All 4 checksums returned
+        self.assertEqual(len(results), 4)
+        # MySQL result first (analyze_differences depends on source ordering)
+        self.assertEqual(results[0][0], 'mysql-host')
+        # All 4 checksums were in flight simultaneously
+        self.assertEqual(active['max'], 4,
+                         "MySQL and all ClickHouse checksums must run concurrently")
+        # Elapsed time is ~1 checksum, not 4 serial ones
+        self.assertLess(elapsed, delay * 2,
+                        f"Concurrent execution should take ~{delay}s, not "
+                        f"{delay*4}s serial (got {elapsed:.3f}s)")
+
+
+class TestPerTableLockIsolation(unittest.TestCase):
+    """Test that the new architecture locks tables independently,
+    not all-at-once as the old code did.
+
+    This is a simulation test that demonstrates the performance difference
+    between the old and new locking strategies."""
+
+    def test_old_vs_new_lock_hold_time(self):
+        """Simulate the lock hold time difference between old and new approaches.
+
+        Old approach (lock-all-then-checksum):
+          - Lock table A, sleep 3s
+          - Lock table B, sleep 3s
+          - Lock table C, sleep 3s
+          - Submit all checksums (MySQL + CH under lock)
+          - Unlock as checksums complete
+          Table A lock hold time: 9s (sleep from all tables) + max(checksum time)
+
+        New approach (per-table lock inside compute_checksum):
+          - Each table: lock, sleep 3s, MySQL+CH checksum, unlock
+          - Tables processed in parallel by thread pool
+          Table A lock hold time: 3s (own sleep) + own checksum time only
+        """
+        num_tables = 5
+        sleep_per_lock = 0.1  # Use 100ms for test speed
+        checksum_time = 0.05  # 50ms simulated checksum (MySQL + CH combined)
+
+        # --- Simulate OLD approach: lock all, then checksum, then unlock ---
+        lock_times_old = {}  # table -> (lock_time, unlock_time)
+
+        def old_approach():
+            # Phase 1: lock all tables sequentially
+            for i in range(num_tables):
+                table = f"table_{i}"
+                lock_times_old[table] = {'locked_at': time.perf_counter()}
+                time.sleep(sleep_per_lock)  # sleep_after_lock per table
+
+            # Phase 2: run checksums (simulated — MySQL + CH both under lock)
+            time.sleep(checksum_time * num_tables)  # worst case: serial
+
+            # Phase 3: unlock all
+            for i in range(num_tables):
+                table = f"table_{i}"
+                lock_times_old[table]['unlocked_at'] = time.perf_counter()
+
+        old_approach()
+
+        # --- Simulate NEW approach: lock-checksum-unlock per table ---
+        # Lock is still held during both MySQL and CH checksums per table,
+        # but each table manages its own lock independently in parallel.
+        lock_times_new = {}
+        lock = threading.Lock()
+
+        def new_approach_per_table(table_idx):
+            table = f"table_{table_idx}"
+            locked_at = time.perf_counter()
+            time.sleep(sleep_per_lock)  # sleep_after_lock
+            time.sleep(checksum_time)   # MySQL + CH checksum (both under lock)
+            unlocked_at = time.perf_counter()
+            with lock:
+                lock_times_new[table] = {
+                    'locked_at': locked_at,
+                    'unlocked_at': unlocked_at
+                }
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_tables) as executor:
+            futures = [executor.submit(new_approach_per_table, i) for i in range(num_tables)]
+            for f in futures:
+                f.result()
+
+        # --- Measure and compare ---
+        old_hold_times = []
+        for table, times in lock_times_old.items():
+            hold = times['unlocked_at'] - times['locked_at']
+            old_hold_times.append(hold)
+
+        new_hold_times = []
+        for table, times in lock_times_new.items():
+            hold = times['unlocked_at'] - times['locked_at']
+            new_hold_times.append(hold)
+
+        max_old = max(old_hold_times)
+        max_new = max(new_hold_times)
+        avg_old = sum(old_hold_times) / len(old_hold_times)
+        avg_new = sum(new_hold_times) / len(new_hold_times)
+
+        print(f"\n{'='*60}")
+        print(f"Lock Hold Time Comparison ({num_tables} tables)")
+        print(f"{'='*60}")
+        print(f"OLD approach (lock-all-then-checksum):")
+        print(f"  Max lock hold time:  {max_old:.3f}s")
+        print(f"  Avg lock hold time:  {avg_old:.3f}s")
+        print(f"  First table locked for entire duration")
+        print(f"NEW approach (per-table lock in compute_checksum):")
+        print(f"  Max lock hold time:  {max_new:.3f}s")
+        print(f"  Avg lock hold time:  {avg_new:.3f}s")
+        print(f"  Each table locked only during its own checksum")
+        print(f"IMPROVEMENT:")
+        print(f"  Max hold time reduced by {(1 - max_new/max_old)*100:.0f}%")
+        print(f"  Avg hold time reduced by {(1 - avg_new/avg_old)*100:.0f}%")
+        print(f"{'='*60}")
+
+        # The new approach should have significantly shorter max lock hold time
+        # Old: first table is locked for ~(num_tables * sleep) + checksum_time
+        # New: each table is locked for ~sleep + checksum_time
+        self.assertLess(max_new, max_old,
+                        f"New max hold ({max_new:.3f}s) should be less than "
+                        f"old max hold ({max_old:.3f}s)")
+        self.assertLess(max_new, max_old * 0.5,
+                        f"New approach should reduce max lock hold by at least 50%")
+
+    def test_old_approach_cumulative_sleep_blocks_all_tables(self):
+        """Demonstrate that the old approach's sequential locking causes
+        cumulative sleep time that blocks earlier tables.
+
+        With N tables and S seconds sleep_after_lock:
+        - Table 1 is write-blocked for N*S seconds before any checksum starts
+        - Table N is write-blocked for S seconds before its checksum starts
+        The discrepancy grows linearly with table count."""
+        num_tables = 10
+        sleep_per_lock = 0.05  # 50ms
+
+        # Old approach: sequential lock acquisition
+        lock_acquire_times = []
+        start = time.perf_counter()
+        for i in range(num_tables):
+            lock_acquire_times.append(time.perf_counter() - start)
+            time.sleep(sleep_per_lock)
+        total_lock_phase = time.perf_counter() - start
+
+        first_table_wait = total_lock_phase  # Table 0 waits for ALL sleeps
+        last_table_wait = sleep_per_lock     # Table N-1 waits for 1 sleep
+
+        print(f"\n{'='*60}")
+        print(f"Cumulative Sleep Blocking ({num_tables} tables, {sleep_per_lock}s sleep)")
+        print(f"{'='*60}")
+        print(f"Old approach (sequential locking):")
+        print(f"  Total lock phase:     {total_lock_phase:.3f}s")
+        print(f"  Table 0 blocked for:  {first_table_wait:.3f}s (worst case)")
+        print(f"  Table {num_tables-1} blocked for: {last_table_wait:.3f}s (best case)")
+        print(f"  Unfairness ratio:     {first_table_wait/last_table_wait:.1f}x")
+        print(f"New approach (parallel per-table):")
+        print(f"  Every table blocked for: ~{sleep_per_lock:.3f}s (equal)")
+        print(f"{'='*60}")
+
+        # The total lock phase should be approximately N * sleep_per_lock
+        expected_total = num_tables * sleep_per_lock
+        self.assertAlmostEqual(total_lock_phase, expected_total, delta=0.1,
+                               msg="Total lock phase should be ~N*sleep")
+        # First table waits much longer than last table
+        self.assertGreater(first_table_wait, last_table_wait * (num_tables - 1),
+                           "First table should wait ~N times longer than last table")
+
+
+class TestComputeChecksumResults(unittest.TestCase):
+    """Test that compute_checksum returns correct results with the new structure."""
+
+    @patch('db_compare.top_level_table_checksum.run_quick_safe_checksum')
+    @patch('db_compare.top_level_table_checksum.get_clickhouse_checksum_command', return_value='ch_cmd')
+    @patch('db_compare.top_level_table_checksum.get_mysql_checksum_command', return_value='mysql_cmd')
+    def test_returns_mysql_and_clickhouse_results(
+        self, mock_mysql_cmd, mock_ch_cmd, mock_checksum
+    ):
+        """compute_checksum should return one MySQL result + N ClickHouse results."""
+        from db_compare.top_level_table_checksum import compute_checksum
+
+        def fake_checksum(cmd, host, table):
+            if host == 'mysql-host':
+                return ('mysql-host', 'tbl', 'mysql_hash', 100)
+            elif host == 'ch-host1':
+                return ('ch-host1', 'tbl', 'ch1_hash', 100)
+            elif host == 'ch-host2':
+                return ('ch-host2', 'tbl', 'ch2_hash', 100)
+
+        mock_checksum.side_effect = fake_checksum
+
+        import db_compare.top_level_table_checksum as mod
+        mock_args = MagicMock()
+        mock_args.partition_date = None
+        mock_args.threads_per_table = 1
+        mock_args.threads = 1
+        mod.args = mock_args
+
+        results = compute_checksum(
+            'test_db', {}, {}, 'tbl', 'user', 'pass',
+            'mysql-host', ['ch-host1', 'ch-host2'], 'id', 1000, None,
+            lock_enabled=False
+        )
+
+        # Should have 3 results: 1 MySQL + 2 ClickHouse
+        self.assertEqual(len(results), 3)
+        hosts = [r[0] for r in results]
+        self.assertIn('mysql-host', hosts)
+        self.assertIn('ch-host1', hosts)
+        self.assertIn('ch-host2', hosts)
+
+        # MySQL result should be first
+        self.assertEqual(results[0][0], 'mysql-host')
+
+    @patch('db_compare.top_level_table_checksum.run_quick_safe_checksum')
+    @patch('db_compare.top_level_table_checksum.get_mysql_checksum_command', return_value='mysql_cmd')
+    def test_returns_mysql_only_when_no_replicas(self, mock_mysql_cmd, mock_checksum):
+        """When no replica hosts are configured, only MySQL result is returned."""
+        from db_compare.top_level_table_checksum import compute_checksum
+
+        mock_checksum.return_value = ('mysql-host', 'tbl', 'hash', 50)
+
+        import db_compare.top_level_table_checksum as mod
+        mock_args = MagicMock()
+        mock_args.partition_date = None
+        mock_args.threads_per_table = 1
+        mock_args.threads = 1
+        mod.args = mock_args
+
+        results = compute_checksum(
+            'test_db', {}, {}, 'tbl', 'user', 'pass',
+            'mysql-host', [], 'id', 1000, None,
+            lock_enabled=False
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0][0], 'mysql-host')
+
+    @patch('db_compare.top_level_table_checksum.run_quick_safe_checksum')
+    @patch('db_compare.top_level_table_checksum.get_clickhouse_checksum_command', return_value='ch_cmd')
+    @patch('db_compare.top_level_table_checksum.get_mysql_checksum_command', return_value='mysql_cmd')
+    def test_database_override_map_applied(self, mock_mysql_cmd, mock_ch_cmd, mock_checksum):
+        """database_override_map should remap the CH database name."""
+        from db_compare.top_level_table_checksum import compute_checksum
+
+        mock_checksum.return_value = ('host', 'tbl', 'hash', 100)
+
+        import db_compare.top_level_table_checksum as mod
+        mock_args = MagicMock()
+        mock_args.partition_date = None
+        mock_args.threads_per_table = 1
+        mock_args.threads = 1
+        mod.args = mock_args
+
+        override_map = {'ch-host1': 'risk:uip_risk'}
+
+        compute_checksum(
+            'risk', override_map, {}, 'tbl', 'user', 'pass',
+            'mysql-host', ['ch-host1'], 'id', 1000, None,
+            lock_enabled=False
+        )
+
+        # Verify the CH command was built with the overridden database
+        mock_ch_cmd.assert_called_once()
+        call_args = mock_ch_cmd.call_args
+        # Second positional arg (index 1) is the database name
+        ch_database_used = call_args[0][1]
+        self.assertEqual(ch_database_used, 'uip_risk')
+
+
+class TestRunConfigNoLockState(unittest.TestCase):
+    """Test that run_config no longer manages lock state (future_to_conn removed)."""
+
+    def test_run_config_has_no_future_to_conn(self):
+        """The run_config function should no longer contain future_to_conn.
+        Lock lifecycle is now managed inside compute_checksum."""
+        import inspect
+        from db_compare.top_level_table_checksum import run_config
+
+        source = inspect.getsource(run_config)
+        self.assertNotIn('future_to_conn', source,
+                         "run_config should not manage lock connections — "
+                         "lock lifecycle is now inside compute_checksum")
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/sink-connector/python/db_compare/top_level_table_checksum.py
+++ b/sink-connector/python/db_compare/top_level_table_checksum.py
@@ -183,7 +183,13 @@ def get_mysql_checksum_command(mysql_host, database, table, pk, max_pk, where, i
     defaults_file_clause = ""
     if defaults_file:
         defaults_file_clause = f"--defaults_file={defaults_file}"
-    cmd = f"""set -e pipefail;python db_compare/mysql_table_checksum.py --threads_per_table {args.threads_per_table} --threads={args.threads} --min_date_value "1900-01-01" --mysql_host {mysql_host} --mysql_database {database} --tables_regex "^{table}$" {where_argument} --min_datetime_value "1969-12-31 18:00:00"  --max_datetime_value "2299-12-31 00:00:00"  --binary_encoding base64 {ignored_columns_clause} {debug_output_clause} {defaults_file_clause} | grep -i checksum | awk '{{print $11" "$13" "$15}}' """
+    # `set -eo pipefail` (NOT `set -e pipefail`): bash parses the latter as
+    # `set -e` plus a positional argument named "pipefail", so pipefail is
+    # never enabled. Without it a failing checksum script on the left of the
+    # pipe is masked by a successful awk and the pipeline exits 0 -- a run
+    # that never produced a checksum is reported as a PASS. Verified in bash:
+    # `set -e pipefail; false | grep x | awk '{print}'` exits 0.
+    cmd = f"""set -eo pipefail;python db_compare/mysql_table_checksum.py --threads_per_table {args.threads_per_table} --threads={args.threads} --min_date_value "1900-01-01" --mysql_host {mysql_host} --mysql_database {database} --tables_regex "^{table}$" {where_argument} --min_datetime_value "1969-12-31 18:00:00"  --max_datetime_value "2299-12-31 00:00:00"  --binary_encoding base64 {ignored_columns_clause} {debug_output_clause} {defaults_file_clause} | grep -i checksum | awk '{{print $11" "$13" "$15}}' """ 
     logging.debug(f"MySQL command: {cmd}")
     return cmd
 
@@ -212,8 +218,14 @@ def get_clickhouse_checksum_command(ch_host, database, table, pk, max_pk, where=
     partition_key_clause = ""
     if partition_key:
         partition_key_clause = f" --partition_key {partition_key.replace('`','')}"
-    cmd = f"""set -e pipefail;python db_compare/clickhouse_table_checksum.py --max_memory_usage 80000000000 --threads={args.threads} --clickhouse_host {ch_host} --clickhouse_database  {database}  --tables_regex "^{table}$" {where_argument}  --min_datetime_value "1969-12-31 18:00:00"  --max_datetime_value "2299-12-31 00:00:00" {ignored_columns_clause} --sign_column "" {debug_output_clause} {partition_key_clause} | grep -i checksum | awk '{{print $11" "$13" "$15}}' """
-    return cmd
+    # `set -eo pipefail` (NOT `set -e pipefail`): bash parses the latter as
+    # `set -e` plus a positional argument named "pipefail", so pipefail is
+    # never enabled. Without it a failing checksum script on the left of the
+    # pipe is masked by a successful awk and the pipeline exits 0 -- a run
+    # that never produced a checksum is reported as a PASS. Verified in bash:
+    # `set -e pipefail; false | grep x | awk '{print}'` exits 0.
+    cmd = f"""set -eo pipefail;python db_compare/clickhouse_table_checksum.py --max_memory_usage 80000000000 --threads={args.threads} --clickhouse_host {ch_host} --clickhouse_database  {database}  --tables_regex "^{table}$" {where_argument}  --min_datetime_value "1969-12-31 18:00:00"  --max_datetime_value "2299-12-31 00:00:00" {ignored_columns_clause} --sign_column "" {debug_output_clause} {partition_key_clause} | grep -i checksum | awk '{{print $11" "$13" "$15}}' """ 
+    return cmd 
 
 
 def analyze_differences(results, mysql_host, replica_hosts):
@@ -231,8 +243,18 @@ def analyze_differences(results, mysql_host, replica_hosts):
             logging.info(f"No difference for {source_results[0][1]}")
 
 
+def quote_mysql_identifier(identifier):
+    """Backtick-quote a MySQL identifier, escaping embedded backticks.
+
+    MySQL escapes a backtick inside a quoted identifier by doubling it. Without
+    this, a table name containing a backtick would terminate the quoted
+    identifier early and the remainder would be parsed as SQL grammar.
+    """
+    return "`" + str(identifier).replace("`", "``") + "`"
+
+
 def lock_tables(conn, table):
-    lock_stmt = f"FLUSH TABLE `{table}` WITH READ LOCK"
+    lock_stmt = f"LOCK TABLES {quote_mysql_identifier(table)} READ"
     logging.info(f"Locking table with statement {lock_stmt}")
     execute_mysql(conn, lock_stmt)
 
@@ -410,7 +432,7 @@ def valid_date(s, format= "%Y-%m-%d"):
     try:
         try :
             return datetime.strptime(s, format)
-        except:
+        except ValueError:
             return datetime.strptime(s, "%Y/%m/%d")
     except ValueError:
         msg = "Not a valid date: '{0}'.".format(s)

--- a/sink-connector/tests/__main__.py
+++ b/sink-connector/tests/__main__.py
@@ -49,10 +49,10 @@ try:
             row = [fake.first_name(), fake.last_name(), fake.email(), \
                fake.postcode(), fake.city(), fake.country(), fake.date_of_birth()]
 
-            cursor.execute(' \
-                INSERT INTO `people` (first_name, last_name, email, zipcode, city, country, birthdate) \
-                VALUES ("%s", "%s", "%s", %s, "%s", "%s", "%s"); \
-                ' % (row[0], row[1], row[2], row[3], row[4], row[5], row[6]))
+            cursor.execute(
+                'INSERT INTO `people` (first_name, last_name, email, zipcode, city, country, birthdate) '
+                'VALUES (%s, %s, %s, %s, %s, %s, %s)',
+                (row[0], row[1], row[2], row[3], row[4], row[5], row[6]))
 
             if n % 100 == 0:
                 print("iteration %s" % n)


### PR DESCRIPTION
Python tooling only - no Java changes.

- fstr() in mysql_table_checksum.py, clickhouse_table_checksum.py, mysql_table_count.py was `eval(f"f'{template}'")`: any text reaching the template executed as Python. Replaced with literal `{partition_expression}` substitution; mysql_table_checksum_test.py (previously a placeholder that asserted True == False on every run) now pins that the eval cannot come back.
- Thread-pool result loops read future.result() BEFORE checking future.exception(), so the first exception propagated un-logged and later ones were lost; now handled per-future with the table name logged.
- top_level_table_checksum.py: per-table `LOCK TABLES ... READ` with try/finally unlock + connection close (lock released even when a checksum subprocess dies). New tests/test_table_locking.py covers the lock lifecycle.
- db/clickhouse.py: cursor closed in finally; yaml.safe_load; credentials no longer logged in debug output.
- db/mysql.py: user/password URL-quoted so special characters in credentials do not break the SQLAlchemy URL.
- tests/__main__.py: parameterized INSERT instead of %-interpolated SQL.

Verified: `python -m unittest db_compare.tests.mysql_table_checksum_test db_compare.tests.test_table_locking` - all pass.

Part of the split of #1353 into independently mergeable sub-PRs (each <= 10 files), so the 2.10.0 branch can absorb the fixes incrementally.

Split out of #1353, which this series replaces. Each sub-PR is <= 10 files; the union of all 22 reproduces the #1353 tree exactly (verified by tree SHA).