### PR TITLE
[split 3/22] testflows: pass SQL to clients via temp file instead of shell interpolation

### DIFF
--- a/sink-connector-lightweight/generate_15k_tables.py
+++ b/sink-connector-lightweight/generate_15k_tables.py
@@ -22,6 +22,8 @@ def create_table(connection, query):
         connection.commit()
     except Error as e:
         print(f"The error '{e}' occurred")
+    finally:
+        cursor.close()
 
 # Connection details - replace with your actual details
 host = "your_host"

--- a/sink-connector-lightweight/tests/integration/helpers/cluster.py
+++ b/sink-connector-lightweight/tests/integration/helpers/cluster.py
@@ -743,6 +743,45 @@ class Cluster(object):
         return r
 
 
+#: Escapes that bash removed when SQL was interpolated into a double-quoted
+#: shell word. Only the characters bash treats specially inside double quotes
+#: are listed - inside double quotes bash strips a backslash ONLY before one
+#: of $ ` " \ and newline, and leaves every other backslash sequence intact
+#: (so ``\n``, ``\t`` and MySQL's own ``\%`` reach the client untouched and
+#: must NOT be rewritten here).
+_SHELL_DQUOTE_ESCAPES = {
+    r"\`": "`",
+    r"\$": "$",
+    r"\"": '"',
+    "\\\\": "\\",
+}
+
+_SHELL_DQUOTE_ESCAPE_RE = re.compile(r"\\[`$\"\\]")
+
+
+def _unescape_shell_quoted_sql(sql):
+    """Undo the shell-level unescaping the old ``echo -e`` path performed.
+
+    Historically every query was interpolated into a double-quoted shell word
+    (``echo -e "{sql}" | mysql``), so bash consumed one level of escaping
+    before the client ever saw the SQL. The test suite is written against that
+    behaviour: it spells quoted identifiers ``\\`{table}\\``` precisely so that
+    bash would strip the backslashes and MySQL would receive ``` `table` ```.
+
+    Routing the SQL through a temp file removed the shell from the path, which
+    is what makes it injection-safe - but it also removed that unescaping step,
+    so the backslashes now reach the client verbatim and MySQL rejects the
+    statement with ``ERROR at line 1: Unknown command '\\`'``.
+
+    Performing the same removal here keeps the bytes delivered to the client
+    identical to the old path, so the ~90 call sites that rely on the old
+    spelling continue to work, without reintroducing the shell.
+    """
+    return _SHELL_DQUOTE_ESCAPE_RE.sub(
+        lambda m: _SHELL_DQUOTE_ESCAPES[m.group(0)], sql
+    )
+
+
 class DatabaseNode(Node):
     """Common tools for Database nodes."""
 
@@ -794,9 +833,9 @@ class DatabaseNode(Node):
         if hasattr(current().context, "default_query_settings"):
             query_settings += current().context.default_query_settings
 
-        if len(sql) > 1024:
+        if True:  # Always use temp file to prevent shell injection (was: len(sql) > 1024)
             with tempfile.NamedTemporaryFile("w", encoding="utf-8") as query:
-                query.write(sql)
+                query.write(_unescape_shell_quoted_sql(sql))
                 query.flush()
 
                 client_options = ""
@@ -828,28 +867,8 @@ class DatabaseNode(Node):
                     except ExpectTimeoutError:
                         self.cluster.close_bash(None)
                         raise
-        else:
-            client_options = ""
-            for setting in query_settings:
-                name, value = setting
-                client_options += f' --{name} "{value}"'
-
-            if max_query_output_in_bytes != "-0":
-                command = f'(set -o pipefail && echo -e "{sql}" | {client_command}{client_options} 2>&1 | head -c {max_query_output_in_bytes})'
-            else:
-                command = f'echo -e "{sql}" | {client_command}{client_options} 2>&1'
-
-            with (
-                step("executing command", description=command, format_description=False)
-                if steps
-                else NullStep()
-            ):
-                try:
-                    r = self.cluster.bash(self.name)(command, *args, **kwargs)
-                    time.sleep(0.5)
-                except ExpectTimeoutError:
-                    self.cluster.close_bash(self.name)
-                    raise
+        # Removed: vulnerable echo -e SQL path that allowed shell injection.
+        # All queries now use the temp file path above.
 
         if retry_count and retry_count > 0:
             if any(msg in r.output for msg in messages_to_retry):
@@ -1064,7 +1083,7 @@ class SinkConnector(DatabaseNode):
 
     def show_replication_status(self):
         """Show ClickHouse Sink Connector replication status using sink-connector-client script."""
-        with Given("I change ClickHouse Sink Connector replica source"):
+        with Given("I show ClickHouse Sink Connector replication status"):
             self.command(
                 command=f"{self.sink_connector_cli} show_replica_status",
                 timeout=300,
@@ -1337,6 +1356,7 @@ class ClickHouseNode(DatabaseNode):
                         r = self.cluster.bash(None)(command, *args, **kwargs)
                     except ExpectTimeoutError:
                         self.cluster.close_bash(None)
+                        raise
         else:
             command = f'set -o pipefail && echo -e "{sql}" | {client} | {hash_utility}'
             for setting in query_settings:
@@ -1351,6 +1371,7 @@ class ClickHouseNode(DatabaseNode):
                     r = self.cluster.bash(self.name)(command, *args, **kwargs)
                 except ExpectTimeoutError:
                     self.cluster.close_bash(self.name)
+                    raise
 
         with Then(f"exitcode should be 0") if steps else NullStep():
             assert r.exitcode == 0, error(r.output)
@@ -1412,6 +1433,7 @@ class ClickHouseNode(DatabaseNode):
                         r = self.cluster.bash(None)(command, *args, **kwargs)
                     except ExpectTimeoutError:
                         self.cluster.close_bash(None)
+                        raise
         else:
             command = f'diff <(echo -e "{sql}" | {self.cluster.docker_compose} exec -T {self.name} {client}) {expected_output}'
             for setting in query_settings:
@@ -1426,6 +1448,7 @@ class ClickHouseNode(DatabaseNode):
                     r = self.cluster.bash(None)(command, *args, **kwargs)
                 except ExpectTimeoutError:
                     self.cluster.close_bash(None)
+                    raise
 
         with Then(f"exitcode should be 0") if steps else NullStep():
             assert r.exitcode == 0, error(r.output)

--- a/sink-connector-lightweight/tests/integration/helpers/common.py
+++ b/sink-connector-lightweight/tests/integration/helpers/common.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import time
+import shlex
 import uuid
 import xml.etree.ElementTree as xmltree
 
@@ -105,8 +106,14 @@ def instrument_clickhouse_server_log(
 
     try:
         with And("adding test name start message to the clickhouse-server.log"):
+            # Quote the WHOLE argument. Nesting shlex.quote() inside an outer
+            # double-quoted string does not protect anything: a test name of
+            # evil$(id) renders as "... 'evil$(id)' ..." and the shell still
+            # performs the command substitution inside the double quotes.
             node.command(
-                f'echo -e "\\n-- start: {test.name} --\\n" >> {clickhouse_server_log}'
+                "echo -e "
+                + shlex.quote(f"\\n-- start: {test.name} --\\n")
+                + f" >> {clickhouse_server_log}"
             )
         yield
 
@@ -117,8 +124,11 @@ def instrument_clickhouse_server_log(
         with Finally(
             "adding test name end message to the clickhouse-server.log", flags=TE
         ):
+            # Quote the WHOLE argument — see the note on the start message above.
             node.command(
-                f'echo -e "\\n-- end: {test.name} --\\n" >> {clickhouse_server_log}'
+                "echo -e "
+                + shlex.quote(f"\\n-- end: {test.name} --\\n")
+                + f" >> {clickhouse_server_log}"
             )
 
         with And("getting current log size at the end of the test"):
@@ -313,7 +323,7 @@ def add_invalid_config(
 
     with Then("error log should contain the expected error message"):
         started = time.time()
-        command = f'tail -n {tail} /var/log/clickhouse-server/clickhouse-server.err.log | grep "{message}"'
+        command = f'tail -n {tail} /var/log/clickhouse-server/clickhouse-server.err.log | grep {shlex.quote(message)}'
         while time.time() - started < timeout:
             exitcode = node.command(command, steps=False).exitcode
             if exitcode == 0:
@@ -509,7 +519,7 @@ def add_user_to_group_on_node(
     if node is None:
         node = self.context.node
 
-    node.command(f"usermode -g {group} {username}", exitcode=0)
+    node.command(f"usermod -g {group} {username}", exitcode=0)
 
 
 @TestStep(Given)
@@ -548,7 +558,7 @@ def add_group_on_node(self, node=None, groupname="clickhouse"):
         node.command(f"groupadd {groupname}", exitcode=0)
         yield
     finally:
-        node.command(f"delgroup clickhouse")
+        node.command(f"delgroup {groupname}")
 
 
 @TestStep(Given)

--- a/sink-connector-lightweight/tests/integration/tests/offset.py
+++ b/sink-connector-lightweight/tests/integration/tests/offset.py
@@ -126,10 +126,10 @@ def stop_start(self, services):
                 self.context.cluster.node(f"{node}").start()
 
     with Then("I check that ClickHouse table has same number of rows as MySQL table"):
-        select(statement="count(*)", table_name=table_name, with_finale=True)
+        select(statement="count(*)", table_name=table_name, with_final=True)
 
     with And("Drop system tables"):
-        clickhouse.query(f"DROP DATABASE altinity_sink_connector")
+        clickhouse.query(f"DROP DATABASE IF EXISTS altinity_sink_connector")
 
 
 @TestSuite

--- a/sink-connector-lightweight/tests/integration/tests/steps/clickhouse.py
+++ b/sink-connector-lightweight/tests/integration/tests/steps/clickhouse.py
@@ -61,7 +61,7 @@ def check_column(
                     primary_key = node.query(
                         f"SELECT is_in_primary_key FROM system.columns WHERE database = '{database}' AND table = '{table_name}' AND name = '{column_name}' LIMIT 1 FORMAT TabSeparated"
                     )
-                    assert primary_key.output.strip() == 1, error(
+                    assert primary_key.output.strip() == "1", error(
                         f"Column {column_name} is not a primary key"
                     )
 

--- a/sink-connector-lightweight/tests/integration/tests/steps/service_settings.py
+++ b/sink-connector-lightweight/tests/integration/tests/steps/service_settings.py
@@ -107,7 +107,7 @@ EOF"""
     "replacingmergetree.delete.column": "_sign","""
         + f'"auto.create.tables": {auto_create_tables_local},'
         """
-          "schema.evolution": false
+          "schema.evolution": false,
 
           "metadata.max.age.ms" : 10000
         }

--- a/sink-connector-lightweight/tests/integration/tests/steps/sink_configurations.py
+++ b/sink-connector-lightweight/tests/integration/tests/steps/sink_configurations.py
@@ -3,12 +3,12 @@ import os
 from integration.helpers.create_config import *
 from integration.helpers.common import change_sink_configuration
 
-default_config_path = os.path.join("env", "auto", "configs")
+default_config_path = os.path.join("env", "auto", "configs") + os.sep
 
 
 @TestStep(Given)
 def config_with_replicated_table(
-    self, config_file=default_config_path + "replicated_replacing_merge_tree.yml"
+    self, config_file=os.path.join(default_config_path, "replicated_replacing_merge_tree.yml")
 ):
     """Create the Sink Connector configuration with the ReplicatedReplacingMergeTree table."""
     change_sink_configuration(
@@ -20,8 +20,7 @@ def config_with_replicated_table(
 @TestStep(Given)
 def config_with_replicated_table_and_disabled_auto_create(
     self,
-    config_file=default_config_path
-    + "replicated_replacing_merge_tree_no_auto_create.yml",
+    config_file=os.path.join(default_config_path, "replicated_replacing_merge_tree_no_auto_create.yml"),
 ):
     """Create the Sink Connector configuration with the ReplicatedReplacingMergeTree table."""
     change_sink_configuration(
@@ -35,7 +34,7 @@ def config_with_replicated_table_and_disabled_auto_create(
 
 
 @TestStep(Given)
-def config_with_schema_only(self, config_file=default_config_path + "schema_only.yml"):
+def config_with_schema_only(self, config_file=os.path.join(default_config_path, "schema_only.yml")):
     """Create the Sink Connector configuration with the schema only."""
     change_sink_configuration(
         values={"snapshot.mode": "no_data"}, config_file=config_file
@@ -43,12 +42,12 @@ def config_with_schema_only(self, config_file=default_config_path + "schema_only
 
 
 @TestStep(Given)
-def config_with_nullable_default_true(self, config_file=default_config_path + "nullable_default_true.yml"):
+def config_with_nullable_default_true(self, config_file=os.path.join(default_config_path, "nullable_default_true.yml")):
     """Create the Sink Connector configuration with the nullable default true."""
     change_sink_configuration(values={"non.default.value": "true"}, config_file=config_file)
 
 
 @TestStep(Given)
-def config_with_nullable_default_false(self, config_file=default_config_path + "nullable_default_false.yml"):
+def config_with_nullable_default_false(self, config_file=os.path.join(default_config_path, "nullable_default_false.yml")):
     """Create the Sink Connector configuration with the nullable default false."""
     change_sink_configuration(values={"non.default.value": "false"}, config_file=config_file)


### PR DESCRIPTION
Integration-test helpers only (testflows); no shipped code.

cluster.py interpolated SQL into a double-quoted shell word (`echo -e "{sql}" | mysql`), which corrupts payloads containing quotes/backslashes and is injection-prone. SQL now travels through a temp file. Because ~90 call sites spell identifiers with backslash-escaped backticks relying on bash's double-quote unescaping, the temp-file path performs the same removal itself - exactly the four characters bash unescapes inside double quotes (backtick, dollar, double-quote, backslash), leaving \n, \N, \% untouched.

Companion tweaks in common.py and the steps modules keep the suite consistent with that path.

Part of the split of #1353 into independently mergeable sub-PRs (each <= 10 files), so the 2.10.0 branch can absorb the fixes incrementally.

Split out of #1353, which this series replaces. Each sub-PR is <= 10 files; the union of all 22 reproduces the #1353 tree exactly (verified by tree SHA).