### PR TITLE
[split 2/22] python: mask passwords in db_dump/db_load command logging, honor dry_run, shlex-quote shell args

### DIFF
--- a/sink-connector/python/db_dump/mysql_dumper.py
+++ b/sink-connector/python/db_dump/mysql_dumper.py
@@ -15,6 +15,7 @@ import datetime
 import os
 from db.mysql import *
 from subprocess import Popen, PIPE
+import shlex
 import subprocess
 import time
 import tempfile
@@ -42,13 +43,47 @@ def record_factory(*args, **kwargs):
 
 logging.setLogRecordFactory(record_factory)
 
+# Secret literals registered at the point they enter a command line, so they can
+# be masked exactly rather than by guessing at shell quoting.
+_REGISTERED_SECRETS = set()
+
+def register_secret(secret):
+    """Register a secret so redact_password() can mask it by exact value.
+
+    Redacting by parsing shell syntax is not reliable: shlex.quote() renders a
+    password containing a single quote as a CONCATENATION of quoted segments
+    (my'secret -> 'my'"'"'secret'), and a password containing whitespace splits
+    across tokens. Masking the known literal value is exact regardless of how
+    the shell chose to quote it.
+    """
+    if secret:
+        _REGISTERED_SECRETS.add(str(secret))
+
+
+def redact_password(cmd):
+    """Return cmd with any registered secret and any --password value masked."""
+    import re as _re
+    redacted = cmd
+    # Longest first, so a secret that contains another is masked whole.
+    for secret in sorted(_REGISTERED_SECRETS, key=len, reverse=True):
+        redacted = redacted.replace(secret, "****")
+    # Fallback for values never registered: consume the whole shell word, which
+    # may be several adjacent quoted/bare segments emitted by shlex.quote().
+    redacted = _re.sub(
+        r"""(--password[=\s]+)((?:'[^']*'|"[^"]*"|[^\s'"]+)+)""",
+        r"\1'****'",
+        redacted,
+    )
+    return redacted
+
+
 def run_command(cmd):
     """
     # -- ======================================================================
     # -- run the command that is passed as cmd and return True or False
     # -- ======================================================================
     """
-    logging.debug("cmd " + cmd)
+    logging.debug("cmd " + redact_password(cmd))
     process = subprocess.Popen(cmd,
                                stdout=subprocess.PIPE,
                                stderr=subprocess.STDOUT,
@@ -62,7 +97,7 @@ def run_command(cmd):
 
 
 def run_quick_command(cmd):
-    logging.debug("cmd " + cmd)
+    logging.debug("cmd " + redact_password(cmd))
     process = subprocess.Popen(cmd,
                                stdout=subprocess.PIPE,
                                stderr=subprocess.STDOUT,
@@ -118,7 +153,8 @@ def generate_mysqlsh_command(dump_dir,
         mysql_user_clause = f" --user {mysql_user}"
     mysql_password_clause = ""
     if mysql_password is not None:
-        mysql_password_clause = f""" --password "{mysql_password}" """
+        register_secret(mysql_password)
+        mysql_password_clause = f" --password {shlex.quote(mysql_password)} "
     mysql_port_clause = ""
     if mysql_port is not None:
         mysql_port_clause = f" --port {mysql_port}"

--- a/sink-connector/python/db_load/clickhouse_loader.py
+++ b/sink-connector/python/db_load/clickhouse_loader.py
@@ -1,5 +1,6 @@
 # python db_load/clickhouse_myloader.py --clickhouse_host localhost  --clickhouse_schema world --dump_dir $HOME/dbdumps/world --db_user root --db_password root --threads 16 --ch_module clickhouse-client-22.5.1.2079 --mysql_source_schema world
 from subprocess import Popen, PIPE
+import shlex
 from db.mysql import is_binary_datatype
 import argparse
 import sys
@@ -265,9 +266,8 @@ def convert_to_clickhouse_table(user_name, table_name, source, rmt_delete_suppor
 
 
 def get_unix_timezone_from_mysql_timezone(timezone):
-    tz = "UTC"
-    timezones = zoneinfo.available_timezones()
-    sorted(timezones)
+    default_tz = "UTC"
+    timezones = sorted(zoneinfo.available_timezones())
     for tz in timezones:
         offset = datetime.datetime.now(zoneinfo.ZoneInfo(
             tz)).utcoffset().total_seconds()/60/60
@@ -280,8 +280,8 @@ def get_unix_timezone_from_mysql_timezone(timezone):
         timezone_from_offset += f"{abs(offset_int):02}:{abs(round((offset-offset_int)*60)):02}"
         logging.debug(tz + "  => "+timezone_from_offset)
         if timezone == timezone_from_offset:
-            break
-    return tz
+            return tz
+    return default_tz
 
 
 def load_schema(args, clickhouse_user=None, clickhouse_password=None,  dry_run=False, datetime_timezone=None):
@@ -408,7 +408,7 @@ def get_column_list(schema_map, schema, table, virtual_columns, transform=False,
 def load_data(args, timezone, schema_map, clickhouse_user=None, clickhouse_password=None, dry_run=False):
 
     if args.mysqlshell:
-        load_data_mysqlshell(args, timezone, schema_map, clickhouse_user=clickhouse_user, clickhouse_password=clickhouse_password, dry_run=False)
+        load_data_mysqlshell(args, timezone, schema_map, clickhouse_user=clickhouse_user, clickhouse_password=clickhouse_password, dry_run=dry_run)
 
     clickhouse_host = args.clickhouse_host
     clickhouse_port = args.clickhouse_port
@@ -417,10 +417,11 @@ def load_data(args, timezone, schema_map, clickhouse_user=None, clickhouse_passw
     password = clickhouse_password
     password_option = ""
     if password is not None:
-        password_option= f"--password '{password}'"
+        register_secret(password)
+        password_option= f"--password {shlex.quote(password)}"
     config_file_option = ""
     if args.clickhouse_config_file is not None:
-       config_file_option= f"--config-file '{args.clickhouse_config_file}'"
+       config_file_option= f"--config-file {shlex.quote(args.clickhouse_config_file)}"
     schema_file = args.dump_dir + '/*-schema.sql.gz'
     for files in glob.glob(schema_file):
         (schema, table_name) = parse_schema_path(files)
@@ -440,8 +441,39 @@ def load_data(args, timezone, schema_map, clickhouse_user=None, clickhouse_passw
             execute_load(cmd)
 
 
+_REGISTERED_SECRETS = set()
+
+
+def register_secret(secret):
+    """Register a secret so redact_password() can mask it by exact value.
+
+    Redacting by parsing shell syntax is not reliable: shlex.quote() renders a
+    password containing a single quote as a CONCATENATION of quoted segments
+    (my'secret -> 'my'"'"'secret'), and one containing whitespace splits across
+    tokens. Masking the known literal is exact however the shell quoted it.
+    """
+    if secret:
+        _REGISTERED_SECRETS.add(str(secret))
+
+
+def redact_password(cmd):
+    """Return cmd with any registered secret and any --password value masked."""
+    redacted = cmd
+    # Longest first, so a secret containing another is masked whole.
+    for secret in sorted(_REGISTERED_SECRETS, key=len, reverse=True):
+        redacted = redacted.replace(secret, "****")
+    # Fallback for values never registered: consume the whole shell word, which
+    # may be several adjacent quoted/bare segments emitted by shlex.quote().
+    redacted = re.sub(
+        r"""(--password[=\s]+)((?:'[^']*'|"[^"]*"|[^\s'"]+)+)""",
+        r"\1'****'",
+        redacted,
+    )
+    return redacted
+
+
 def execute_load(cmd):
-    logging.info(cmd)
+    logging.info(redact_password(cmd))
     if args.dry_run:
         logging.info("dry-run not executing")
         return 
@@ -459,13 +491,14 @@ def load_data_mysqlshell(args, timezone, schema_map, clickhouse_user=None, click
     ch_schema = args.clickhouse_database
 
     schema_files = args.dump_dir + f"/{args.mysql_source_database}@*.sql"
-    password = args.clickhouse_password
+    password = clickhouse_password
     password_option = ""
     if password is not None:
-        password_option= f"--password '{password}'"
+        register_secret(password)
+        password_option= f"--password {shlex.quote(password)}"
     config_file_option = ""
     if args.clickhouse_config_file is not None:
-       config_file_option= f"--config-file '{args.clickhouse_config_file}'"
+       config_file_option= f"--config-file {shlex.quote(args.clickhouse_config_file)}"
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.threads) as executor:
         futures = []
         for file in glob.glob(schema_files):


### PR DESCRIPTION
Python tooling only.

- mysql_dumper.py / clickhouse_loader.py logged the full shell command line including `--password <secret>`. Secrets are now registered at the point they enter a command line and masked by exact value (register_secret()/redact_password()); parsing shell quoting is not reliable because shlex.quote() splits a password containing a quote into concatenated segments.
- Password and config-file arguments are shlex.quote()d instead of hand-quoted.
- clickhouse_loader.py: the dry_run argument was accepted but hardcoded to False at the mysqlshell call site - now passed through; timezone fallback loop returned the last iterated zone instead of UTC on no-match.

Part of the split of #1353 into independently mergeable sub-PRs (each <= 10 files), so the 2.10.0 branch can absorb the fixes incrementally.

Split out of #1353, which this series replaces. Each sub-PR is <= 10 files; the union of all 22 reproduces the #1353 tree exactly (verified by tree SHA).