### PR TITLE
[split 4/22] helm: restore snapshot.mode=schema_only default, add configurable disable.drop.truncate

### DIFF
--- a/sink-connector-lightweight/helm/sink-connector-lightweight/templates/configmap.yaml
+++ b/sink-connector-lightweight/helm/sink-connector-lightweight/templates/configmap.yaml
@@ -21,7 +21,18 @@ data:
     clickhouse.server.password: "root"
     clickhouse.server.port: "8123"
     database.allowPublicKeyRetrieval: "true"
-    snapshot.mode: "initial"
+    snapshot.mode: {{ .Values.connector.snapshotMode | default "schema_only" | quote }}
+    {{- /* DESTRUCTIVE: this key controls whether replicated DROP/TRUNCATE are
+           applied; it emits config only, and destroys nothing by itself.
+           Key-presence check, NOT `default`: Sprig's default treats boolean
+           false as empty, so `--set connector.disableDropTruncate=false`
+           would silently render "true" and flip the guard on a cluster where
+           an operator explicitly disabled it. */}}
+    {{- if kindIs "invalid" .Values.connector.disableDropTruncate }}
+    disable.drop.truncate: "true"
+    {{- else }}
+    disable.drop.truncate: {{ .Values.connector.disableDropTruncate | toString | quote }}
+    {{- end }}
     offset.flush.interval.ms: 5000
     connector.class: "io.debezium.connector.postgresql.PostgresConnector"
     offset.storage: "io.debezium.storage.jdbc.offset.JdbcOffsetBackingStore"
@@ -99,7 +110,18 @@ data:
       clickhouse.server.password: "root"
       clickhouse.server.port: "8123"
       database.allowPublicKeyRetrieval: "true"
-      snapshot.mode: "initial"
+      snapshot.mode: {{ .Values.connector.snapshotMode | default "schema_only" | quote }}
+      {{- /* DESTRUCTIVE: this key controls whether replicated DROP/TRUNCATE are
+             applied; it emits config only, and destroys nothing by itself.
+             Key-presence check, NOT `default`: Sprig's default treats boolean
+             false as empty, so `--set connector.disableDropTruncate=false`
+             would silently render "true" and flip the guard on a cluster where
+             an operator explicitly disabled it. */}}
+      {{- if kindIs "invalid" .Values.connector.disableDropTruncate }}
+      disable.drop.truncate: "true"
+      {{- else }}
+      disable.drop.truncate: {{ .Values.connector.disableDropTruncate | toString | quote }}
+      {{- end }}
       offset.flush.interval.ms: 5000
       connector.class: "io.debezium.connector.mysql.MySqlConnector"
       offset.storage: "io.debezium.storage.jdbc.offset.JdbcOffsetBackingStore"

--- a/sink-connector-lightweight/helm/sink-connector-lightweight/values.yaml
+++ b/sink-connector-lightweight/helm/sink-connector-lightweight/values.yaml
@@ -89,5 +89,10 @@ debezium:
   pod:
     mountPath: "/usr/share/debezium/storage"
 
+### Connector safety settings
+connector:
+  snapshotMode: "schema_only"
+  disableDropTruncate: "true"
+
 #### Postgres connector
-postgres: true 
+postgres: true


### PR DESCRIPTION
Helm chart only.

- snapshot.mode becomes configurable (connector.snapshotMode), defaulting to schema_only - the chart had it pinned to initial, which re-snapshots on every fresh deploy.
- disable.drop.truncate becomes configurable (connector.disableDropTruncate), defaulting to true. Uses a key-presence check rather than Sprig `default` because `default` treats boolean false as empty - `--set connector.disableDropTruncate=false` would silently render "true".

Part of the split of #1353 into independently mergeable sub-PRs (each <= 10 files), so the 2.10.0 branch can absorb the fixes incrementally.

Split out of #1353, which this series replaces. Each sub-PR is <= 10 files; the union of all 22 reproduces the #1353 tree exactly (verified by tree SHA).