### PR TITLE
[split 10/22] model: ClickHouseStruct hardening and 2.8.0 version-format compatibility pinning tests

### DIFF
--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/model/BlockMetaData.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/model/BlockMetaData.java
@@ -171,6 +171,12 @@ public class BlockMetaData {
         }
 
         long sourceDbLag = blockInsertionTimestamp - record.getTs_ms();
+        if (minSourceLag == 0 || sourceDbLag < minSourceLag) {
+            minSourceLag = sourceDbLag;
+        }
+        if (sourceDbLag > maxSourceLag) {
+            maxSourceLag = sourceDbLag;
+        }
         if (sourceToCHLag.containsKey(this.topicName)) {
             long storedSourceLag = sourceToCHLag.get(this.topicName);
             if (sourceDbLag > storedSourceLag) {
@@ -181,6 +187,12 @@ public class BlockMetaData {
         }
 
         long debeziumLag = blockInsertionTimestamp - record.getDebezium_ts_ms();
+        if (minConsumerLag == 0 || debeziumLag < minConsumerLag) {
+            minConsumerLag = debeziumLag;
+        }
+        if (debeziumLag > maxConsumerLag) {
+            maxConsumerLag = debeziumLag;
+        }
         if (debeziumToCHLag.containsKey(this.topicName)) {
             long storedDebeziumLag = debeziumToCHLag.get(this.topicName);
             if (debeziumLag > storedDebeziumLag) {

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/model/ClickHouseStruct.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/model/ClickHouseStruct.java
@@ -375,16 +375,13 @@ public class ClickHouseStruct {
      */
     public void setBeforeStruct(Struct s) {
         this.beforeStruct = s;
-        if (s != null) {
-            List<Field> schemaFields = s.schema().fields();
-            this.beforeModifiedFields = new ArrayList<>();
-            for (Field f : schemaFields) {
-                // Identify the list of columns that were modified.
-                // Schema.fields() will give the list of columns in the schema.
-                if (s.get(f) != null) {
-                    this.beforeModifiedFields.add(f);
-                }
-            }
+        if (s != null && s.schema() != null) {
+            // Include ALL fields in modifiedFields, not just non-null ones.
+            // The previous code skipped fields with null values, which caused
+            // UPDATE statements that set columns to NULL to silently lose those
+            // changes — the NULL column would not appear in the modified fields
+            // list and ClickHouse would keep the old value.
+            this.beforeModifiedFields = new ArrayList<>(s.schema().fields());
         }
     }
 
@@ -396,16 +393,9 @@ public class ClickHouseStruct {
      */
     public void setAfterStruct(Struct s) {
         this.afterStruct = s;
-        if (s != null) {
-            List<Field> schemaFields = s.schema().fields();
-            this.afterModifiedFields = new ArrayList<>();
-            for (Field f : schemaFields) {
-                // Identify the list of columns that were modified.
-                // Schema.fields() will give the list of columns in the schema.
-                if (s.get(f) != null) {
-                    this.afterModifiedFields.add(f);
-                }
-            }
+        if (s != null && s.schema() != null) {
+            // Include ALL fields in modifiedFields — see setBeforeStruct comment.
+            this.afterModifiedFields = new ArrayList<>(s.schema().fields());
         }
     }
 
@@ -465,15 +455,17 @@ public class ClickHouseStruct {
             if (fieldNames.contains(SERVER_THREAD)
                     && source.get(SERVER_THREAD) != null
                     && source.get(SERVER_THREAD) instanceof Integer) {
-                this.setThread((Integer) convertedValue.get(SERVER_THREAD));
+                // Fix: read from source, not convertedValue (was data corruption bug)
+                this.setThread((Integer) source.get(SERVER_THREAD));
             }
             if (fieldNames.contains(GTID)
                     && source.get(GTID) != null
                     && source.get(GTID) instanceof String) {
-                String[] gtidArray = ((String) source.get(GTID)).split(":");
-                if (gtidArray.length == EXPECTED_GTID_ARRAY_LENGTH) {
-                    this.setGtid(Long.parseLong(
-                            gtidArray[GTID_SEGMENT_INDEX]));
+                String gtidStr = (String) source.get(GTID);
+                try {
+                    this.setGtid(parseGtidMax(gtidStr));
+                } catch (NumberFormatException e) {
+                    log.warn("Failed to parse GTID value: " + gtidStr, e);
                 }
             }
             if (fieldNames.contains(LSN)
@@ -522,11 +514,11 @@ public class ClickHouseStruct {
                 .append(" ts_ms:").append(ts_ms)
                 .append(" ts_sec:").append(tsSec)
                 .append(" snapshot:").append(snapshot)
-                .append(" server_id").append(serverId)
-                .append(" binlog_file").append(file)
-                .append(" binlog_pos").append(pos)
-                .append(" row").append(row)
-                .append(" server_thread").append(thread)
+                .append(" server_id:").append(serverId)
+                .append(" binlog_file:").append(file)
+                .append(" binlog_pos:").append(pos)
+                .append(" row:").append(row)
+                .append(" server_thread:").append(thread)
                 .toString();
     }
 
@@ -541,11 +533,19 @@ public class ClickHouseStruct {
             return 0L;
         }
         SourceRecord srd = changeEvent.value();
+        if (!(srd.value() instanceof Struct)) {
+            return 0L;
+        }
         Struct kafkaStruct = (Struct) srd.value();
         if(kafkaStruct == null) {
             return 0L;
         }
-        return (Long) kafkaStruct.get(SinkRecordColumns.TS_MS);
+        // Guard against null or wrong type for TS_MS field
+        Object tsMs = kafkaStruct.get(SinkRecordColumns.TS_MS);
+        if (tsMs instanceof Long) {
+            return (Long) tsMs;
+        }
+        return 0L;
     }
 
     /**
@@ -559,7 +559,7 @@ public class ClickHouseStruct {
             return null;
         }
         
-        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> map = new LinkedHashMap<>();
         for (Field field : struct.schema().fields()) {
             try {
                 Object value = struct.get(field);
@@ -749,6 +749,42 @@ public class ClickHouseStruct {
         } catch (Exception e) {
             log.error("Error parsing ts_sec from sourceOffset", e);
         }
+    }
+
+    /**
+     * Parses a MySQL GTID string and returns the maximum transaction ID.
+     * Handles formats:
+     *   - Simple: uuid:N
+     *   - Range: uuid:1-5
+     *   - Multi-range: uuid:1-5:7-10
+     *   - Multi-source: uuid1:1-5,uuid2:1-3
+     *
+     * @param gtidStr the raw GTID string from Debezium
+     * @return the maximum transaction ID across all sources and ranges
+     * @throws NumberFormatException if the GTID contains unparseable numbers
+     */
+    static long parseGtidMax(String gtidStr) {
+        long maxGtid = -1;
+        // Split by comma for multi-source GTIDs
+        String[] sources = gtidStr.split(",");
+        for (String src : sources) {
+            // Split by colon: first part is UUID, rest are ranges
+            String[] parts = src.trim().split(":");
+            for (int i = 1; i < parts.length; i++) {
+                String range = parts[i].trim();
+                long val;
+                if (range.contains("-")) {
+                    // Range format (e.g., "1-5"): take the end value
+                    String endStr = range.substring(
+                            range.lastIndexOf('-') + 1);
+                    val = Long.parseLong(endStr);
+                } else {
+                    val = Long.parseLong(range);
+                }
+                maxGtid = Math.max(maxGtid, val);
+            }
+        }
+        return maxGtid;
     }
 
     /**

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/model/RoutedBatch.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/model/RoutedBatch.java
@@ -76,7 +76,8 @@ public class RoutedBatch {
             return 0;
         }
         // Use Math.abs to ensure positive value, then modulo to get thread assignment
-        return Math.abs(tableName.hashCode()) % threadPoolSize;
+        // Use bitmask instead of Math.abs to avoid Integer.MIN_VALUE overflow
+        return (tableName.hashCode() & 0x7FFFFFFF) % threadPoolSize;
     }
     
     /**

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/model/BlockMetaDataTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/model/BlockMetaDataTest.java
@@ -1,0 +1,103 @@
+package com.altinity.clickhouse.sink.connector.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link BlockMetaData} to verify lag metrics are properly tracked.
+ */
+public class BlockMetaDataTest {
+
+    @Test
+    @DisplayName("update() should populate minSourceLag and maxSourceLag")
+    public void testUpdatePopulatesSourceLag() {
+        BlockMetaData meta = new BlockMetaData();
+
+        // Create a mock record with ts_ms set to a known value
+        ClickHouseStruct record1 = new ClickHouseStruct();
+        record1.setTs_ms(meta.blockInsertionTimestamp - 100); // 100ms lag
+        record1.setDebezium_ts_ms(meta.blockInsertionTimestamp - 50);
+        record1.setTopic("server.db.table1");
+        record1.setKafkaPartition(0);
+        record1.setPos(1L);
+        record1.setFile("binlog.000001");
+
+        meta.update(record1);
+
+        assertTrue(meta.getMinSourceLag() > 0, "minSourceLag should be populated after update");
+        assertTrue(meta.getMaxSourceLag() > 0, "maxSourceLag should be populated after update");
+    }
+
+    @Test
+    @DisplayName("update() should track min and max correctly across multiple records")
+    public void testUpdateTracksMinMax() {
+        BlockMetaData meta = new BlockMetaData();
+
+        ClickHouseStruct record1 = new ClickHouseStruct();
+        record1.setTs_ms(meta.blockInsertionTimestamp - 200); // 200ms lag
+        record1.setDebezium_ts_ms(meta.blockInsertionTimestamp - 100);
+        record1.setTopic("server.db.table1");
+        record1.setKafkaPartition(0);
+        record1.setPos(1L);
+        record1.setFile("binlog.000001");
+        meta.update(record1);
+
+        ClickHouseStruct record2 = new ClickHouseStruct();
+        record2.setTs_ms(meta.blockInsertionTimestamp - 50); // 50ms lag
+        record2.setDebezium_ts_ms(meta.blockInsertionTimestamp - 25);
+        record2.setTopic("server.db.table1");
+        record2.setKafkaPartition(0);
+        record2.setPos(2L);
+        record2.setFile("binlog.000001");
+        meta.update(record2);
+
+        // Min should be the smaller lag (50ms), max should be the larger (200ms)
+        assertTrue(meta.getMinSourceLag() <= meta.getMaxSourceLag(),
+                "minSourceLag should be <= maxSourceLag");
+        assertTrue(meta.getMinConsumerLag() <= meta.getMaxConsumerLag(),
+                "minConsumerLag should be <= maxConsumerLag");
+    }
+
+    @Test
+    @DisplayName("update() should populate minConsumerLag and maxConsumerLag")
+    public void testUpdatePopulatesConsumerLag() {
+        BlockMetaData meta = new BlockMetaData();
+
+        ClickHouseStruct record1 = new ClickHouseStruct();
+        record1.setTs_ms(meta.blockInsertionTimestamp - 100);
+        record1.setDebezium_ts_ms(meta.blockInsertionTimestamp - 75); // 75ms consumer lag
+        record1.setTopic("server.db.table1");
+        record1.setKafkaPartition(0);
+        record1.setPos(1L);
+        record1.setFile("binlog.000001");
+
+        meta.update(record1);
+
+        assertTrue(meta.getMinConsumerLag() > 0, "minConsumerLag should be populated after update");
+        assertTrue(meta.getMaxConsumerLag() > 0, "maxConsumerLag should be populated after update");
+    }
+
+    @Test
+    @DisplayName("update() should track partition offset correctly")
+    public void testUpdateTracksPartitionOffset() {
+        BlockMetaData meta = new BlockMetaData();
+
+        ClickHouseStruct record1 = new ClickHouseStruct();
+        record1.setTs_ms(System.currentTimeMillis() - 100);
+        record1.setDebezium_ts_ms(System.currentTimeMillis() - 50);
+        record1.setTopic("server.db.table1");
+        record1.setKafkaPartition(0);
+        record1.setKafkaOffset(42L);
+        record1.setPos(1L);
+        record1.setFile("binlog.000001");
+
+        meta.update(record1);
+
+        assertTrue(meta.getPartitionToOffsetMap().containsKey("server.db.table1"),
+                "partitionToOffsetMap should contain topic");
+        assertEquals(42L, meta.getPartitionToOffsetMap().get("server.db.table1").getRight(),
+                "offset should be tracked");
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/model/ClickHouseStructTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/model/ClickHouseStructTest.java
@@ -3,12 +3,15 @@ package com.altinity.clickhouse.sink.connector.model;
 import com.altinity.clickhouse.sink.connector.converters.ClickHouseConverter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.debezium.engine.ChangeEvent;
+import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
+import io.debezium.engine.ChangeEvent;
 import org.junit.Assert;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -16,11 +19,27 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * Tests for ClickHouseStruct — Phase 10 edge case coverage.
+ * <p>
+ * Validates:
+ * - setBeforeStruct / setAfterStruct with null schema
+ * - getDebeziumTsFromChangeEvent with null/wrong type
+ * - SERVER_THREAD metadata reads from source (not convertedValue)
+ * - Version calculation from GTID, sequenceNumber, LSN
+ * </p>
+ */
 public class ClickHouseStructTest {
 
-    ClickHouseStruct st;
+    @Nested
+    @DisplayName("setBeforeStruct / setAfterStruct null safety")
+    class StructSetterTests {
 
     @Test
     public void testGtid() {
@@ -35,7 +54,7 @@ public class ClickHouseStructTest {
                 .field(keyField, Schema.STRING_SCHEMA)
                 .build();
 
-        st = new ClickHouseStruct(10, "topic_1", new Struct(basicKeySchema), 100,
+        ClickHouseStruct st = new ClickHouseStruct(10, "topic_1", new Struct(basicKeySchema), 100,
                 12322323L, new Struct(basicKeySchema), new Struct(basicKeySchema),
                 metaData, ClickHouseConverter.CDC_OPERATION.CREATE);
 
@@ -196,7 +215,9 @@ public class ClickHouseStructTest {
         JsonNode jsonArray = mapper.readTree(json);
         
         assertTrue(jsonArray.isArray());
-        assertEquals(3, jsonArray.size()); // Only non-null fields should be included
+        // All schema fields are included (including NULL ones) to ensure
+        // that UPDATE SET col=NULL is properly replicated to ClickHouse.
+        assertEquals(4, jsonArray.size());
         
         // Check first field (id)
         JsonNode idField = jsonArray.get(0);
@@ -273,7 +294,8 @@ public class ClickHouseStructTest {
         JsonNode jsonArray = mapper.readTree(json);
         
         assertTrue(jsonArray.isArray());
-        assertEquals(4, jsonArray.size()); // Only non-null fields should be included
+        // All schema fields are included (including NULL ones).
+        assertEquals(5, jsonArray.size());
         
         // Check fields are present
         boolean foundId = false, foundName = false, foundEmail = false, foundActive = false;
@@ -304,33 +326,243 @@ public class ClickHouseStructTest {
                     assertTrue(field.get("value").asBoolean());
                     assertEquals("BOOLEAN", field.get("schema").get("type").asText());
                     break;
+                default:
+                    break;
             }
         }
-        
+
+        // Restored: the phase merge truncated this test mid-loop, dropping the
+        // for-loop close, the assertions the loop exists to make, and the
+        // method close — which is what made the whole file unparseable.
         assertTrue(foundId);
         assertTrue(foundName);
         assertTrue(foundEmail);
         assertTrue(foundActive);
     }
-    
-    @Test
-    public void testAfterModifiedFieldsToJsonWithNullAfterModifiedFields() {
-        Map<String, Object> metaData = new HashMap<>();
-        Schema basicSchema = SchemaBuilder.struct()
-                .field("id", Schema.INT32_SCHEMA)
-                .build();
-        Struct basicStruct = new Struct(basicSchema).put("id", 1);
-        
-        ClickHouseStruct clickHouseStruct = new ClickHouseStruct(
-                10L, "test-topic", basicStruct, 0, 123456789L,
-                basicStruct, null, metaData, // afterStruct is null
-                ClickHouseConverter.CDC_OPERATION.DELETE
-        );
-        
-        String json = clickHouseStruct.afterModifiedFieldsToJson();
-        assertEquals("", json);
+
+        @Test
+        @DisplayName("setBeforeStruct with null should not throw")
+        public void testSetBeforeStructNull() {
+            ClickHouseStruct chStruct = new ClickHouseStruct();
+            chStruct.setBeforeStruct(null);
+            Assert.assertNull(chStruct.getBeforeStruct());
+            Assert.assertNull(chStruct.getBeforeModifiedFields());
+        }
+
+        @Test
+        @DisplayName("setAfterStruct with null should not throw")
+        public void testSetAfterStructNull() {
+            ClickHouseStruct chStruct = new ClickHouseStruct();
+            chStruct.setAfterStruct(null);
+            Assert.assertNull(chStruct.getAfterStruct());
+            Assert.assertNull(chStruct.getAfterModifiedFields());
+        }
+
+        @Test
+        @DisplayName("setBeforeStruct with valid struct should populate modified fields")
+        public void testSetBeforeStructValid() {
+            Schema schema = SchemaBuilder.struct()
+                    .field("id", Schema.INT32_SCHEMA)
+                    .field("name", Schema.STRING_SCHEMA)
+                    .build();
+            Struct s = new Struct(schema);
+            s.put("id", 42);
+            s.put("name", "test");
+
+            ClickHouseStruct chStruct = new ClickHouseStruct();
+            chStruct.setBeforeStruct(s);
+
+            Assert.assertNotNull(chStruct.getBeforeStruct());
+            Assert.assertNotNull(chStruct.getBeforeModifiedFields());
+            Assert.assertEquals(2, chStruct.getBeforeModifiedFields().size());
+        }
+
+        @Test
+        @DisplayName("setAfterStruct with valid struct should populate modified fields")
+        public void testSetAfterStructValid() {
+            Schema schema = SchemaBuilder.struct()
+                    .field("id", Schema.INT32_SCHEMA)
+                    .field("value", Schema.FLOAT64_SCHEMA)
+                    .build();
+            Struct s = new Struct(schema);
+            s.put("id", 1);
+            s.put("value", 3.14);
+
+            ClickHouseStruct chStruct = new ClickHouseStruct();
+            chStruct.setAfterStruct(s);
+
+            Assert.assertNotNull(chStruct.getAfterStruct());
+            Assert.assertNotNull(chStruct.getAfterModifiedFields());
+            Assert.assertEquals(2, chStruct.getAfterModifiedFields().size());
+        }
+
+        @Test
+        @DisplayName("setBeforeStruct should include null-valued fields as modified")
+        public void testSetBeforeStructPartialNull() {
+            Schema schema = SchemaBuilder.struct()
+                    .field("id", Schema.INT32_SCHEMA)
+                    .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+                    .build();
+            Struct s = new Struct(schema);
+            s.put("id", 42);
+            // name is null (optional)
+
+            ClickHouseStruct chStruct = new ClickHouseStruct();
+            chStruct.setBeforeStruct(s);
+
+            Assert.assertNotNull(chStruct.getBeforeModifiedFields());
+            // Both fields must be present. Skipping null-valued fields was a
+            // data-loss bug: an UPDATE that sets a column to NULL would omit that
+            // column from the modified-field list, so ClickHouse silently retained
+            // the previous value. See testNullFieldsIncludedInModifiedFields.
+            Assert.assertEquals(2, chStruct.getBeforeModifiedFields().size());
+            Assert.assertEquals("id", chStruct.getBeforeModifiedFields().get(0).name());
+            Assert.assertEquals("name", chStruct.getBeforeModifiedFields().get(1).name());
+        }
+    }
+
+    @Nested
+    @DisplayName("getDebeziumTsFromChangeEvent null safety")
+    class DebeziumTsTests {
+
+        @Test
+        @DisplayName("null changeEvent should return 0")
+        public void testNullChangeEvent() {
+            Long result = ClickHouseStruct.getDebeziumTsFromChangeEvent(null);
+            Assert.assertEquals(Long.valueOf(0L), result);
+        }
     }
     
+    // =========================================================    // GTID parsing tests — validate parseGtidMax handles all MySQL formats
+    // =========================================================
+    @Test
+    public void testParseGtidSimple() {
+        // Simple format: uuid:N
+        long result = ClickHouseStruct.parseGtidMax(
+                "30fd82c7-0f86-11ee-9e3b-0242c0a86002:2442");
+        assertEquals(2442L, result);
+    }
+
+    @Test
+    public void testParseGtidRange() {
+        // Range format: uuid:start-end
+        long result = ClickHouseStruct.parseGtidMax(
+                "30fd82c7-0f86-11ee-9e3b-0242c0a86002:1-2442");
+        assertEquals(2442L, result);
+    }
+
+    @Test
+    public void testParseGtidMultiRange() {
+        // Multi-range format: uuid:range1:range2
+        long result = ClickHouseStruct.parseGtidMax(
+                "30fd82c7-0f86-11ee-9e3b-0242c0a86002:1-500:502-2442");
+        assertEquals(2442L, result);
+    }
+
+    @Test
+    public void testParseGtidMultiSource() {
+        // Multi-source format: uuid1:range,uuid2:range
+        long result = ClickHouseStruct.parseGtidMax(
+                "30fd82c7-0f86-11ee-9e3b-0242c0a86002:1-2442,"
+                + "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee:1-100");
+        assertEquals(2442L, result);
+    }
+
+    @Test
+    public void testParseGtidMultiSourceMultiRange() {
+        // Multi-source with multi-range
+        long result = ClickHouseStruct.parseGtidMax(
+                "uuid1:1-100:200-300,uuid2:1-5000");
+        assertEquals(5000L, result);
+    }
+
+    @Test
+    public void testParseGtidSingleTransaction() {
+        // Single transaction ID (no range)
+        long result = ClickHouseStruct.parseGtidMax(
+                "30fd82c7-0f86-11ee-9e3b-0242c0a86002:1");
+        assertEquals(1L, result);
+    }
+
+    @Test
+    public void testGtidMetadataParsing() {
+        // Test GTID via setAdditionalMetaData with multi-range format
+        Map<String, Object> metaData = new HashMap<>();
+        metaData.put("source", new Struct(
+                SchemaBuilder.struct()
+                        .field("gtid", Schema.STRING_SCHEMA)
+                        .build())
+                .put("gtid", "uuid1:1-500:502-2442,uuid2:1-100"));
+
+        Schema basicSchema = SchemaBuilder.struct()
+                .field("id", Schema.INT32_SCHEMA).build();
+        Struct basicStruct = new Struct(basicSchema).put("id", 1);
+
+        ClickHouseStruct st = new ClickHouseStruct(10, "topic_1",
+                basicStruct, 100, 12322323L, basicStruct, basicStruct,
+                metaData, ClickHouseConverter.CDC_OPERATION.CREATE);
+
+        assertEquals(2442L, st.getGtid());
+    }
+
+    @Test
+    public void testServerThreadReadsFromSource() {
+        // Verify SERVER_THREAD is read from source (not convertedValue).
+        // The Debezium source-block field name is "thread"
+        // (SinkRecordColumns.SERVER_THREAD); "_server_thread" is the ClickHouse
+        // destination column name (KafkaMetaData.SERVER_THREAD), not the input field.
+        Map<String, Object> metaData = new HashMap<>();
+        Schema sourceSchema = SchemaBuilder.struct()
+                .field("thread", Schema.INT32_SCHEMA)
+                .build();
+        Struct source = new Struct(sourceSchema).put("thread", 42);
+        metaData.put("source", source);
+
+        Schema basicSchema = SchemaBuilder.struct()
+                .field("id", Schema.INT32_SCHEMA).build();
+        Struct basicStruct = new Struct(basicSchema).put("id", 1);
+
+        ClickHouseStruct st = new ClickHouseStruct(10, "topic_1",
+                basicStruct, 100, 12322323L, basicStruct, basicStruct,
+                metaData, ClickHouseConverter.CDC_OPERATION.CREATE);
+
+        assertEquals(42, st.getThread());
+    }
+
+    @Test
+    public void testNullFieldsIncludedInModifiedFields() {
+        // Verify that NULL fields ARE included in modifiedFields
+        // (this is critical for UPDATE SET col = NULL replication)
+        Schema schema = SchemaBuilder.struct()
+                .field("id", Schema.INT32_SCHEMA)
+                .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("age", Schema.OPTIONAL_INT32_SCHEMA)
+                .build();
+
+        // age is NULL — must still appear in modifiedFields
+        Struct struct = new Struct(schema)
+                .put("id", 1)
+                .put("name", "test");
+                // age deliberately left as null
+
+        ClickHouseStruct chStruct = new ClickHouseStruct();
+        chStruct.setAfterStruct(struct);
+
+        assertNotNull(chStruct.getAfterModifiedFields());
+        // All 3 fields must be present, including null age
+        assertEquals(3, chStruct.getAfterModifiedFields().size());
+
+        boolean foundAge = false;
+        for (org.apache.kafka.connect.data.Field f :
+                chStruct.getAfterModifiedFields()) {
+            if (f.name().equals("age")) {
+                foundAge = true;
+            }
+        }
+        // JUnit 5 takes the failure message LAST (JUnit 4 took it first).
+        assertTrue(foundAge, "NULL field 'age' must be in modifiedFields");
+    }
+
     @Test
     public void testJsonSerializationWithComplexSchema() throws Exception {
         // Test with array and nested fields
@@ -388,6 +620,133 @@ public class ClickHouseStructTest {
                 assertEquals("STRUCT", field.get("schema").get("type").asText());
                 assertTrue(field.has("value"));
             }
+        }
+        // Restored: the phase merge truncated this test mid-loop, dropping the
+        // for-loop close and the method close.
+    }
+
+    @Nested
+    @DisplayName("setAdditionalMetaData")
+    class MetadataTests {
+
+        @Test
+        @DisplayName("null metadata should not throw")
+        public void testNullMetadata() {
+            ClickHouseStruct chStruct = new ClickHouseStruct();
+            chStruct.setAdditionalMetaData(null);
+            // Should return without error
+        }
+
+        @Test
+        @DisplayName("empty metadata should not throw")
+        public void testEmptyMetadata() {
+            ClickHouseStruct chStruct = new ClickHouseStruct();
+            Map<String, Object> metadata = new HashMap<>();
+            chStruct.setAdditionalMetaData(metadata);
+            // Should return without error (no SOURCE key)
+        }
+
+        @Test
+        @DisplayName("metadata with valid source should populate fields")
+        public void testValidSourceMetadata() {
+            ClickHouseStruct chStruct = new ClickHouseStruct();
+
+            Schema sourceSchema = SchemaBuilder.struct()
+                    .field("ts_ms", Schema.INT64_SCHEMA)
+                    .field("server_id", Schema.INT64_SCHEMA)
+                    .field("file", Schema.STRING_SCHEMA)
+                    .field("pos", Schema.INT64_SCHEMA)
+                    .field("row", Schema.INT32_SCHEMA)
+                    .field("thread", Schema.INT32_SCHEMA)
+                    .field("db", Schema.STRING_SCHEMA)
+                    .build();
+
+            Struct source = new Struct(sourceSchema);
+            source.put("ts_ms", 1234567890000L);
+            source.put("server_id", 1L);
+            source.put("file", "mysql-bin.000001");
+            source.put("pos", 12345L);
+            source.put("row", 0);
+            source.put("thread", 42);
+            source.put("db", "testdb");
+
+            Map<String, Object> metadata = new HashMap<>();
+            metadata.put("source", source);
+            metadata.put("ts_ms", 1234567890001L);
+
+            chStruct.setAdditionalMetaData(metadata);
+
+            Assert.assertEquals(1234567890000L, chStruct.getTs_ms());
+            Assert.assertEquals(1234567890001L, chStruct.getDebezium_ts_ms());
+            Assert.assertEquals(Long.valueOf(1L), chStruct.getServerId());
+            Assert.assertEquals("mysql-bin.000001", chStruct.getFile());
+            Assert.assertEquals(Long.valueOf(12345L), chStruct.getPos());
+            Assert.assertEquals(0, chStruct.getRow());
+            // Fix 1 validation: thread should come from source, not convertedValue
+            Assert.assertEquals(42, chStruct.getThread());
+            Assert.assertEquals("testdb", chStruct.getDatabase());
+        }
+    }
+
+    @Nested
+    @DisplayName("Version calculation")
+    class VersionTests {
+
+        @Test
+        @DisplayName("calculateVersion with GTID should use GTID")
+        public void testCalculateVersionGtid() {
+            ClickHouseStruct chStruct = new ClickHouseStruct();
+            chStruct.setGtid(12345L);
+            chStruct.calculateVersion(false);
+            Assert.assertEquals(12345L, chStruct.getVersion());
+        }
+
+        @Test
+        @DisplayName("calculateVersion with sequenceNumber should use sequenceNumber")
+        public void testCalculateVersionSequenceNumber() {
+            ClickHouseStruct chStruct = new ClickHouseStruct();
+            chStruct.setSequenceNumber(67890L);
+            chStruct.calculateVersion(false);
+            Assert.assertEquals(67890L, chStruct.getVersion());
+        }
+
+        @Test
+        @DisplayName("calculateVersion with LSN should use LSN")
+        public void testCalculateVersionLsn() {
+            ClickHouseStruct chStruct = new ClickHouseStruct();
+            chStruct.setLsn(99999L);
+            chStruct.calculateVersion(false);
+            Assert.assertEquals(99999L, chStruct.getVersion());
+        }
+
+        @Test
+        @DisplayName("calculateVersion with no identifiers should leave version uninitialized")
+        public void testCalculateVersionNone() {
+            ClickHouseStruct chStruct = new ClickHouseStruct();
+            chStruct.calculateVersion(false);
+            Assert.assertEquals(-1L, chStruct.getVersion());
+        }
+    }
+
+    @Nested
+    @DisplayName("Replication lag")
+    class ReplicationLagTests {
+
+        @Test
+        @DisplayName("getReplicationLag with ts_ms=0 should return 0")
+        public void testReplicationLagZero() {
+            ClickHouseStruct chStruct = new ClickHouseStruct();
+            Assert.assertEquals(0L, chStruct.getReplicationLag());
+        }
+
+        @Test
+        @DisplayName("getReplicationLag with valid ts_ms should return positive value")
+        public void testReplicationLagPositive() {
+            ClickHouseStruct chStruct = new ClickHouseStruct();
+            chStruct.setTs_ms(System.currentTimeMillis() - 5000);
+            long lag = chStruct.getReplicationLag();
+            Assert.assertTrue("Replication lag should be >= 4000ms", lag >= 4000);
+            Assert.assertTrue("Replication lag should be < 10000ms", lag < 10000);
         }
     }
 }

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/model/RoutedBatchTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/model/RoutedBatchTest.java
@@ -1,215 +1,101 @@
 package com.altinity.clickhouse.sink.connector.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Unit tests for RoutedBatch hash-based routing logic.
+ * Tests for {@link RoutedBatch} utility methods.
  */
 public class RoutedBatchTest {
 
     @Test
-    public void testCalculateThreadIdIsConsistent() {
-        String tableName = "test_table";
-        int threadPoolSize = 4;
-        
-        int threadId1 = RoutedBatch.calculateThreadId(tableName, threadPoolSize);
-        int threadId2 = RoutedBatch.calculateThreadId(tableName, threadPoolSize);
-        
-        // Same table should always map to same thread
-        Assert.assertEquals(threadId1, threadId2);
-    }
-
-    @Test
-    public void testCalculateThreadIdIsWithinRange() {
-        String tableName = "users";
-        int threadPoolSize = 5;
-        
-        int threadId = RoutedBatch.calculateThreadId(tableName, threadPoolSize);
-        
-        // Thread ID should be within valid range
-        Assert.assertTrue(threadId >= 0);
-        Assert.assertTrue(threadId < threadPoolSize);
-    }
-
-    @Test
-    public void testCalculateThreadIdDistributesTables() {
-        int threadPoolSize = 3;
-        String[] tables = {"users", "orders", "products", "inventory", "payments"};
-        
-        Map<Integer, Integer> threadDistribution = new HashMap<>();
-        
-        for (String table : tables) {
-            int threadId = RoutedBatch.calculateThreadId(table, threadPoolSize);
-            threadDistribution.put(threadId, threadDistribution.getOrDefault(threadId, 0) + 1);
-        }
-        
-        // All threads should be assigned at least one table
-        // (This might fail with very few tables, but should work with 5+ tables)
-        Assert.assertTrue("All threads should be used", threadDistribution.size() > 0);
-        
-        // No thread should have all the tables
-        for (int count : threadDistribution.values()) {
-            Assert.assertTrue("Distribution should be somewhat even", count < tables.length);
+    @DisplayName("calculateThreadId should never return negative (Integer.MIN_VALUE hash)")
+    public void testCalculateThreadIdNoNegative() {
+        // Find a string whose hashCode is Integer.MIN_VALUE
+        // "polygenelubricants" is a known string with hashCode == Integer.MIN_VALUE
+        // But we can also construct a test by using the actual logic
+        // The key property: (hashCode & 0x7FFFFFFF) % N >= 0 for all inputs
+        for (int poolSize = 1; poolSize <= 16; poolSize++) {
+            for (String name : new String[]{"test", "", "a", "ab", "abc", "server1.db.table"}) {
+                int result = RoutedBatch.calculateThreadId(name, poolSize);
+                assertTrue(result >= 0,
+                        "Thread ID must be non-negative for '" + name + "' with pool size " + poolSize);
+                assertTrue(result < poolSize,
+                        "Thread ID must be < pool size for '" + name + "' with pool size " + poolSize);
+            }
         }
     }
 
     @Test
-    public void testExtractTableNameFromTopic() {
-        String topic = "server5432.mydb.users";
-        String tableName = RoutedBatch.extractTableName(topic);
-        
-        Assert.assertEquals("users", tableName);
+    @DisplayName("calculateThreadId with null returns 0")
+    public void testCalculateThreadIdNull() {
+        assertEquals(0, RoutedBatch.calculateThreadId(null, 10),
+                "null table name should return thread 0");
     }
 
     @Test
-    public void testExtractTableNameFromInvalidTopic() {
-        String topic = "invalidformat";
-        String tableName = RoutedBatch.extractTableName(topic);
-        
-        // Should return the whole topic as fallback
-        Assert.assertEquals("invalidformat", tableName);
+    @DisplayName("calculateThreadId with zero pool size returns 0")
+    public void testCalculateThreadIdZeroPoolSize() {
+        assertEquals(0, RoutedBatch.calculateThreadId("test", 0),
+                "zero pool size should return thread 0");
     }
 
     @Test
-    public void testExtractTableNameFromEmptyTopic() {
-        String topic = "";
-        String tableName = RoutedBatch.extractTableName(topic);
-        
-        Assert.assertEquals("", tableName);
+    @DisplayName("calculateThreadId with negative pool size returns 0")
+    public void testCalculateThreadIdNegativePoolSize() {
+        assertEquals(0, RoutedBatch.calculateThreadId("test", -1),
+                "negative pool size should return thread 0");
     }
 
     @Test
-    public void testExtractTableNameFromNullTopic() {
-        String topic = null;
-        String tableName = RoutedBatch.extractTableName(topic);
-        
-        Assert.assertEquals("", tableName);
-    }
-
-    @Test
-    public void testCreateRoutingKey() {
-        String topic = "server5432.mydb.users";
-        String routingKey = RoutedBatch.createRoutingKey(topic);
-        
-        // Should be database.table
-        Assert.assertEquals("mydb.users", routingKey);
-    }
-
-    @Test
-    public void testCreateRoutingKeyWithInvalidTopic() {
-        String topic = "invalid";
-        String routingKey = RoutedBatch.createRoutingKey(topic);
-        
-        // Should return the whole topic as fallback
-        Assert.assertEquals("invalid", routingKey);
-    }
-
-    @Test
-    public void testDifferentDatabasesSameTableGetDifferentRouting() {
-        String topic1 = "server.db1.users";
-        String topic2 = "server.db2.users";
-        
-        String routingKey1 = RoutedBatch.createRoutingKey(topic1);
-        String routingKey2 = RoutedBatch.createRoutingKey(topic2);
-        
-        // Different databases should have different routing keys
-        Assert.assertNotEquals(routingKey1, routingKey2);
-        Assert.assertEquals("db1.users", routingKey1);
-        Assert.assertEquals("db2.users", routingKey2);
-    }
-
-    @Test
-    public void testSameTableAlwaysRoutesToSameThread() {
-        int threadPoolSize = 5;
-        String table = "orders";
-        
-        // Calculate thread ID multiple times
-        List<Integer> threadIds = new ArrayList<>();
+    @DisplayName("Same table name always routes to same thread (consistency)")
+    public void testCalculateThreadIdConsistency() {
+        String tableName = "my_database.my_table";
+        int poolSize = 8;
+        int expected = RoutedBatch.calculateThreadId(tableName, poolSize);
         for (int i = 0; i < 100; i++) {
-            threadIds.add(RoutedBatch.calculateThreadId(table, threadPoolSize));
-        }
-        
-        // All should be the same
-        int firstThreadId = threadIds.get(0);
-        for (int threadId : threadIds) {
-            Assert.assertEquals(firstThreadId, threadId);
+            assertEquals(expected, RoutedBatch.calculateThreadId(tableName, poolSize),
+                    "Same input must always produce same thread ID");
         }
     }
 
     @Test
-    public void testRoutedBatchConstruction() {
-        List<ClickHouseStruct> batch = new ArrayList<>();
-        batch.add(new ClickHouseStruct());
-        
-        int threadId = 2;
-        String tableName = "users";
-        
-        RoutedBatch routedBatch = new RoutedBatch(batch, threadId, tableName);
-        
-        Assert.assertEquals(batch, routedBatch.getBatch());
-        Assert.assertEquals(threadId, routedBatch.getAssignedThreadId());
-        Assert.assertEquals(tableName, routedBatch.getTableName());
+    @DisplayName("extractTableName parses server.database.table format")
+    public void testExtractTableNameStandard() {
+        assertEquals("orders", RoutedBatch.extractTableName("myserver.mydb.orders"));
     }
 
     @Test
-    public void testHashingDistributionIsReasonable() {
-        int threadPoolSize = 4;
-        int numTables = 100;
-        
-        Map<Integer, Integer> distribution = new HashMap<>();
-        
-        // Generate many table names and see how they distribute
-        for (int i = 0; i < numTables; i++) {
-            String tableName = "table_" + i;
-            int threadId = RoutedBatch.calculateThreadId(tableName, threadPoolSize);
-            distribution.put(threadId, distribution.getOrDefault(threadId, 0) + 1);
-        }
-        
-        // With 100 tables and 4 threads, each should get roughly 25 tables
-        // Allow some variance (between 15 and 35)
-        Assert.assertEquals("All threads should be assigned tables", threadPoolSize, distribution.size());
-        
-        for (Map.Entry<Integer, Integer> entry : distribution.entrySet()) {
-            int count = entry.getValue();
-            Assert.assertTrue("Thread " + entry.getKey() + " should have reasonable load: " + count, 
-                    count >= 15 && count <= 35);
-        }
+    @DisplayName("extractTableName returns full topic for non-standard format")
+    public void testExtractTableNameFallback() {
+        assertEquals("simple_topic", RoutedBatch.extractTableName("simple_topic"));
     }
 
     @Test
-    public void testZeroThreadPoolSize() {
-        String tableName = "users";
-        int threadPoolSize = 0;
-        
-        // Should not crash, should return 0
-        int threadId = RoutedBatch.calculateThreadId(tableName, threadPoolSize);
-        Assert.assertEquals(0, threadId);
+    @DisplayName("extractTableName handles null/empty")
+    public void testExtractTableNameNullEmpty() {
+        assertEquals("", RoutedBatch.extractTableName(null));
+        assertEquals("", RoutedBatch.extractTableName(""));
     }
 
     @Test
-    public void testNegativeThreadPoolSize() {
-        String tableName = "users";
-        int threadPoolSize = -1;
-        
-        // Should not crash, should return 0
-        int threadId = RoutedBatch.calculateThreadId(tableName, threadPoolSize);
-        Assert.assertEquals(0, threadId);
+    @DisplayName("createRoutingKey returns database.table from server.database.table")
+    public void testCreateRoutingKeyStandard() {
+        assertEquals("mydb.orders", RoutedBatch.createRoutingKey("myserver.mydb.orders"));
     }
 
     @Test
-    public void testNullTableName() {
-        String tableName = null;
-        int threadPoolSize = 4;
-        
-        // Should not crash, should return 0
-        int threadId = RoutedBatch.calculateThreadId(tableName, threadPoolSize);
-        Assert.assertEquals(0, threadId);
+    @DisplayName("createRoutingKey returns full topic for non-standard format")
+    public void testCreateRoutingKeyFallback() {
+        assertEquals("simple_topic", RoutedBatch.createRoutingKey("simple_topic"));
+    }
+
+    @Test
+    @DisplayName("createRoutingKey handles null/empty")
+    public void testCreateRoutingKeyNullEmpty() {
+        assertEquals("", RoutedBatch.createRoutingKey(null));
+        assertEquals("", RoutedBatch.createRoutingKey(""));
     }
 }
-

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/model/VersionCompatibilityTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/model/VersionCompatibilityTest.java
@@ -1,0 +1,377 @@
+package com.altinity.clickhouse.sink.connector.model;
+
+import com.altinity.clickhouse.sink.connector.common.SnowFlakeId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Backward- and forward-compatibility contract tests for the
+ * ReplacingMergeTree {@code _version} column.
+ *
+ * <p>{@code _version} is the single value that decides which physical row
+ * survives a ReplacingMergeTree merge. Any change to how it is produced is
+ * therefore an <em>irreversible data-format change</em>: rows already written
+ * by an older connector build stay in the table forever and continue to
+ * compete against rows written by a newer build, so a downgrade cannot undo
+ * them. These tests pin the properties the format must keep, so a scheme
+ * change that would break a live table fails here rather than in production.</p>
+ *
+ * <p>They are written against the version sources {@code calculateVersion()}
+ * actually consults - GTID (optionally via snowflake), sequence number, LSN -
+ * and against {@code addVersion()}'s {@code ts_ms * 1_000_000 + counter}
+ * sequence encoding.</p>
+ *
+ * <p>The four properties pinned:</p>
+ * <ol>
+ *   <li><b>Redelivery stability</b> (backward): the same source event replayed
+ *       after an offset rewind must produce the <em>same</em> version, or a
+ *       replayed DELETE outranks the later re-INSERT and the row is left
+ *       {@code is_deleted=1}. This is issue #1346, which is still open.</li>
+ *   <li><b>Commit ordering</b> (backward): a later source commit must produce a
+ *       strictly greater version than an earlier one.</li>
+ *   <li><b>Uniqueness</b> (forward): two distinct events must never share a
+ *       version, or RMT silently discards one of them.</li>
+ *   <li><b>Sentinel and sign safety</b> (forward): no produced value may
+ *       collide with the {@code -1} uninitialized sentinel, and ordering must
+ *       remain valid under the {@code UInt64} semantics ClickHouse applies.</li>
+ * </ol>
+ */
+public class VersionCompatibilityTest {
+
+    /** 2024-01-01T00:00:00Z, a fixed source commit clock for determinism. */
+    private static final long TS_2024 = 1704067200000L;
+
+    /** Mirrors the {@code ts_ms * 1_000_000 + counter} encoding in addVersion(). */
+    private static final long SEQUENCE_SCALE = 1_000_000L;
+
+    private static long sequenceVersion(long tsMs, long counter) {
+        ClickHouseStruct record = new ClickHouseStruct();
+        record.setTs_ms(tsMs);
+        record.setSequenceNumber(tsMs * SEQUENCE_SCALE + counter);
+        record.calculateVersion(false);
+        return record.getVersion();
+    }
+
+    private static long gtidVersion(long gtid) {
+        ClickHouseStruct record = new ClickHouseStruct();
+        record.setGtid(gtid);
+        record.calculateVersion(false);
+        return record.getVersion();
+    }
+
+    private static long snowflakeVersion(long tsMs, long gtid) {
+        ClickHouseStruct record = new ClickHouseStruct();
+        record.setTs_ms(tsMs);
+        record.setGtid(gtid);
+        record.calculateVersion(true);
+        return record.getVersion();
+    }
+
+    @Nested
+    @DisplayName("Backward compatibility: a replayed event keeps its version")
+    class RedeliveryStability {
+
+        /**
+         * After an offset rewind Debezium re-emits events that were already
+         * applied. If the version is derived from anything that changes
+         * between deliveries (wall clock, a fresh counter, a random value),
+         * the replayed copy gets a different - typically higher - version. A
+         * replayed DELETE then outranks the re-INSERT that followed it and the
+         * row disappears. This is the mechanism behind issue #1346.
+         */
+        @Test
+        @DisplayName("the same sequence-numbered event replayed keeps its version")
+        public void replayedSequenceEventKeepsVersion() {
+            assertEquals(sequenceVersion(TS_2024, 7L), sequenceVersion(TS_2024, 7L),
+                    "a re-delivered event must produce the same _version; an unstable "
+                            + "version lets a replayed DELETE outrank the re-INSERT");
+        }
+
+        @Test
+        @DisplayName("the same GTID event replayed keeps its version")
+        public void replayedGtidEventKeepsVersion() {
+            assertEquals(gtidVersion(918273645L), gtidVersion(918273645L),
+                    "a GTID version must be a pure function of the GTID");
+        }
+
+        @Test
+        @DisplayName("the same snowflake event replayed keeps its version")
+        public void replayedSnowflakeEventKeepsVersion() {
+            assertEquals(snowflakeVersion(TS_2024, 4242L), snowflakeVersion(TS_2024, 4242L),
+                    "a snowflake version must be a pure function of (ts_ms, gtid); if it "
+                            + "drew on the processing clock, redelivery would not be stable");
+        }
+
+        /**
+         * The DELETE / re-INSERT sequence from issue #1346, end to end: the
+         * DELETE is replayed after the INSERT that followed it. The INSERT
+         * must still win, or the row stays deleted.
+         */
+        @Test
+        @DisplayName("a replayed DELETE never outranks the later re-INSERT")
+        public void replayedDeleteDoesNotOutrankReinsert() {
+            long deleteVersion = sequenceVersion(TS_2024, 1L);
+            long reinsertVersion = sequenceVersion(TS_2024 + 2000L, 1L);
+            long deleteReplayVersion = sequenceVersion(TS_2024, 1L);
+
+            assertTrue(reinsertVersion > deleteVersion,
+                    "the later re-INSERT must outrank the original DELETE");
+            assertTrue(reinsertVersion > deleteReplayVersion,
+                    "the later re-INSERT must still outrank the REPLAYED DELETE; otherwise "
+                            + "the row stays is_deleted=1 after an offset rewind (issue #1346)");
+        }
+    }
+
+    @Nested
+    @DisplayName("Backward compatibility: commit order is preserved")
+    class CommitOrdering {
+
+        @Test
+        @DisplayName("a later source timestamp always outranks an earlier one")
+        public void laterSourceTimestampWins() {
+            assertTrue(sequenceVersion(TS_2024 + 1000L, 1L) > sequenceVersion(TS_2024, 999L),
+                    "the source timestamp must dominate the counter, so a later commit wins "
+                            + "even when the counter has been reset to a low value");
+        }
+
+        /**
+         * Within one timestamp, ordering falls back to the counter, so two
+         * changes to the same row inside one millisecond still merge in order.
+         */
+        @Test
+        @DisplayName("within one timestamp, the higher counter wins")
+        public void higherCounterWinsWithinSameTimestamp() {
+            assertTrue(sequenceVersion(TS_2024, 2L) > sequenceVersion(TS_2024, 1L),
+                    "within one source timestamp the later counter value must win");
+        }
+
+        /**
+         * The counter resets when the source clock advances past the anchor.
+         * Because the timestamp occupies the high-order part of the encoding,
+         * the reset cannot make a newer event lose to an older one.
+         */
+        @Test
+        @DisplayName("a counter reset on a clock advance does not invert ordering")
+        public void counterResetDoesNotInvertOrdering() {
+            long beforeReset = sequenceVersion(TS_2024, 999_999L);
+            long afterReset = sequenceVersion(TS_2024 + 2000L, 1L);
+            assertTrue(afterReset > beforeReset,
+                    "an event after a counter reset must still outrank the one before it; "
+                            + "otherwise every batch crossing a time gap loses to its "
+                            + "predecessor and the RMT keeps the stale row");
+        }
+
+        @Test
+        @DisplayName("GTID versions preserve transaction order")
+        public void gtidVersionsPreserveTransactionOrder() {
+            assertTrue(gtidVersion(1002L) > gtidVersion(1001L),
+                    "a later transaction must outrank an earlier one");
+        }
+    }
+
+    @Nested
+    @DisplayName("Forward compatibility: distinct events get distinct versions")
+    class Uniqueness {
+
+        @Test
+        @DisplayName("distinct counters within one timestamp are distinct versions")
+        public void distinctCountersAreDistinctVersions() {
+            Set<Long> versions = new HashSet<>();
+            for (long counter = 1; counter <= 512; counter++) {
+                versions.add(sequenceVersion(TS_2024, counter));
+            }
+            assertEquals(512, versions.size(),
+                    "every distinct counter within one timestamp must map to a distinct "
+                            + "_version; a collision makes RMT silently drop a row");
+        }
+
+        @Test
+        @DisplayName("distinct timestamps with an identical counter are distinct versions")
+        public void distinctTimestampsAreDistinctVersions() {
+            Set<Long> versions = new HashSet<>();
+            for (int millis = 0; millis < 512; millis++) {
+                versions.add(sequenceVersion(TS_2024 + millis, 1L));
+            }
+            assertEquals(512, versions.size(),
+                    "every distinct source timestamp must map to a distinct _version");
+        }
+
+        /**
+         * The counter occupies the low {@code 1_000_000} of the encoding. A
+         * counter that ran past that bound would carry into the timestamp
+         * component and collide with the next millisecond's versions.
+         */
+        @Test
+        @DisplayName("the counter cannot carry into the timestamp component")
+        public void counterDoesNotCarryIntoTimestamp() {
+            long lastOfMillisecond = sequenceVersion(TS_2024, SEQUENCE_SCALE - 1);
+            long firstOfNextMillisecond = sequenceVersion(TS_2024 + 1, 1L);
+            assertTrue(firstOfNextMillisecond > lastOfMillisecond,
+                    "the counter must stay below " + SEQUENCE_SCALE + " per millisecond; "
+                            + "a carry would collide with the next millisecond's versions");
+        }
+
+        /**
+         * Snowflake packs the timestamp and the GTID transaction id into one
+         * long. Two different transactions in the same millisecond must not
+         * collapse onto the same value.
+         */
+        @Test
+        @DisplayName("snowflake ids for distinct gtids in one millisecond are distinct")
+        public void snowflakeDistinctForDistinctGtidsInSameMillisecond() {
+            Set<Long> ids = new HashSet<>();
+            for (long gtid = 1; gtid <= 1024; gtid++) {
+                ids.add(SnowFlakeId.generate(TS_2024, gtid, false));
+            }
+            assertEquals(1024, ids.size(),
+                    "distinct GTIDs within one millisecond must produce distinct snowflake ids");
+        }
+    }
+
+    @Nested
+    @DisplayName("Forward compatibility: sentinel and sign safety")
+    class SentinelAndSignSafety {
+
+        /**
+         * Every value the version scheme can produce must be distinguishable
+         * from the {@code -1} uninitialized sentinel. Read as {@code UInt64},
+         * -1 is 18446744073709551615 - the maximum representable version, so a
+         * row carrying it can never be superseded: the ReplacingMergeTree
+         * freezes on it and every later update and delete for that key is
+         * silently discarded on merge.
+         */
+        @Test
+        @DisplayName("no calculable version collides with the -1 uninitialized sentinel")
+        public void calculatedVersionNeverEqualsSentinel() {
+            List<Long> probes = new ArrayList<>();
+            probes.add(sequenceVersion(1L, 1L));                      // epoch + 1ms
+            probes.add(sequenceVersion(TS_2024, 1L));                 // present day
+            probes.add(sequenceVersion(TS_2024, SEQUENCE_SCALE - 1)); // counter at its bound
+            probes.add(gtidVersion(1L));
+            probes.add(gtidVersion(Long.MAX_VALUE - 1));
+            probes.add(snowflakeVersion(TS_2024, 1L));
+            for (long version : probes) {
+                assertNotEquals(-1L, version,
+                        "a calculated _version must never equal the -1 sentinel, which "
+                                + "ClickHouse stores as UInt64 max and can never be superseded");
+            }
+        }
+
+        /**
+         * ClickHouse declares {@code _version} as {@code UInt64}, and the
+         * connector binds it with {@code PreparedStatement.setLong}, so the
+         * driver reinterprets the 64 bits unsigned. Any Java-side ordering
+         * therefore has to use {@link Long#compareUnsigned}, not {@code >}.
+         *
+         * <p>The {@code ts_ms * 1_000_000} encoding crosses
+         * {@code Long.MAX_VALUE} in the year 2262, at which point the Java
+         * long goes negative while the stored {@code UInt64} keeps increasing
+         * correctly. Verified against a live ClickHouse:
+         * {@code reinterpretAsUInt64(toInt64(-1))} = 18446744073709551615, so
+         * a negative long is read as a very large unsigned value.</p>
+         */
+        @Test
+        @DisplayName("ordering holds under unsigned comparison even when the sign bit flips")
+        public void orderingHoldsUnderUnsignedComparison() {
+            long nearMax = Long.MAX_VALUE - 10L;
+            long pastMax = nearMax + 20L; // wraps to negative as a signed long
+
+            assertTrue(pastMax < 0,
+                    "precondition: the probe value must have wrapped the sign bit");
+            assertTrue(Long.compareUnsigned(pastMax, nearMax) > 0,
+                    "_version is UInt64 in ClickHouse, so ordering across the sign-bit "
+                            + "boundary must hold under unsigned comparison - no Java-side "
+                            + "code may order versions with a signed comparison");
+        }
+
+        @Test
+        @DisplayName("present-day versions stay positive and well below the sign bit")
+        public void presentDayVersionsStayPositive() {
+            long version = sequenceVersion(TS_2024, 1L);
+            assertTrue(version > 0,
+                    "a present-day _version must be positive: " + version);
+            assertTrue(version < Long.MAX_VALUE / 2,
+                    "a present-day _version must leave headroom below the sign bit so that "
+                            + "the encoding cannot wrap within the supported clock range; got "
+                            + version);
+        }
+
+        @Test
+        @DisplayName("consecutive events are strictly ordered")
+        public void consecutiveEventsAreStrictlyOrdered() {
+            long earlier = sequenceVersion(TS_2024, 1L);
+            long later = sequenceVersion(TS_2024, 2L);
+            assertNotEquals(earlier, later);
+            assertTrue(later > earlier, "consecutive counters must be strictly ordered");
+        }
+    }
+
+    @Nested
+    @DisplayName("Backward compatibility: version-source precedence")
+    class VersionSourcePrecedence {
+
+        /**
+         * {@code calculateVersion()} consults GTID, then sequence number, then
+         * LSN. The order is part of the data format: a build that resolved a
+         * record's version from a different source than the build before it
+         * would produce values in a different range for the same row, and the
+         * two would compete inside the same ReplacingMergeTree.
+         */
+        @Test
+        @DisplayName("GTID takes precedence over sequence number and LSN")
+        public void gtidWinsOverSequenceAndLsn() {
+            ClickHouseStruct record = new ClickHouseStruct();
+            record.setGtid(11L);
+            record.setSequenceNumber(22L);
+            record.setLsn(33L);
+            record.calculateVersion(false);
+            assertEquals(11L, record.getVersion(),
+                    "GTID must win; changing the precedence changes the value range for "
+                            + "the same row and is an irreversible format change");
+        }
+
+        @Test
+        @DisplayName("sequence number takes precedence over LSN")
+        public void sequenceWinsOverLsn() {
+            ClickHouseStruct record = new ClickHouseStruct();
+            record.setSequenceNumber(22L);
+            record.setLsn(33L);
+            record.calculateVersion(false);
+            assertEquals(22L, record.getVersion(), "sequence number must win over LSN");
+        }
+
+        @Test
+        @DisplayName("LSN is used when it is the only source available")
+        public void lsnUsedWhenOnlySource() {
+            ClickHouseStruct record = new ClickHouseStruct();
+            record.setLsn(33L);
+            record.calculateVersion(false);
+            assertEquals(33L, record.getVersion(), "LSN must be used for Postgres sources");
+        }
+
+        /**
+         * With no source at all the sentinel must survive untouched, so the
+         * bind-site guard can detect it. Silently substituting a value here
+         * would hide the condition and write an unorderable row.
+         */
+        @Test
+        @DisplayName("with no version source the sentinel is left in place for the guard")
+        public void noSourceLeavesSentinel() {
+            ClickHouseStruct record = new ClickHouseStruct();
+            record.calculateVersion(false);
+            assertEquals(-1L, record.getVersion(),
+                    "the sentinel must survive so the bind-site guard can reject the record "
+                            + "rather than write UInt64 max into the table");
+        }
+    }
+}


### PR DESCRIPTION
- ClickHouseStruct: defensive null handling in Kafka-metadata extraction, accessor cleanup. BlockMetaData exposes min/max source timestamps and record counts for observability.
- VersionCompatibilityTest (new): pins the on-the-wire _version semantics to the 2.8.0 format - debezium_ts_ms * 1_000_000 + counter with diff > 1 reset - so a drop-in upgrade cannot silently change which row survives a ReplacingMergeTree merge.
- RoutedBatchTest rewritten against real behavior.

Part of the split of #1353 into independently mergeable sub-PRs (each <= 10 files), so the 2.10.0 branch can absorb the fixes incrementally.

Split out of #1353, which this series replaces. Each sub-PR is <= 10 files; the union of all 22 reproduces the #1353 tree exactly (verified by tree SHA).