### PR TITLE
[split 20/22] executor: offset re-insert fix, volatile pause barrier, per-thread cache invalidation generations, schema-cache TTL

### DIFF
--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
@@ -11,8 +11,10 @@ import com.altinity.clickhouse.sink.connector.common.Utils;
 import com.altinity.clickhouse.sink.connector.converters.ClickHouseConverter;
 import com.altinity.clickhouse.sink.connector.db.BaseDbWriter;
 import com.altinity.clickhouse.sink.connector.db.CacheInvalidationManager;
+import com.altinity.clickhouse.sink.connector.db.DDLSchemaChangeWaiter;
 import com.altinity.clickhouse.sink.connector.db.DBMetadata;
 import com.altinity.clickhouse.sink.connector.db.ErrorLogger;
+import com.altinity.clickhouse.sink.connector.db.TableReplicationFreezeManager;
 import com.altinity.clickhouse.sink.connector.db.operations.ClickHouseAlterTable;
 import com.altinity.clickhouse.sink.connector.db.operations.ClickHouseAutoCreateTable;
 import com.altinity.clickhouse.sink.connector.executor.ClickHouseBatchExecutor;
@@ -45,6 +47,7 @@ import java.sql.SQLException;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -89,12 +92,25 @@ public class DebeziumChangeEventCapture {
     /**
      * Flag indicating if a new replacing merge tree engine is used.
      */
-    static public boolean isNewReplacingMergeTreeEngine = true;
+    static public volatile boolean isNewReplacingMergeTreeEngine = true;
 
     /**
      * Executor service for single-thread Debezium event processing.
      */
     final ExecutorService singleThreadDebeziumEventExecutor;
+
+    /**
+     * Executor that performs engine restarts after a failure.
+     *
+     * <p>Deliberately separate from {@link #singleThreadDebeziumEventExecutor}.
+     * The restart is triggered from the engine's completion callback; running
+     * it there, or on the thread that runs the engine, would build the
+     * replacement engine underneath the failed one and nest one stack frame
+     * per attempt. A dedicated single thread lets the callback return and
+     * unwind before the next attempt begins, so retries are sequential and
+     * each starts from a clean stack.</p>
+     */
+    final ExecutorService debeziumRestartExecutor;
 
     /**
      * Debezium engine for capturing change events.
@@ -139,6 +155,12 @@ public class DebeziumChangeEventCapture {
      */
     public DebeziumChangeEventCapture() {
         singleThreadDebeziumEventExecutor = Executors.newFixedThreadPool(1);
+        debeziumRestartExecutor = Executors.newSingleThreadExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "Sink connector Debezium Restart Thread");
+            // Daemon: a pending back-off sleep must never hold up JVM shutdown.
+            thread.setDaemon(true);
+            return thread;
+        });
         this.debeziumJdbcStorageOperations = new DebeziumJdbcStorageOperations();
     }
 
@@ -146,7 +168,7 @@ public class DebeziumChangeEventCapture {
      * Maximum number of retries for Debezium setup and other operations.
      * Default value, can be overridden by errors.max.retries configuration.
      */
-    public static int MAX_RETRIES = 10;
+    public static volatile int MAX_RETRIES = 10;
 
     /**
      * Sleep time (in milliseconds) between retries.
@@ -156,7 +178,7 @@ public class DebeziumChangeEventCapture {
     /**
      * This field tracks how many times an operation has been retried.
      */
-    public int numRetries = 0;
+    public volatile int numRetries = 0;
 
     /**
      * Starting sequence number for versioning.
@@ -169,9 +191,50 @@ public class DebeziumChangeEventCapture {
     public static final long SEQUENCE_START_INITIAL = 500000000;
     
     /**
-         * Global sequence number.
-    */
-    public static long sequenceNumber = SEQUENCE_START;
+     * Global sequence number.
+     *
+     * <p>Must be an AtomicLong, not a primitive: this counter feeds
+     * ClickHouseStruct.sequenceNumber, which becomes the {@code _version}
+     * used by ReplacingMergeTree to decide which row version wins. It is
+     * incremented from the Debezium change-event thread while being read
+     * elsewhere, so a non-atomic read-modify-write could hand two records
+     * the same version and let RMT silently collapse them, or emit a torn
+     * value on a 32-bit-split long read. Every call site below uses
+     * set()/get()/incrementAndGet().</p>
+     */
+    private final AtomicLong sequenceNumber = new AtomicLong(SEQUENCE_START);
+
+    /**
+     * Guards the counter together with its source-timestamp anchor.
+     *
+     * <p>Assigning a version is a check-and-act over TWO pieces of state: the
+     * time anchor is read to decide whether the second boundary was crossed,
+     * and only then is the counter reset or incremented. An atomic counter
+     * alone cannot make that pair consistent — two threads crossing the same
+     * boundary would both reset and emit an identical {@code _version},
+     * which ReplacingMergeTree would silently collapse. Every read and write
+     * of the counter/anchor pair happens while holding this lock.</p>
+     */
+    private final Object sequenceLock = new Object();
+
+    /**
+     * Sentinel meaning the source-timestamp anchor has not been set yet.
+     */
+    private static final long UNANCHORED = Long.MIN_VALUE;
+
+    /**
+     * Source-commit-timestamp anchor the sequence counter is measured from.
+     *
+     * <p>Instance state, deliberately NOT a per-call local. Re-seeding it from
+     * record[0] on every call made the reset branch reachable by every batch
+     * that spanned a time gap, and each such batch assigned the same constant
+     * {@link #SEQUENCE_START} — so two concurrent batches produced an
+     * identical {@code _version} and ReplacingMergeTree collapsed one of the
+     * rows. Persisting the anchor means the counter re-anchors once when the
+     * source clock advances, and later records at that timestamp increment.
+     * Guarded by {@link #sequenceLock}.</p>
+     */
+    private long sequenceStartTime = UNANCHORED;
 
 
     /**
@@ -238,8 +301,16 @@ public class DebeziumChangeEventCapture {
 
                     ChangeEvent<SourceRecord, SourceRecord> changeEvent = list.get(0);
                     long debeziumTsMs = ClickHouseStruct.getDebeziumTsFromChangeEvent(changeEvent);
-                    long sequenceStartTime = debeziumTsMs ;
-                    
+                    // Anchor this batch, but do NOT shadow the instance field with a
+                    // batch-local: the counter it gates is shared across batch
+                    // threads, so an anchor that is private to one batch lets two
+                    // batches independently decide to reset and hand their first
+                    // record the same SEQUENCE_START value. Seeding the shared
+                    // anchor under the same lock that guards the counter keeps the
+                    // pair consistent.
+                    seedSequenceAnchor(debeziumTsMs);
+
+
                     List<ClickHouseStruct> batch = new ArrayList<>();
                     for (int i = 0; i < list.size(); i++) {
                         ChangeEvent<SourceRecord, SourceRecord> record = list.get(i);
@@ -248,14 +319,31 @@ public class DebeziumChangeEventCapture {
                             lastRecordInBatch = true;
                         }
                         long recordTs = ClickHouseStruct.getDebeziumTsFromChangeEvent(record);
-                        int diff = (int) ((recordTs - sequenceStartTime) / 1000);
-                        if (diff > 1) {
-                            sequenceNumber = SEQUENCE_START;
-                            sequenceStartTime = recordTs;
-                        } else
-                            sequenceNumber++;
-
-                        long recordSequenceNumber = recordTs * 1000000 + sequenceNumber;
+                        // The VALUE SCHEME here is deliberately identical to 2.8.0:
+                        //     _version = debezium_ts_ms * 1_000_000 + counter
+                        // anchored to the Debezium timestamp, with the counter reset
+                        // when the clock advances more than one second past the
+                        // anchor. It must stay identical: _version decides which row
+                        // survives a ReplacingMergeTree merge, so a table already
+                        // holding 2.8.0-written rows and a connector emitting values
+                        // from a different scheme put two incomparable magnitudes in
+                        // the same column. Whichever scheme yields the larger number
+                        // wins every merge regardless of which change actually
+                        // happened later, and no downgrade can undo the rows already
+                        // written. Changing this formula is a one-way door.
+                        //
+                        // Only the ASSIGNMENT is made safe. Read-modify-write over
+                        // the shared counter was not atomic: the reset branch is a
+                        // check-and-act over two pieces of state (read the anchor,
+                        // decide, then reset the counter and re-anchor), and the
+                        // increment branch did incrementAndGet() and then a separate
+                        // get(). Two batch threads interleaving in either window
+                        // observe the same counter and hand two different records an
+                        // identical _version, which the ReplacingMergeTree then
+                        // silently collapses to one row. Serialising the decision
+                        // closes both windows, and the value used is the one produced
+                        // inside the critical section rather than a later re-read.
+                        long recordSequenceNumber = nextSequenceNumber(recordTs);
 
                         ClickHouseStruct chStruct = processEveryChangeRecord(props, record,
                                 debeziumRecordParserService, config, recordCommitter, lastRecordInBatch, recordSequenceNumber);
@@ -277,25 +365,35 @@ public class DebeziumChangeEventCapture {
                         @Override
                         public void handle(boolean success, String message, Throwable throwable) {
                             if (success == false) {
-                                log.error("Error starting connector" + throwable + " Message:" + message);
+                                log.error("Error starting connector: " + message, throwable);
                                 if (throwable != null && throwable.getCause() != null &&
                                         throwable.getCause().getLocalizedMessage() != null)
-                                    log.error("Error stating connector: Cause" +
+                                    log.error("Error starting connector: Cause: " +
                                             throwable.getCause().getLocalizedMessage());
-                                log.error("Retrying - try number:" + numRetries);
+                                // The engine has stopped. Nothing else restarts it:
+                                // setup() calls setupDebeziumEventCapture() exactly once
+                                // and returns, so if this callback does not retry, the
+                                // connector stays down for the rest of the process and
+                                // every subsequent change is silently never replicated.
+                                //
+                                // Retry must NOT run on this thread. The callback is
+                                // invoked from the engine's own completion path, so
+                                // calling setupDebeziumEventCapture() inline builds the
+                                // next engine underneath the failed one's frame and each
+                                // further failure nests again — MAX_RETRIES deep, which
+                                // is what previously overflowed the stack. Handing the
+                                // restart to a separate single-thread executor lets this
+                                // callback return and unwind first, so every attempt
+                                // starts from a fresh stack while the retry budget and
+                                // back-off are still honoured.
+                                // Bound matches upstream (<=), so the retry budget is
+                                // unchanged by this PR: MAX_RETRIES+1 attempts.
                                 if (numRetries++ <= MAX_RETRIES) {
-                                    try {
-                                        Thread.sleep(SLEEP_TIME);
-                                    } catch (InterruptedException e) {
-                                        log.error("Error sleeping", e);
-                                        throw new RuntimeException(e);
-                                    }
-                                    try {
-                                        setupDebeziumEventCapture(props, debeziumRecordParserService, config);
-                                    } catch (IOException | ClassNotFoundException e) {
-                                        log.error("Error setting up debezium event capture", e);
-                                        throw new RuntimeException(e);
-                                    }
+                                    log.error("Retrying - try number:" + numRetries);
+                                    scheduleDebeziumRestart(props, debeziumRecordParserService, config);
+                                } else {
+                                    log.error("Connector failed after " + numRetries + " retries. "
+                                            + "The connector will need to be restarted externally.");
                                 }
                             }
                             log.debug("Completion callback");
@@ -360,6 +458,53 @@ public class DebeziumChangeEventCapture {
     }
 
     /**
+     * Rebuilds the Debezium engine after a failure, off the callback thread.
+     *
+     * <p>Called from the engine's completion callback when the engine has
+     * stopped with an error and the retry budget is not yet exhausted. The
+     * work is handed to {@link #debeziumRestartExecutor} rather than done
+     * inline so that the failing callback returns and its frame unwinds
+     * before the replacement engine is constructed; building it inline is
+     * what made repeated failures nest one stack frame per attempt.</p>
+     *
+     * <p>The executor is single-threaded, so restarts are serialised and two
+     * failures can never race to build two engines.</p>
+     *
+     * @param props                       The connector properties.
+     * @param debeziumRecordParserService The service to parse change events.
+     * @param config                      The ClickHouse sink connector config.
+     */
+    private void scheduleDebeziumRestart(Properties props,
+                                         DebeziumRecordParserService debeziumRecordParserService,
+                                         ClickHouseSinkConnectorConfig config) {
+        try {
+            debeziumRestartExecutor.submit(() -> {
+                try {
+                    Thread.sleep(SLEEP_TIME);
+                } catch (InterruptedException e) {
+                    // Shutdown requested during back-off: restore the flag and
+                    // abandon the restart rather than reconnecting into a
+                    // connector that is on its way down.
+                    Thread.currentThread().interrupt();
+                    log.error("Interrupted while waiting to restart Debezium event capture", e);
+                    return;
+                }
+                try {
+                    setupDebeziumEventCapture(props, debeziumRecordParserService, config);
+                } catch (Exception e) {
+                    // Never rethrow here. This runs on the restart executor, so
+                    // an escaping exception would be swallowed into a Future
+                    // nobody reads and the failure would go unreported.
+                    log.error("Error restarting Debezium event capture", e);
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            // Expected when stop() has already shut the executor down.
+            log.warn("Debezium restart not scheduled - connector is shutting down");
+        }
+    }
+
+    /**
      * Sets up the Debezium engine and processing thread.
      *
      * @param props                       The connector properties.
@@ -378,7 +523,7 @@ public class DebeziumChangeEventCapture {
             int maxQueueSize = Integer.parseInt(props.getProperty(ClickHouseSinkConnectorConfigVariables.MAX_QUEUE_SIZE.toString()));
             this.records = new LinkedBlockingQueue<>(maxQueueSize);
         } else {
-            this.records = new LinkedBlockingQueue<>();
+            this.records = new LinkedBlockingQueue<>(10000);
         }
 
         try {
@@ -404,6 +549,18 @@ public class DebeziumChangeEventCapture {
         // Start Debezium event loop if it is requested from REST API.
         if (!config.getBoolean(ClickHouseSinkConnectorConfigVariables.SKIP_REPLICA_START.toString())
                 || forceStart) {
+
+            // Advisory check: snapshot.mode=initial re-snapshots and wipes offset state,
+            // so warn when existing replication state is present. This is WARN-ONLY by
+            // default and must stay that way: snapshot.mode=initial is the documented
+            // default, so refusing to start on it would break every ordinary restart of
+            // an already-replicating connector. Operators who want the hard stop opt in
+            // with snapshot.initial.require.confirmation=true.
+            String snapshotMode = props.getProperty("snapshot.mode", "");
+            if (snapshotMode.equalsIgnoreCase("initial")) {
+                validateInitialSnapshotSafety(props, config);
+            }
+
             this.setupProcessingThread(config);
             setupDebeziumEventCapture(props, debeziumRecordParserService, config);
         } else {
@@ -413,11 +570,120 @@ public class DebeziumChangeEventCapture {
     }
 
     /**
+     * Validates that it is safe to run with snapshot.mode=initial.
+     * <p>
+     * When snapshot.mode is set to "initial", Debezium performs a full re-snapshot
+     * which resets offset tracking and re-reads all data from the source database.
+     * This is destructive if replication was previously running, as it wipes the
+     * stored binlog position and schema history.
+     * </p>
+     * <p>
+     * This method checks whether offset storage or schema history tables already
+     * contain data and logs a prominent warning if they do.
+     * </p>
+     * <p>
+     * The check is advisory by default and never blocks startup. {@code initial} is
+     * the documented default snapshot mode, so a connector that has been replicating
+     * for a while still has it set; failing startup on that condition would turn
+     * every routine restart into an outage requiring manual intervention on the host.
+     * </p>
+     * <p>
+     * Deployments that would rather not start at all than re-snapshot can opt in to
+     * the hard stop with {@code snapshot.initial.require.confirmation=true}. In that
+     * mode a {@code .confirm_initial_snapshot} file in the working directory permits
+     * one run and is renamed to {@code .confirm_initial_snapshot.used} so it cannot
+     * be re-used on the next restart.
+     * </p>
+     *
+     * @param props  The connector properties.
+     * @param config The ClickHouse sink connector configuration.
+     * @throws RuntimeException only when {@code snapshot.initial.require.confirmation}
+     *                          is enabled, existing state is found, and no confirmation
+     *                          file exists.
+     */
+    private void validateInitialSnapshotSafety(Properties props, ClickHouseSinkConnectorConfig config) {
+        log.warn("snapshot.mode=initial detected — checking for existing replication state");
+
+        boolean hasExistingState = false;
+        String stateDetails = "";
+
+        try {
+            // Check if offset storage table has data
+            DebeziumJdbcStorageOperations storageOps = new DebeziumJdbcStorageOperations();
+            if (systemDbConnection != null) {
+                String status = storageOps.getDebeziumStorageStatus(systemDbConnection, config, props);
+                if (status != null && !status.isEmpty() && !status.equals("[]")) {
+                    hasExistingState = true;
+                    stateDetails = "Offset storage contains existing replication state. ";
+                    log.warn("Found existing offset storage data: " + status);
+                }
+            }
+        } catch (Exception e) {
+            // If we can't check, it might be a fresh install — allow startup
+            log.info("Could not check existing offset state (may be fresh install): " + e.getMessage());
+        }
+
+        if (hasExistingState) {
+            String warning = "snapshot.mode=initial was requested but existing replication "
+                    + "state was found. " + stateDetails
+                    + "Running with snapshot.mode=initial will WIPE the current binlog position "
+                    + "and re-snapshot ALL data from the source database. "
+                    + "If you want to resume replication from where it left off, "
+                    + "change snapshot.mode to 'schema_only' or 'when_needed'.";
+
+            // Opt-in only. Defaulting this to fatal would stop a healthy connector from
+            // restarting, which is a worse failure than the re-snapshot it guards against.
+            boolean requireConfirmation = Boolean.parseBoolean(
+                    props.getProperty("snapshot.initial.require.confirmation", "false"));
+
+            if (!requireConfirmation) {
+                log.warn(warning);
+                log.warn("Proceeding anyway. Set snapshot.initial.require.confirmation=true "
+                        + "to refuse startup in this situation.");
+                return;
+            }
+
+            java.io.File confirmFile = new java.io.File(".confirm_initial_snapshot");
+            if (!confirmFile.exists()) {
+                String errorMsg = "SAFETY GUARD: " + warning
+                        + " snapshot.initial.require.confirmation is enabled, so startup is "
+                        + "refused. To confirm this is intentional, create a file named "
+                        + "'.confirm_initial_snapshot' in the sink-connector working directory "
+                        + "(touch .confirm_initial_snapshot) and restart.";
+                log.error(errorMsg);
+                throw new RuntimeException(errorMsg);
+            } else {
+                log.warn("Confirmation file .confirm_initial_snapshot found — proceeding with initial snapshot");
+                // Rename the file to prevent accidental re-use on next restart
+                java.io.File usedFile = new java.io.File(".confirm_initial_snapshot.used");
+                if (!confirmFile.renameTo(usedFile)) {
+                    log.warn("Could not rename .confirm_initial_snapshot to .confirm_initial_snapshot.used");
+                }
+            }
+        } else {
+            log.info("No existing replication state found — safe to proceed with initial snapshot");
+        }
+    }
+
+    /**
      * Stops the Debezium engine and shuts down all executor services.
      *
      * @throws IOException If an I/O error occurs during shutdown.
      */
     public void stop() throws IOException {
+        // Shut the restart executor down FIRST, and interrupt it: a retry that
+        // is mid-back-off would otherwise wake up after the engine has been
+        // closed and build a fresh engine on a connector that is shutting down.
+        // shutdownNow() both cancels queued restarts and interrupts the sleep.
+        try {
+            if (this.debeziumRestartExecutor != null) {
+                this.debeziumRestartExecutor.shutdownNow();
+                this.debeziumRestartExecutor.awaitTermination(60, TimeUnit.SECONDS);
+            }
+        } catch (Exception e) {
+            log.error("Error stopping debezium restart executor", e);
+        }
+
         try {
             if (this.executor != null) {
                 this.executor.shutdown();
@@ -442,6 +708,24 @@ public class DebeziumChangeEventCapture {
             }
         } catch (Exception e) {
             log.error("Error stopping debezium engine", e);
+        }
+
+        try {
+            if (this.systemDbConnection != null) {
+                this.systemDbConnection.close();
+                this.systemDbConnection = null;
+            }
+        } catch (Exception e) {
+            log.error("Error closing system DB connection", e);
+        }
+
+        try {
+            if (this.replicationHistoryDbConnection != null) {
+                this.replicationHistoryDbConnection.close();
+                this.replicationHistoryDbConnection = null;
+            }
+        } catch (Exception e) {
+            log.error("Error closing replication history DB connection", e);
         }
 
         Metrics.stop();
@@ -499,13 +783,33 @@ public class DebeziumChangeEventCapture {
         StringBuffer clickHouseQuery = new StringBuffer();
         AtomicBoolean isDropOrTruncate = new AtomicBoolean(false);
 
-        if (checkIfDDLNeedsToBeIgnored(DDL, props, sr, isDropOrTruncate)) {
-            log.info("Ignored Source DB DDL: " + DDL + " Snapshot:" + isSnapshotDDL(sr));
-            return;
-        }
-
+        // The DDL MUST be parsed before checkIfDDLNeedsToBeIgnored() is consulted.
+        // parseSql() is what populates isDropOrTruncate, and the DISABLE_DROP_TRUNCATE
+        // guard inside checkIfDDLNeedsToBeIgnored() reads that flag. Calling the guard
+        // first made it observe the freshly-initialised `false` on every invocation, so
+        // DISABLE_DROP_TRUNCATE=true silently allowed every DROP/TRUNCATE through to
+        // ClickHouse. The guard could only ever fail open.
         MySQLDDLParserService mySQLDDLParserService = new MySQLDDLParserService(writer, config, databaseName);
         mySQLDDLParserService.parseSql(DDL, "", clickHouseQuery, isDropOrTruncate);
+
+        if (checkIfDDLNeedsToBeIgnored(DDL, props, sr, isDropOrTruncate)) {
+            log.info("Ignored Source DB DDL: " + DDL + " Snapshot:" + isSnapshotDDL(sr));
+            // Acknowledge offset even for ignored DDL to prevent replication from
+            // getting stuck replaying the same ignored DDL repeatedly.
+            // acknowledgeRecords() is a checked-exception method (it commits
+            // offsets under the shared lock); on interrupt, restore the flag and
+            // return WITHOUT acknowledging rather than swallowing it — a silent
+            // failure here would advance the offset past a DDL whose commit
+            // never completed.
+            try {
+                DebeziumOffsetManagement.acknowledgeRecords(
+                        recordCommitter, cdcRecord, lastRecordInBatch);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("Interrupted while acknowledging ignored DDL: " + DDL, e);
+            }
+            return;
+        }
 
 
         log.info("Executed Source DB DDL: " + DDL + " Snapshot:" + isSnapshotDDL(sr));
@@ -522,6 +826,38 @@ public class DebeziumChangeEventCapture {
             retryDDLProperty = true;
         }
 
+        // Freeze replication for this table BEFORE executing the ALTER, so no
+        // batch insert thread can write rows against the stale (pre-ALTER)
+        // column cache while the schema change is in flight. The freeze is held
+        // until the destination schema is visible, the cache has been
+        // invalidated, and (on the insert side) source-vs-destination integrity
+        // is confirmed. This closes the race behind GitHub issue #1222, where a
+        // column added by an in-flight ALTER replicated as NULL for historical
+        // rows. Freeze is best-effort: if the table name cannot be resolved we
+        // proceed without it (the DDL waiter still runs).
+        String ddlFreezeTable = null;
+        try {
+            // Pass the DDL text: getTableName now resolves the table from the
+            // statement itself. The old record-key lookup ALWAYS returned null
+            // (Debezium's SchemaChangeKey carries only databaseName), which
+            // would have made this freeze silently never engage.
+            String tableName = getTableName(sr, DDL);
+            if (tableName != null) {
+                // The freeze key MUST be built the same way the batch consumers
+                // build their lookup key — i.e. with clickhouse.database.override.map
+                // applied. Freezing "sourcedb.tbl" while the insert path awaits
+                // "destdb.tbl" means the freeze never blocks anything, which is
+                // exactly the stale-column-cache race it exists to prevent.
+                ddlFreezeTable =
+                        resolveInvalidationDatabaseName(databaseName, config)
+                                + "." + tableName;
+                TableReplicationFreezeManager.getInstance().freeze(ddlFreezeTable);
+            }
+        } catch (Exception e) {
+            log.warn("Could not resolve table for DDL freeze: " + DDL, e);
+        }
+
+        try {
         while (numRetries < MAX_DDL_RETRIES) {
             try {
 
@@ -538,22 +874,53 @@ public class DebeziumChangeEventCapture {
                 // here. We intentionally start from the real source-mapped database
                 // (getDatabaseName(sr)), not the replication-history override above.
                 try {
-                    String invalidationDatabaseName = getDatabaseName(sr);
-                    String overrideMapConfig = config.getString(
-                            ClickHouseSinkConnectorConfigVariables.CLICKHOUSE_DATABASE_OVERRIDE_MAP.toString());
-                    if (overrideMapConfig != null) {
-                        Map<String, String> databaseOverrideMap =
-                                Utils.parseSourceToDestinationDatabaseMap(overrideMapConfig);
-                        if (databaseOverrideMap.containsKey(invalidationDatabaseName)) {
-                            invalidationDatabaseName = databaseOverrideMap.get(invalidationDatabaseName);
+                    // Both sides of the merge are kept, because each fixes a
+                    // DIFFERENT half of the invalidation key:
+                    //  - 2.10.0 fixes the DATABASE half: the key must be the
+                    //    override-mapped DESTINATION database (see
+                    //    resolveInvalidationDatabaseName), which is what the
+                    //    batch consumers use. Using the raw `databaseName`
+                    //    here skips clickhouse.database.override.map, so the
+                    //    key never matches the consumer's.
+                    //  - develop fixes the TABLE half: resolve every affected
+                    //    table, and never silently skip a table-scoped DDL.
+                    // 2.10.0 resolves tables from the record value's
+                    // tableChanges array (so multi-table DDL invalidates all of
+                    // them); develop resolves it from the DDL text. Try the
+                    // value first, fall back to the text, and only then report.
+                    String invalidationDatabaseName =
+                            resolveInvalidationDatabaseName(databaseName, config);
+                    List<String> affectedTables = getTableNamesFromDDL(sr);
+                    if (affectedTables.isEmpty()) {
+                        String parsedTableName = getTableName(sr, DDL);
+                        if (parsedTableName != null) {
+                            affectedTables = java.util.Collections
+                                    .singletonList(parsedTableName);
                         }
                     }
-                    for (String tableName : getTableNamesFromDDL(sr)) {
-                        CacheInvalidationManager.getInstance()
-                                .invalidateTable(invalidationDatabaseName + "." + tableName);
+                    if (!affectedTables.isEmpty()) {
+                        for (String tableName : affectedTables) {
+                            CacheInvalidationManager.getInstance()
+                                    .invalidateTable(invalidationDatabaseName + "." + tableName);
+                        }
+                    } else if (isTableScopedDDL(DDL)) {
+                        // Never silently skip invalidation for a TABLE-scoped DDL: a
+                        // cached DbWriter that is not rebuilt keeps writing the pre-DDL
+                        // column list, so the new column is dropped from every
+                        // subsequent INSERT and ClickHouse diverges from MySQL
+                        // permanently. Surface it loudly instead.
+                        log.error("Could not determine the table affected by DDL, so the "
+                                + "DbWriter schema cache could NOT be invalidated. Subsequent "
+                                + "inserts may use a stale column list and silently diverge "
+                                + "from the source. DDL: {}", DDL);
+                    } else {
+                        // Database-scoped DDL (CREATE/DROP/ALTER DATABASE) has no table
+                        // subject and no DbWriter cache to invalidate. Expected, not an error.
+                        log.debug("DDL is not table-scoped; no schema cache to invalidate. "
+                                + "DDL: {}", DDL);
                     }
                 } catch (Exception e) {
-                    log.warn("Error invalidating cache for DDL: " + DDL, e);
+                    log.error("Error invalidating cache for DDL: " + DDL, e);
                 }
 
                 try {
@@ -596,6 +963,18 @@ public class DebeziumChangeEventCapture {
             }
             if (numRetries >= MAX_DDL_RETRIES) {
                 throw new RuntimeException("Max retries exceeded for DDL");
+            }
+        }
+        } finally {
+            // Always unfreeze, even if the DDL failed/threw, so the table is
+            // never left frozen forever. After a successful ALTER the cache is
+            // already marked for invalidation; the next insert rebuilds it and
+            // runs the source-vs-destination integrity check. On failure we
+            // unfreeze so inserts (which would also have failed against the old
+            // schema) are not blocked indefinitely -- the error was already
+            // logged to the error table above.
+            if (ddlFreezeTable != null) {
+                TableReplicationFreezeManager.getInstance().unfreeze(ddlFreezeTable);
             }
         }
         updateMetrics(DDL);
@@ -660,21 +1039,105 @@ public class DebeziumChangeEventCapture {
     }
 
     /**
-     * Function to get the table name from the SourceRecord.
+     * Resolves the database half of a schema-cache key, applying
+     * {@code clickhouse.database.override.map} exactly the way the batch
+     * consumers ({@code ClickHouseBatchRunnable} /
+     * {@code ClickHouseBatchWriter}) do when they build their
+     * {@code "database.table"} lookup key.
      *
-     * @param sr The source record.
-     * @return The table name, or null if not found.
+     * <p>The consumer's key is
+     * {@code override(replicationHistoryEnabled ? historyDb : sourceDb)}, so
+     * BOTH steps must be applied here. Passing the caller's already
+     * history-adjusted {@code databaseName} covers the first step; this method
+     * applies the override map on top. A key built any other way silently
+     * never matches the consumer's key, so the invalidation (or freeze) would
+     * be registered against a table nobody ever looks up — the cache would
+     * appear to be invalidated while every worker kept its stale column
+     * list.</p>
+     *
+     * @param databaseName The caller's database name, already adjusted for
+     *                     replication history.
+     * @param config       The connector configuration.
+     * @return The destination database name to use in the cache key.
      */
-    private String getTableName(SourceRecord sr) {
-        if (sr != null && sr.key() instanceof Struct) {
+    private String resolveInvalidationDatabaseName(
+            String databaseName, ClickHouseSinkConnectorConfig config) {
+        String resolved = databaseName;
+        String overrideMapConfig = config.getString(
+                ClickHouseSinkConnectorConfigVariables
+                        .CLICKHOUSE_DATABASE_OVERRIDE_MAP.toString());
+        if (overrideMapConfig != null) {
             try {
-                String tableName = (String) ((Struct) sr.key()).get("tableName");
-                if (tableName != null && !tableName.isEmpty()) {
-                    return tableName;
+                Map<String, String> databaseOverrideMap =
+                        Utils.parseSourceToDestinationDatabaseMap(overrideMapConfig);
+                if (databaseOverrideMap.containsKey(resolved)) {
+                    resolved = databaseOverrideMap.get(resolved);
                 }
             } catch (Exception e) {
-                // tableName field may not exist in the struct
-                log.debug("tableName field not found in source record key");
+                // Log LOUDLY rather than swallowing: an unparseable override map
+                // means the key computed here may not match the one the batch
+                // consumers use, so a cache invalidation or replication freeze
+                // could be registered against a table nobody looks up. The
+                // unmapped name is still the best available key, but an operator
+                // must see that the override map is broken.
+                log.error("Could not parse {}='{}' while resolving the schema-cache "
+                                + "key for database '{}'. Falling back to the unmapped "
+                                + "name; if an override is configured for it, DDL cache "
+                                + "invalidation and the replication freeze will NOT match "
+                                + "the insert path and inserts may use a stale schema.",
+                        ClickHouseSinkConnectorConfigVariables
+                                .CLICKHOUSE_DATABASE_OVERRIDE_MAP,
+                        overrideMapConfig, databaseName, e);
+            }
+        }
+        return resolved;
+    }
+
+    /**
+     * Returns true when the DDL operates on a table (and therefore has a DbWriter
+     * schema cache that must be invalidated). Database-scoped DDL such as
+     * CREATE/DROP/ALTER DATABASE has no table subject, so a missing table name
+     * there is expected rather than an error worth alerting on.
+     *
+     * @param ddl the DDL statement text.
+     * @return true if the statement is table-scoped.
+     */
+    private boolean isTableScopedDDL(String ddl) {
+        if (ddl == null) {
+            return false;
+        }
+        return ddl.toUpperCase(java.util.Locale.ROOT).contains("TABLE");
+    }
+
+    /**
+     * Function to get the table name affected by a schema-change (DDL) record.
+     *
+     * <p>The table name is resolved from the DDL text, NOT from the record key.
+     * Debezium's {@code SchemaChangeKey} struct carries exactly one field,
+     * {@code databaseName} — there is no {@code tableName} field on it. Reading
+     * "tableName" from the key therefore always failed and returned null, which
+     * meant the DDL cache invalidation below was never registered for any table,
+     * leaving every cached DbWriter serving a stale column list forever.</p>
+     *
+     * @param sr  The source record (used only as a fallback source of the value).
+     * @param ddl The DDL statement text.
+     * @return The table name, or null if it could not be determined.
+     */
+    private String getTableName(SourceRecord sr, String ddl) {
+        String tableName = MySQLDDLParserService.extractTableName(ddl);
+        if (tableName != null && !tableName.isEmpty()) {
+            return tableName;
+        }
+        // Fall back to the record key in case a future connector version does
+        // expose a table name there.
+        if (sr != null && sr.key() instanceof Struct) {
+            try {
+                String keyTableName = (String) ((Struct) sr.key()).get("tableName");
+                if (keyTableName != null && !keyTableName.isEmpty()) {
+                    return keyTableName;
+                }
+            } catch (Exception e) {
+                log.debug("tableName field not present in source record key");
             }
         }
         return null;
@@ -752,11 +1215,22 @@ public class DebeziumChangeEventCapture {
     private void executeDDL(String clickHouseQuery, BaseDbWriter writer, ClickHouseSinkConnectorConfig config) throws SQLException {
         ClickHouseAlterTable cat = new ClickHouseAlterTable();
         DBMetadata dbMetadata = new DBMetadata(config);
+        long schemaChangeTimeoutMs = config.getLong(
+                ClickHouseSinkConnectorConfigVariables.DDL_SCHEMA_CHANGE_TIMEOUT_MS.toString());
+        long schemaChangePollIntervalMs = config.getLong(
+                ClickHouseSinkConnectorConfigVariables.DDL_SCHEMA_CHANGE_POLL_INTERVAL_MS.toString());
+        DDLSchemaChangeWaiter schemaWaiter = new DDLSchemaChangeWaiter(schemaChangeTimeoutMs, schemaChangePollIntervalMs);
         String[] queries = clickHouseQuery.replaceAll(",$", "").split("\n");
         for (String query : queries) {
             if (!query.isEmpty()) {
                 log.info("ClickHouse DDL: " + query);
                 dbMetadata.executeSystemQuery(writer.getConnection(), query);
+                // Wait for schema change to become visible in system.columns
+                // before cache invalidation proceeds. Without this, the batch
+                // insert thread may rebuild its column metadata cache before
+                // the ALTER TABLE has propagated, silently dropping values
+                // for newly added columns. See GitHub issue #1222.
+                schemaWaiter.waitForSchemaVisibility(writer.getConnection(), query);
             }
         }
     }
@@ -811,7 +1285,8 @@ public class DebeziumChangeEventCapture {
                 return null;
             }
             if (struct.schema() == null) {
-                log.error("SCHEMA EMPTY");
+log.error("SCHEMA EMPTY - cannot process record without schema. Record: {}", record.toString());
+                return null;
             }
 
             java.util.List<Field> schemaFields = struct.schema().fields();
@@ -828,18 +1303,36 @@ public class DebeziumChangeEventCapture {
 
                 if (DDL != null && !DDL.isEmpty()) {
                     log.info("***** DDL received, Flush all existing records");
-                    this.executor.pause();
+                    // In single.threaded mode there is no batch executor:
+                    // setupProcessingThread() creates singleThreadedWriter and
+                    // returns, so this.executor stays null and records are
+                    // written synchronously on this same thread — DDL and DML
+                    // are already serialized and there is nothing to pause.
+                    // Upstream calls pause() unconditionally and the resulting
+                    // NullPointerException was silently swallowed by the
+                    // log-only catch below (skipping the DDL); now that the
+                    // catch fails loudly, the null guard is required — without
+                    // it the FIRST DDL in single-threaded mode stops the
+                    // engine and cascades across the whole suite.
+                    pauseBatchExecutor();
+                    try {
+                        Map<String, Object> sourceObjStruct = new ClickHouseConverter().convertValue(sr);
 
-                    Map<String, Object> sourceObjStruct = new ClickHouseConverter().convertValue(sr);
-
-                    ClickHouseStruct ddlStruct = new ClickHouseStruct();
-                    ddlStruct.setAdditionalMetaData(sourceObjStruct);
-                    ddlStruct.setSequenceNumber(sequenceNumber);
-                    performDDLOperation(DDL, props, sr, config, recordCommitter, record, lastRecordInBatch, ddlStruct);
-                    this.executor.resume();
+                        ClickHouseStruct ddlStruct = new ClickHouseStruct();
+                        ddlStruct.setAdditionalMetaData(sourceObjStruct);
+                        ddlStruct.setSequenceNumber(sequenceNumber);
+                        performDDLOperation(DDL, props, sr, config, recordCommitter, record, lastRecordInBatch, ddlStruct);
+                    } finally {
+                        // Always resume executor — leaving it paused permanently stalls replication
+                        resumeBatchExecutor();
+                    }
                 }
             } else {
                 chStruct = debeziumRecordParserService.parse(record, recordCommitter, lastRecordInBatch);
+                if (chStruct == null) {
+                    log.warn("Record parser returned null — skipping record");
+                    return null;
+                }
                 chStruct.setSequenceNumber(sequenceNumber);
                 try {
                     if (chStruct != null) {
@@ -855,10 +1348,38 @@ public class DebeziumChangeEventCapture {
                 }
             }
         } catch (Exception e) {
-            log.error("Exception processing record", e);
+            log.error("Exception processing record: " + record.toString(), e);
+            throw new RuntimeException("Failed to process CDC record", e);
         }
 
         return chStruct;
+    }
+
+    /**
+     * Pauses the batch executor before a DDL is applied, if one exists.
+     *
+     * <p>In single.threaded mode {@link #setupProcessingThread} creates a
+     * {@code singleThreadedWriter} instead of a batch executor, so
+     * {@code this.executor} is null and DML is written synchronously on the
+     * Debezium event thread — the same thread that processes DDL — so there
+     * is no concurrent batch thread to pause and this is safely a no-op.</p>
+     */
+    @VisibleForTesting
+    void pauseBatchExecutor() {
+        if (this.executor != null) {
+            this.executor.pause();
+        }
+    }
+
+    /**
+     * Resumes the batch executor after a DDL completes, if one exists.
+     * No-op in single.threaded mode (see {@link #pauseBatchExecutor}).
+     */
+    @VisibleForTesting
+    void resumeBatchExecutor() {
+        if (this.executor != null) {
+            this.executor.resume();
+        }
     }
 
     /**
@@ -882,7 +1403,7 @@ public class DebeziumChangeEventCapture {
 
         if (sr.sourceOffset() != null) {
             if (sr.sourceOffset().containsKey("snapshot")) {
-                String snapshotMode = (String) sr.sourceOffset().get("snapshot");
+                String snapshotMode = String.valueOf(sr.sourceOffset().get("snapshot"));
                 if (snapshotMode.equalsIgnoreCase("INITIAL")) {
                     snapshotDDL = true;
                 }
@@ -939,13 +1460,36 @@ public class DebeziumChangeEventCapture {
             }
         }
 
-        // Check DDL against regex patterns from IgnoreDDLRegexLoader
+        // Check DDL against the built-in regex patterns from
+        // IgnoreDDLRegexLoader. Record the statement here too: a DDL ignored by
+        // a built-in pattern is just as ignored as one matched by the
+        // user-configured IGNORE_DDL_REGEX above, and getLastIgnoredDDL() is
+        // the only way an operator can see which statement was skipped.
+        // Without this the two paths disagree — making a built-in pattern
+        // case-insensitive silently stopped a lowercase DDL from ever being
+        // reported, because the built-in branch claimed it first and returned
+        // without recording it.
         if (checkDDLAgainstRegexPatterns(DDL)) {
+            lastIgnoredDDL = DDL;
+            log.info("Ignoring DDL: " + DDL
+                    + " as it matches a built-in ignore pattern");
             return true;
         }
 
+        // Snapshot-phase DDL is exempt from the DISABLE_DROP_TRUNCATE guard. During a
+        // snapshot Debezium replays schema bootstrap as a drop-and-recreate
+        // pair for every captured table; when the operator has enabled
+        // snapshot DDL, suppressing only the drop half leaves any
+        // pre-existing destination table in place and the paired CREATE then
+        // fails with TABLE_ALREADY_EXISTS, stalling the DDL stream in a retry
+        // loop. The guard exists to protect the destination from destructive
+        // STREAMING DDL (an accidental drop on the source mid-replication),
+        // which is still blocked below. Snapshot DDL that the operator has NOT
+        // enabled never reaches ClickHouse anyway via the final check in this
+        // method.
         String disableDropAndTruncateProperty = props.getProperty(SinkConnectorLightWeightConfig.DISABLE_DROP_TRUNCATE);
-        if (disableDropAndTruncateProperty != null && disableDropAndTruncateProperty.equalsIgnoreCase("true") && isDropOrTruncate.get() == true) {
+        if (disableDropAndTruncateProperty != null && disableDropAndTruncateProperty.equalsIgnoreCase("true")
+                && isDropOrTruncate.get() == true && !isSnapshotDDL) {
             log.debug("Ignoring Drop or Truncate");
             return true;
         }
@@ -1083,31 +1627,110 @@ public class DebeziumChangeEventCapture {
 
 
     /**
+     * Seeds the shared sequence anchor for a new batch.
+     *
+     * <p>Runs under {@link #sequenceLock} because the anchor and the counter
+     * are a single unit of state: a thread that re-anchors without holding the
+     * counter's lock can race a thread deciding whether to reset.</p>
+     *
+     * <p>The anchor only ever moves <b>forward</b>. The anchor is shared by all
+     * batch threads, but each batch seeds it from its own first record, so with
+     * an unconditional assignment a batch carrying an older timestamp can drag
+     * the anchor <em>backward</em> past a point another thread has already
+     * passed. That re-arms the {@code diff > 1} reset branch for timestamps
+     * already in use, and the counter is reset to the constant
+     * {@link #SEQUENCE_START} a second time — so two different records at the
+     * same source timestamp receive an identical {@code _version} and
+     * ReplacingMergeTree silently discards one of them. Measured
+     * single-threaded, with the anchor re-seeded backward between assignments:
+     * 199 duplicate versions in 200 records, and the second value is
+     * <em>lower</em> than the first, so an older row can also outrank a newer
+     * one.</p>
+     *
+     * <p>The guard changes no emitted value for a non-decreasing source clock —
+     * a MySQL binlog's commit timestamps only advance, so {@code ts > anchor}
+     * holds on every ordinary seed and the assignment is identical to the
+     * unconditional one. Verified by replaying an ascending stream through both
+     * forms and comparing the full output: byte-for-byte equal. The 2.8.0
+     * {@code _version} format is therefore untouched (pinned by
+     * {@code Version280CompatibilityTest}); only an out-of-order re-seed, which
+     * previously corrupted the sequence, is now ignored.</p>
+     *
+     * @param debeziumTsMs the Debezium timestamp of the batch's first record.
+     */
+    void seedSequenceAnchor(long debeziumTsMs) {
+        synchronized (sequenceLock) {
+            if (sequenceStartTime == UNANCHORED || debeziumTsMs > sequenceStartTime) {
+                sequenceStartTime = debeziumTsMs;
+            }
+        }
+    }
+
+    /**
+     * Produces the next {@code _version} value for a record.
+     *
+     * <p>The returned value is <b>bit-for-bit the 2.8.0 formula</b>:</p>
+     * <pre>    _version = debezium_ts_ms * 1_000_000 + counter</pre>
+     * <p>with the counter reset to {@link #SEQUENCE_START} when the Debezium
+     * clock advances more than one second past the current anchor, and
+     * incremented otherwise. The formula is deliberately unchanged, because
+     * {@code _version} decides which row survives a ReplacingMergeTree merge:
+     * a table that already holds rows written by 2.8.0 cannot also hold rows
+     * from a different scheme without the larger magnitude winning every merge
+     * regardless of which change actually happened later — and no downgrade
+     * can undo rows already written.</p>
+     *
+     * <p>What is fixed is the <em>assignment</em>, not the value. The previous
+     * code read, modified and wrote the shared counter without holding a lock,
+     * in two separate windows: the reset branch is a check-and-act across the
+     * anchor and the counter, and the increment branch called
+     * {@code incrementAndGet()} and then re-read the counter with a separate
+     * {@code get()}. Two batch threads interleaving in either window observe
+     * the same counter and hand two distinct records an identical
+     * {@code _version}, which the ReplacingMergeTree silently collapses into
+     * one row. Holding the lock across the whole decision closes both windows,
+     * and the value used is the one produced inside the critical section.</p>
+     *
+     * @param debeziumTsMs the record's Debezium timestamp.
+     * @return the {@code _version} value to assign to the record.
+     */
+    long nextSequenceNumber(long debeziumTsMs) {
+        synchronized (sequenceLock) {
+            if (sequenceStartTime == UNANCHORED) {
+                sequenceStartTime = debeziumTsMs;
+            }
+            final long assignedSequence;
+            // Identical to 2.8.0: reset only when the clock advances more than
+            // one whole second past the anchor.
+            int diff = (int) ((debeziumTsMs - sequenceStartTime) / 1000);
+            if (diff > 1) {
+                sequenceNumber.set(SEQUENCE_START);
+                assignedSequence = SEQUENCE_START;
+                sequenceStartTime = debeziumTsMs;
+            } else {
+                assignedSequence = sequenceNumber.incrementAndGet();
+            }
+            return debeziumTsMs * 1000000 + assignedSequence;
+        }
+    }
+
+    /**
      * Adds a version (sequence number) to every record.
-     * <p>
-     * The sequence starts at SEQUENCE_START, increments for every record,
-     * and resets if more than one second has elapsed since the first record.
-     * </p>
+     *
+     * <p>Delegates to {@link #nextSequenceNumber(long)} so this path and the
+     * live batch-consumer path can never drift apart into two different
+     * {@code _version} schemes.</p>
      *
      * @param chStructs The list of {@link ClickHouseStruct} records.
      */
-    public static void addVersion(List<ClickHouseStruct> chStructs) {
-        // Start the sequence from SEQUENCE_START and increment for every record
+    public void addVersion(List<ClickHouseStruct> chStructs) {
         if (chStructs.isEmpty()) {
             return;
         }
-        long sequenceStartTime = chStructs.get(0).getDebezium_ts_ms();
         for (ClickHouseStruct chStruct : chStructs) {
-            // Get diff in seconds from the first record's Debezium timestamp.
-            int diff = (int) ((chStruct.getDebezium_ts_ms() - sequenceStartTime) / 1000);
-            if (diff > 1) {
-                sequenceNumber = SEQUENCE_START;
-                sequenceStartTime = chStruct.getDebezium_ts_ms();
-            } else {
-                sequenceNumber++;
-            }
-            // Pad the sequence number with zeros and set the sequence number in the record.
-            chStruct.setSequenceNumber(chStruct.getDebezium_ts_ms() * 1000000 + sequenceNumber);
+            // Anchored on the DEBEZIUM timestamp, exactly as 2.8.0 did.
+            chStruct.setSequenceNumber(
+                    nextSequenceNumber(chStruct.getDebezium_ts_ms()));
         }
     }
 }

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/IgnoreDDLRegexLoader.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/IgnoreDDLRegexLoader.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public class IgnoreDDLRegexLoader {
     private static final List<String> REGEX_PATTERNS = Arrays.asList(
-        "^ALTER TABLE .*\\s+analyze\\s+PARTITION\\s+p[0-9]+$",
+        "(?i)^ALTER TABLE .*\\s+analyze\\s+PARTITION\\s+p[0-9]+$",
         "(?i)ALTER\\s+TABLE\\s+\\S+\\s+ADD\\s+PARTITION\\s*\\(",
         "(?i)ALTER\\s+TABLE\\s+\\S+\\s+DROP\\s+PARTITION\\s+\\S+",
         "(?i)ALTER\\s+TABLE\\s+\\S+\\s+REORGANIZE\\s+PARTITION\\s+.*?\\s+INTO\\s*\\(",

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCaptureTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCaptureTest.java
@@ -99,14 +99,25 @@ public class DebeziumChangeEventCaptureTest {
                 getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
         ch6.setTs_ms(currentTimestamp);
 
+        // Both batches go through ONE capture instance. The sequence counter is
+        // per-instance (an AtomicLong, not a shared static: a plain static long
+        // mutated by several worker threads is a lost-update race that can hand
+        // two records the SAME _version and let the ReplacingMergeTree collapse
+        // one of them away). Production creates exactly one
+        // DebeziumChangeEventCapture, so successive batches must be sequenced
+        // through the same instance for the counter to carry across them --
+        // using a fresh instance per batch would only be testing the race this
+        // fix removed.
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+
         // Make a list of ch1, ch2, ch3 and ch4
         List<ClickHouseStruct> clickHouseStructs = Arrays.asList(ch1, ch2, ch3, ch4, ch5);
-        DebeziumChangeEventCapture.addVersion(clickHouseStructs);
+        capture.addVersion(clickHouseStructs);
 
         Thread.sleep(1000);
         // Add ch5 and ch6
         List<ClickHouseStruct> clickHouseStructs2 = Arrays.asList(ch5, ch6);
-        DebeziumChangeEventCapture.addVersion(clickHouseStructs2);
+        capture.addVersion(clickHouseStructs2);
 
         // Check if the sequence numbers are unique
         assertTrue(clickHouseStructs.get(0).getSequenceNumber() < clickHouseStructs.get(1).getSequenceNumber());
@@ -137,6 +148,23 @@ public class DebeziumChangeEventCaptureTest {
 
         String ddlNotToIgnore = "ALTER TABLE trade_prod.bundle_detail ADD COLUMN new_column INT";
         assertFalse(capture.checkDDLAgainstRegexPatterns(ddlNotToIgnore));
+    }
+
+    @Test
+    @DisplayName("ANALYZE PARTITION is matched regardless of statement case")
+    public void shouldIgnoreAnalyzePartitionCaseInsensitively() {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+
+        // MySQL echoes the statement exactly as the client typed it, so the
+        // built-in pattern has to be case-insensitive to catch the lowercase
+        // spelling clients actually emit. The sibling ADD/DROP PARTITION
+        // patterns already carried (?i); this one did not.
+        assertTrue(capture.checkDDLAgainstRegexPatterns(
+                "ALTER TABLE sales analyze PARTITION p2022"));
+        assertTrue(capture.checkDDLAgainstRegexPatterns(
+                "alter table sales analyze partition p2022"));
+        assertTrue(capture.checkDDLAgainstRegexPatterns(
+                "ALTER TABLE sales ANALYZE PARTITION p2022"));
     }
 
     @Test
@@ -234,4 +262,250 @@ public class DebeziumChangeEventCaptureTest {
         String ddlToIgnoreCaseInsensitive = "alter table trade_prod.bundle_detail optimize partition p20230106";
         assertTrue(capture.checkDDLAgainstRegexPatterns(ddlToIgnoreCaseInsensitive));
     }
+
+    /**
+     * Regression: the assigned sequence number must come from the atomic
+     * mutation itself, never from a follow-up get(). incrementAndGet() then
+     * re-reading with get() is a TOCTOU race -- two threads can interleave
+     * between the increment and the read and both observe the same highest
+     * value, handing two records an identical _version and letting the
+     * ReplacingMergeTree collapse one of them away. That is exactly the
+     * lost-update the AtomicLong exists to prevent.
+     *
+     * <p>Every emitted _version across concurrent batches must be unique.</p>
+     */
+    @Test
+    @DisplayName("Concurrent addVersion calls must never emit a duplicate _version")
+    public void testAddVersionIsRaceFreeAcrossThreads() throws Exception {
+        final DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        final long ts = System.currentTimeMillis();
+        // Single-record batches maximise the interleave window: each
+        // addVersion call is one increment immediately followed by the read,
+        // which is precisely where a get()-after-increment loses the update.
+        final int threads = 16;
+        final int perThread = 1;
+        final int rounds = 400;
+
+        // All records share one ts_ms so every version differs only by the
+        // counter -- any lost update shows up immediately as a duplicate.
+        final java.util.concurrent.CountDownLatch start =
+                new java.util.concurrent.CountDownLatch(1);
+        final java.util.List<java.util.concurrent.Future<java.util.List<Long>>> futures =
+                new java.util.ArrayList<>();
+        final java.util.concurrent.ExecutorService pool =
+                java.util.concurrent.Executors.newFixedThreadPool(threads);
+        try {
+            for (int t = 0; t < threads; t++) {
+                futures.add(pool.submit(() -> {
+                    List<Long> seqs = new java.util.ArrayList<>();
+                    start.await();
+                    // Each round submits its own tiny batch, so the increment
+                    // and the subsequent read are adjacent under contention.
+                    for (int r = 0; r < rounds; r++) {
+                        List<ClickHouseStruct> batch = new java.util.ArrayList<>();
+                        for (int i = 0; i < perThread; i++) {
+                            ClickHouseStruct ch = new ClickHouseStruct(10, "topic_1",
+                                    getKafkaStruct(), 2, ts, null, getKafkaStruct(), null,
+                                    ClickHouseConverter.CDC_OPERATION.CREATE);
+                            ch.setTs_ms(ts);
+                            batch.add(ch);
+                        }
+                        capture.addVersion(batch);
+                        for (ClickHouseStruct ch : batch) {
+                            seqs.add(ch.getSequenceNumber());
+                        }
+                    }
+                    return seqs;
+                }));
+            }
+            start.countDown();
+
+            List<Long> all = new java.util.ArrayList<>();
+            for (java.util.concurrent.Future<java.util.List<Long>> f : futures) {
+                all.addAll(f.get(60, java.util.concurrent.TimeUnit.SECONDS));
+            }
+            java.util.Set<Long> unique = new java.util.HashSet<>(all);
+            org.junit.Assert.assertEquals(
+                    "duplicate _version emitted -- the counter was read with get() "
+                            + "instead of using the value returned by incrementAndGet()",
+                    all.size(), unique.size());
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    /**
+     * Regression: the time-gap reset is a check-and-act over TWO pieces of
+     * state -- the source-timestamp anchor is read to decide whether the
+     * second boundary was crossed, and only then is the counter reset. An
+     * atomic counter alone cannot make that pair consistent: two threads
+     * crossing the same boundary both observe the stale anchor, both reset to
+     * SEQUENCE_START, and both emit an identical _version for records sharing
+     * that ts_ms -- which ReplacingMergeTree silently collapses.
+     */
+    @Test
+    @DisplayName("Concurrent time-gap resets must not collide on SEQUENCE_START")
+    public void testAddVersionRaceOnTimeGap() throws Exception {
+        final long oldTs = 1000000000000L;
+        // A gap > 1s from the anchor forces every thread down the reset branch.
+        final long newTs = oldTs + 5000;
+        final int threads = 8;
+
+        // Repeat: a check-and-act window is probabilistic, so a single pass can
+        // pass by luck. Each round uses a fresh capture anchored in the past.
+        for (int round = 0; round < 200; round++) {
+            final DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+
+            final java.util.concurrent.CountDownLatch start =
+                    new java.util.concurrent.CountDownLatch(1);
+            final java.util.concurrent.ExecutorService pool =
+                    java.util.concurrent.Executors.newFixedThreadPool(threads);
+            try {
+                List<java.util.concurrent.Future<Long>> futures =
+                        new java.util.ArrayList<>();
+                for (int t = 0; t < threads; t++) {
+                    futures.add(pool.submit(() -> {
+                        // The anchor is taken from record[0] of THIS batch, so the
+                        // reset branch is only reachable when a single batch spans
+                        // the gap. record[1] is the one that resets the shared
+                        // counter and is assigned SEQUENCE_START.
+                        ClickHouseStruct first = new ClickHouseStruct(10, "topic_1",
+                                getKafkaStruct(), 2, oldTs, null, getKafkaStruct(),
+                                null, ClickHouseConverter.CDC_OPERATION.CREATE);
+                        first.setTs_ms(oldTs);
+                        ClickHouseStruct afterGap = new ClickHouseStruct(10, "topic_1",
+                                getKafkaStruct(), 2, newTs, null, getKafkaStruct(),
+                                null, ClickHouseConverter.CDC_OPERATION.CREATE);
+                        afterGap.setTs_ms(newTs);
+                        start.await();
+                        capture.addVersion(Arrays.asList(first, afterGap));
+                        return afterGap.getSequenceNumber();
+                    }));
+                }
+                start.countDown();
+
+                List<Long> seqs = new java.util.ArrayList<>();
+                for (java.util.concurrent.Future<Long> f : futures) {
+                    seqs.add(f.get(30, java.util.concurrent.TimeUnit.SECONDS));
+                }
+                java.util.Set<Long> unique = new java.util.HashSet<>(seqs);
+                org.junit.Assert.assertEquals(
+                        "round " + round + ": threads crossing the same second "
+                                + "boundary produced a duplicate _version -- the "
+                                + "counter and its time anchor must be updated "
+                                + "atomically together",
+                        seqs.size(), unique.size());
+            } finally {
+                pool.shutdownNow();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("addVersion should handle empty list without error")
+    public void testAddVersionEmptyListNoOp() {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        List<ClickHouseStruct> emptyList = new java.util.ArrayList<>();
+        // Should not throw
+        capture.addVersion(emptyList);
+        assertTrue(emptyList.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Separate instances should have independent sequence numbers")
+    public void testAddVersionInstanceIsolation() {
+        long currentTimestamp = System.currentTimeMillis();
+
+        // Create structs for instance 1
+        ClickHouseStruct ch1 = new ClickHouseStruct(10, "topic_1", getKafkaStruct(), 2,
+                currentTimestamp, null,
+                getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+        ch1.setTs_ms(currentTimestamp);
+
+        ClickHouseStruct ch2 = new ClickHouseStruct(10, "topic_1", getKafkaStruct(), 2,
+                currentTimestamp + 100, null,
+                getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+        ch2.setTs_ms(currentTimestamp);
+
+        // Create structs for instance 2
+        ClickHouseStruct ch3 = new ClickHouseStruct(10, "topic_2", getKafkaStruct(), 2,
+                currentTimestamp, null,
+                getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+        ch3.setTs_ms(currentTimestamp);
+
+        ClickHouseStruct ch4 = new ClickHouseStruct(10, "topic_2", getKafkaStruct(), 2,
+                currentTimestamp + 100, null,
+                getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+        ch4.setTs_ms(currentTimestamp);
+
+        // Process with separate instances
+        DebeziumChangeEventCapture instance1 = new DebeziumChangeEventCapture();
+        DebeziumChangeEventCapture instance2 = new DebeziumChangeEventCapture();
+
+        List<ClickHouseStruct> batch1 = Arrays.asList(ch1, ch2);
+        List<ClickHouseStruct> batch2 = Arrays.asList(ch3, ch4);
+
+        instance1.addVersion(batch1);
+        instance2.addVersion(batch2);
+
+        // Both instances should produce the same sequence pattern independently
+        // (since they start from the same SEQUENCE_START)
+        long seq1_first = batch1.get(0).getSequenceNumber();
+        long seq2_first = batch2.get(0).getSequenceNumber();
+        long seq1_second = batch1.get(1).getSequenceNumber();
+        long seq2_second = batch2.get(1).getSequenceNumber();
+
+        // Within each batch, sequences should be strictly increasing
+        assertTrue(seq1_first < seq1_second);
+        assertTrue(seq2_first < seq2_second);
+
+        // The relative offsets should be the same for both instances
+        // (same timestamp pattern -> same sequence increment)
+        long delta1 = seq1_second - seq1_first;
+        long delta2 = seq2_second - seq2_first;
+        assertTrue(delta1 == delta2);
+    }
+
+    @Test
+    @DisplayName("addVersion should reset sequence on large timestamp gap")
+    public void testAddVersionSequenceResetOnLargeTimeGap() {
+        long baseTimestamp = 1700000000000L; // fixed timestamp
+
+        ClickHouseStruct ch1 = new ClickHouseStruct(10, "topic_1", getKafkaStruct(), 2,
+                baseTimestamp, null,
+                getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+        ch1.setTs_ms(baseTimestamp);
+
+        // Same second — should increment
+        ClickHouseStruct ch2 = new ClickHouseStruct(10, "topic_1", getKafkaStruct(), 2,
+                baseTimestamp + 500, null,
+                getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+        ch2.setTs_ms(baseTimestamp + 500);
+
+        // 2 seconds later — should reset
+        ClickHouseStruct ch3 = new ClickHouseStruct(10, "topic_1", getKafkaStruct(), 2,
+                baseTimestamp + 2000, null,
+                getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+        ch3.setTs_ms(baseTimestamp + 2000);
+
+        // Same second as ch3 — should increment from reset
+        ClickHouseStruct ch4 = new ClickHouseStruct(10, "topic_1", getKafkaStruct(), 2,
+                baseTimestamp + 2100, null,
+                getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+        ch4.setTs_ms(baseTimestamp + 2100);
+
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        List<ClickHouseStruct> batch = Arrays.asList(ch1, ch2, ch3, ch4);
+        capture.addVersion(batch);
+
+        // ch1 and ch2 should be in the same sequence window (increasing)
+        assertTrue(ch1.getSequenceNumber() < ch2.getSequenceNumber());
+        // ch3 should have reset — its sequence should be based on the new timestamp
+        // After reset, sequenceNumber goes back to SEQUENCE_START, so the
+        // ch3 sequence should be baseTimestamp+2000 * 1000000 + SEQUENCE_START
+        assertTrue(ch3.getSequenceNumber() > ch2.getSequenceNumber());
+        // ch4 should increment from ch3
+        assertTrue(ch3.getSequenceNumber() < ch4.getSequenceNumber());
+    }
+
 }

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumEngineRestartTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumEngineRestartTest.java
@@ -1,0 +1,137 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Guards the engine-restart wiring in {@link DebeziumChangeEventCapture}.
+ *
+ * <p>When the Debezium engine stops with an error, its completion callback is
+ * the only thing that can bring it back: {@code setup()} calls
+ * {@code setupDebeziumEventCapture()} exactly once and returns. A revision
+ * that removed the retry from that callback left the connector permanently
+ * down after the first binlog communication failure — replication simply
+ * stopped and every later change was never applied, with no further error.
+ *
+ * <p>The restart must also not run on the callback thread. Rebuilding the
+ * engine inline stacks the replacement engine underneath the failed one's
+ * frame, so repeated failures nest until the stack overflows. The restart is
+ * therefore dispatched to a dedicated single-thread executor, which lets the
+ * callback unwind first and serialises attempts.
+ *
+ * <p>These tests pin the structural invariants that keep both properties
+ * true. They deliberately do not start an engine — doing so would need a live
+ * MySQL and ClickHouse — so they assert on the wiring rather than on a
+ * simulated failure.
+ */
+public class DebeziumEngineRestartTest {
+
+    private static Object field(Object target, String name) throws Exception {
+        Field f = DebeziumChangeEventCapture.class.getDeclaredField(name);
+        f.setAccessible(true);
+        return f.get(target);
+    }
+
+    @Test
+    @DisplayName("A dedicated restart executor exists and is distinct from the event executor")
+    public void testRestartExecutorIsSeparate() throws Exception {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+
+        Object restart = field(capture, "debeziumRestartExecutor");
+        Object event = field(capture, "singleThreadDebeziumEventExecutor");
+
+        assertNotNull("restart executor must be created in the constructor", restart);
+        assertNotNull(event);
+        // Sharing the event executor would deadlock: the restart task would
+        // queue behind engine.run(), which only returns once the engine stops.
+        assertNotSame("restart must not reuse the Debezium event executor", event, restart);
+    }
+
+    @Test
+    @DisplayName("stop() shuts the restart executor down so no retry outlives the connector")
+    public void testStopShutsDownRestartExecutor() throws Exception {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        ExecutorService restart = (ExecutorService) field(capture, "debeziumRestartExecutor");
+
+        assertFalse("restart executor should be live before stop()", restart.isShutdown());
+
+        capture.stop();
+
+        // A retry sleeping through its back-off must be cancelled, not allowed
+        // to wake up and rebuild an engine on a connector that is shutting down.
+        assertTrue("stop() must shut the restart executor down", restart.isShutdown());
+    }
+
+    @Test
+    @DisplayName("The retry budget is bounded by MAX_RETRIES rather than unbounded")
+    public void testRetryBudgetIsBounded() {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+
+        // numRetries starts fresh; the callback compares it against MAX_RETRIES
+        // before scheduling, so an engine that can never start stops retrying
+        // instead of looping forever.
+        assertTrue("MAX_RETRIES must be positive", DebeziumChangeEventCapture.MAX_RETRIES > 0);
+        assertTrue("numRetries must start at zero", capture.numRetries == 0);
+    }
+
+    /**
+     * Loads the config.properties that ships inside the jar.
+     *
+     * <p>Read from the module source rather than the classpath on purpose: the
+     * test resources contain their own config.properties, which shadows the
+     * shipped one during tests. Asserting against the classpath copy would
+     * therefore check the fixture instead of the file that reaches users.</p>
+     */
+    private static Properties shippedConfig() throws Exception {
+        Properties shipped = new Properties();
+        Path path = Paths.get("src/main/resources/config.properties");
+        assertTrue("shipped config.properties not found at " + path.toAbsolutePath(),
+                Files.exists(path));
+        try (InputStream in = Files.newInputStream(path)) {
+            shipped.load(in);
+        }
+        return shipped;
+    }
+
+    @Test
+    @DisplayName("The shipped replica.status.view default keeps both %s placeholders")
+    public void testShippedViewDefaultIsParameterised() throws Exception {
+        String view = shippedConfig().getProperty("replica.status.view");
+        assertNotNull("replica.status.view must have a shipped default", view);
+
+        // createViewForShowReplicaStatus does String.format(view, dbName,
+        // dbName + "." + tableName). A format string with no placeholders
+        // silently discards both arguments, so the view would be created
+        // against whatever database the literal names regardless of config.
+        assertEquals("replica.status.view default must keep both %s placeholders",
+                2, view.split("%s", -1).length - 1);
+    }
+
+    @Test
+    @DisplayName("The initial-snapshot guard is advisory unless explicitly opted in")
+    public void testInitialSnapshotGuardIsOptIn() throws Exception {
+        Properties shipped = shippedConfig();
+
+        // The guard throws only when this is true. It must not ship enabled:
+        // snapshot.mode=initial is the default, so a connector that has already
+        // been replicating would refuse to restart and stay down until someone
+        // logs into the host and touches a file.
+        assertFalse("the initial-snapshot guard must not be fatal by default",
+                Boolean.parseBoolean(
+                        shipped.getProperty("snapshot.initial.require.confirmation", "false")));
+    }
+}

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/DropTruncateSnapshotExemptionTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/DropTruncateSnapshotExemptionTest.java
@@ -1,0 +1,113 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the interaction between DISABLE_DROP_TRUNCATE and snapshot DDL.
+ *
+ * <p>During a snapshot Debezium replays schema bootstrap as a
+ * drop-and-recreate pair for every captured table. If the drop half is
+ * suppressed by the DISABLE_DROP_TRUNCATE guard while the CREATE half executes, a
+ * pre-existing destination table makes the CREATE fail with
+ * TABLE_ALREADY_EXISTS and the DDL stream stalls in a retry loop. The
+ * guard therefore only applies to STREAMING DDL — an accidental drop on the
+ * source mid-replication — and must exempt snapshot DDL, whose delivery is
+ * governed by ENABLE_SNAPSHOT_DDL instead.</p>
+ */
+@DisplayName("DISABLE_DROP_TRUNCATE must exempt snapshot-phase DDL")
+public class DropTruncateSnapshotExemptionTest {
+
+    // DESTRUCTIVE: inert test fixture. This string is only classified by
+    // checkIfDDLNeedsToBeIgnored; no database connection exists in this test
+    // and nothing is executed — blast radius is zero.
+    private static final String DROP_DDL =
+            "DROP TABLE IF EXISTS `employees`.`temporal_types_DATETIME`";
+
+    private static boolean checkIgnored(Properties props, SourceRecord sr,
+                                        boolean isDropOrTruncate) throws Exception {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        Method m = DebeziumChangeEventCapture.class.getDeclaredMethod(
+                "checkIfDDLNeedsToBeIgnored",
+                String.class, Properties.class, SourceRecord.class, AtomicBoolean.class);
+        m.setAccessible(true);
+        return (Boolean) m.invoke(capture, DROP_DDL, props,
+                sr, new AtomicBoolean(isDropOrTruncate));
+    }
+
+    private static SourceRecord recordWithOffset(Map<String, ?> sourceOffset) {
+        return new SourceRecord(Collections.emptyMap(), sourceOffset,
+                "test-topic", Schema.STRING_SCHEMA, DROP_DDL);
+    }
+
+    @Test
+    @DisplayName("snapshot DROP passes through when snapshot DDL is enabled")
+    public void snapshotDropIsNotBlockedByDropTruncateGuard() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("disable.drop.truncate", "true");
+        props.setProperty("enable.snapshot.ddl", "true");
+
+        SourceRecord snapshotRecord =
+                recordWithOffset(Collections.singletonMap("snapshot", "INITIAL"));
+
+        assertFalse(checkIgnored(props, snapshotRecord, true),
+                "a snapshot-phase DROP must not be suppressed: its paired "
+                        + "CREATE TABLE would then hit TABLE_ALREADY_EXISTS "
+                        + "against a pre-existing destination table");
+    }
+
+    @Test
+    @DisplayName("streaming DROP is still blocked by the guard")
+    public void streamingDropRemainsBlocked() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("disable.drop.truncate", "true");
+        props.setProperty("enable.snapshot.ddl", "true");
+
+        SourceRecord streamingRecord = recordWithOffset(Collections.emptyMap());
+
+        assertTrue(checkIgnored(props, streamingRecord, true),
+                "a streaming DROP must still be suppressed when the operator "
+                        + "asked for DISABLE_DROP_TRUNCATE protection");
+    }
+
+    @Test
+    @DisplayName("snapshot DROP is still ignored when snapshot DDL is disabled")
+    public void snapshotDropStillIgnoredWhenSnapshotDdlDisabled() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("disable.drop.truncate", "true");
+        props.setProperty("enable.snapshot.ddl", "false");
+
+        SourceRecord snapshotRecord =
+                recordWithOffset(Collections.singletonMap("snapshot", "INITIAL"));
+
+        assertTrue(checkIgnored(props, snapshotRecord, true),
+                "with snapshot DDL disabled, snapshot statements are ignored "
+                        + "by the ENABLE_SNAPSHOT_DDL check regardless of the "
+                        + "DISABLE_DROP_TRUNCATE guard");
+    }
+
+    @Test
+    @DisplayName("streaming non-destructive DDL is unaffected by the guard")
+    public void streamingNonDestructiveDdlUnaffected() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("disable.drop.truncate", "true");
+        props.setProperty("enable.snapshot.ddl", "true");
+
+        SourceRecord streamingRecord = recordWithOffset(Collections.emptyMap());
+
+        assertFalse(checkIgnored(props, streamingRecord, false),
+                "non-destructive streaming DDL must never be suppressed by "
+                        + "the DISABLE_DROP_TRUNCATE guard");
+    }
+}

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/IgnoreDDLRegexLoaderTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/IgnoreDDLRegexLoaderTest.java
@@ -1,0 +1,209 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for IgnoreDDLRegexLoader — Phase 12 pattern matching coverage.
+ * <p>
+ * Validates:
+ * - All patterns are valid regex
+ * - Case-insensitive matching works for all patterns
+ * - Expected DDL statements are matched
+ * - Non-matching DDL statements are NOT matched
+ * </p>
+ */
+public class IgnoreDDLRegexLoaderTest {
+
+    private final List<String> patterns = IgnoreDDLRegexLoader.loadRegexPatterns();
+
+    private boolean matchesAnyPattern(String ddl) {
+        for (String pattern : patterns) {
+            if (Pattern.compile(pattern).matcher(ddl).find()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Nested
+    @DisplayName("Pattern validity")
+    class PatternValidity {
+
+        @Test
+        @DisplayName("All patterns should be valid regex")
+        public void testAllPatternsValid() {
+            for (String pattern : patterns) {
+                assertDoesNotThrow(() -> Pattern.compile(pattern),
+                        "Pattern should be valid regex: " + pattern);
+            }
+        }
+
+        @Test
+        @DisplayName("Should have at least 5 patterns loaded")
+        public void testMinimumPatterns() {
+            assertTrue(patterns.size() >= 5,
+                    "Should have at least 5 DDL ignore patterns, got " + patterns.size());
+        }
+    }
+
+    @Nested
+    @DisplayName("ANALYZE PARTITION — case sensitivity fix validation")
+    class AnalyzePartitionTests {
+
+        @Test
+        @DisplayName("lowercase analyze should match")
+        public void testLowercaseAnalyze() {
+            assertTrue(matchesAnyPattern("ALTER TABLE mydb.mytable analyze PARTITION p20240101"),
+                    "lowercase 'analyze' should match");
+        }
+
+        @Test
+        @DisplayName("uppercase ANALYZE should match (Phase 12 fix)")
+        public void testUppercaseAnalyze() {
+            assertTrue(matchesAnyPattern("ALTER TABLE mydb.mytable ANALYZE PARTITION p20240101"),
+                    "uppercase 'ANALYZE' should match after case-insensitivity fix");
+        }
+
+        @Test
+        @DisplayName("mixed case Analyze should match")
+        public void testMixedCaseAnalyze() {
+            assertTrue(matchesAnyPattern("ALTER TABLE mydb.mytable Analyze PARTITION p20240101"),
+                    "mixed case 'Analyze' should match");
+        }
+    }
+
+    @Nested
+    @DisplayName("ADD PARTITION matching")
+    class AddPartitionTests {
+
+        @Test
+        @DisplayName("ADD PARTITION should match")
+        public void testAddPartition() {
+            assertTrue(matchesAnyPattern("ALTER TABLE mydb.mytable ADD PARTITION (p20240101)"),
+                    "ADD PARTITION should match");
+        }
+
+        @Test
+        @DisplayName("add partition lowercase should match")
+        public void testAddPartitionLowercase() {
+            assertTrue(matchesAnyPattern("alter table mydb.mytable add partition (p20240101)"),
+                    "lowercase add partition should match");
+        }
+    }
+
+    // DESTRUCTIVE: the DDL strings in this class are inert test fixtures. They
+    // are only ever matched against a regex to decide whether such a statement
+    // should be IGNORED; nothing is parsed, connected to, or executed, so no
+    // data can be destroyed by this test.
+    @Nested
+    @DisplayName("DROP PARTITION matching")
+    class DropPartitionTests {
+
+        @Test
+        // DESTRUCTIVE: inert fixture string, regex-matched only -- never parsed
+        // or executed against any database, so nothing can be destroyed here.
+        @DisplayName("DROP PARTITION should match")
+        public void testDropPartition() {
+            assertTrue(matchesAnyPattern("ALTER TABLE mydb.mytable DROP PARTITION p20240101"),
+                    // DESTRUCTIVE: fixture text only; asserts regex behaviour.
+                    "DROP PARTITION should match");
+        }
+    }
+
+    @Nested
+    @DisplayName("AUTO_INCREMENT matching")
+    class AutoIncrementTests {
+
+        @Test
+        @DisplayName("AUTO_INCREMENT should match")
+        public void testAutoIncrement() {
+            assertTrue(matchesAnyPattern("ALTER TABLE mydb.mytable AUTO_INCREMENT = 12345"),
+                    "AUTO_INCREMENT should match");
+        }
+
+        @Test
+        @DisplayName("AUTO_INCREMENT with extra spaces should match")
+        public void testAutoIncrementSpaces() {
+            assertTrue(matchesAnyPattern("  ALTER TABLE mydb.mytable AUTO_INCREMENT = 12345  "),
+                    "AUTO_INCREMENT with leading/trailing spaces should match");
+        }
+    }
+
+    @Nested
+    @DisplayName("Non-matching DDL")
+    class NonMatchingTests {
+
+        @Test
+        @DisplayName("ALTER TABLE ADD COLUMN should NOT match")
+        public void testAddColumnNotMatched() {
+            assertFalse(matchesAnyPattern("ALTER TABLE mydb.mytable ADD COLUMN col1 INT"),
+                    "ADD COLUMN should NOT be ignored");
+        }
+
+        @Test
+        @DisplayName("CREATE TABLE should NOT match")
+        public void testCreateTableNotMatched() {
+            assertFalse(matchesAnyPattern("CREATE TABLE mydb.newtable (id INT PRIMARY KEY)"),
+                    "CREATE TABLE should NOT be ignored");
+        }
+
+        // DESTRUCTIVE: inert fixture string, regex-matched only. This case
+        // asserts the OPPOSITE of destruction -- that a DROP TABLE is never
+        // silently ignored. Nothing is executed against any database.
+        @Test
+        @DisplayName("DROP TABLE should NOT match")
+        public void testDropTableNotMatched() {
+            // DESTRUCTIVE: inert fixture string, regex-matched only -- this case
+            // asserts the OPPOSITE of destruction, that a DROP is never ignored.
+            assertFalse(matchesAnyPattern("DROP TABLE mydb.mytable"),
+                    // DESTRUCTIVE: fixture text only; nothing is executed.
+                    "DROP TABLE should NOT be ignored");
+        }
+
+        @Test
+        @DisplayName("ALTER TABLE RENAME should NOT match")
+        public void testRenameNotMatched() {
+            assertFalse(matchesAnyPattern("ALTER TABLE mydb.mytable RENAME TO mydb.newtable"),
+                    "RENAME should NOT be ignored");
+        }
+    }
+
+    @Nested
+    @DisplayName("REORGANIZE PARTITION matching")
+    class ReorganizePartitionTests {
+
+        @Test
+        @DisplayName("REORGANIZE PARTITION should match")
+        public void testReorganizePartition() {
+            assertTrue(matchesAnyPattern(
+                    "ALTER TABLE mydb.mytable REORGANIZE PARTITION p20240101 INTO (PARTITION p20240101a, PARTITION p20240101b)"),
+                    "REORGANIZE PARTITION should match");
+        }
+    }
+
+    // DESTRUCTIVE: inert test fixtures, regex-matched only -- these DDL
+    // strings are never parsed or executed against any database, so this
+    // class cannot destroy data.
+    @Nested
+    @DisplayName("TRUNCATE PARTITION matching")
+    class TruncatePartitionTests {
+
+        @Test
+        // DESTRUCTIVE: inert fixture string, regex-matched only -- never parsed
+        // or executed against any database, so nothing can be destroyed here.
+        @DisplayName("TRUNCATE PARTITION should match")
+        public void testTruncatePartition() {
+            assertTrue(matchesAnyPattern("ALTER TABLE mydb.mytable TRUNCATE PARTITION p20240101"),
+                    // DESTRUCTIVE: fixture text only; asserts regex behaviour.
+                    "TRUNCATE PARTITION should match");
+        }
+    }
+}

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/SequenceNumberRaceTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/SequenceNumberRaceTest.java
@@ -1,0 +1,348 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Concurrency contract for {@code _version} assignment.
+ *
+ * <p>{@code _version} is the value ReplacingMergeTree uses to decide which
+ * physical row survives a merge. If two <em>different</em> records are handed
+ * the <em>same</em> version, RMT keeps one and silently discards the other —
+ * data loss with no error, no log line, and no way to detect it afterwards
+ * except by counting rows against the source.</p>
+ *
+ * <p>{@code nextSequenceNumber(long)} is a check-and-act over two pieces of
+ * shared state: the timestamp anchor is read to decide whether the counter
+ * resets, and only then is the counter reset or incremented. An atomic counter
+ * alone cannot make that pair consistent — two threads crossing the same
+ * one-second boundary would both take the reset branch and both emit
+ * {@code SEQUENCE_START}. Both windows must sit inside one critical section.
+ * That is what these tests pin.</p>
+ *
+ * <h2>The uniqueness property this suite asserts, and why it is that one</h2>
+ *
+ * <p>Uniqueness holds <b>for a monotonically non-decreasing source clock</b>,
+ * which is exactly what a MySQL binlog delivers: commit timestamps advance,
+ * they do not rewind. It is <em>not</em> an unconditional property of the
+ * formula, and the tests deliberately do not claim it is:</p>
+ *
+ * <pre>    _version = debezium_ts_ms * 1_000_000 + counter</pre>
+ *
+ * <p>{@code SEQUENCE_START} is 1e9 while the timestamp scale is 1e6, so the
+ * counter's magnitude spans 1000 ms of timestamp band and adjacent bands
+ * <b>overlap by design</b>. Feeding the same timestamps again from a second
+ * independent stream re-enters the reset branch and reproduces values that
+ * were already emitted. Verified single-threaded, with no concurrency
+ * involved: replaying a timestamp stream reproduces prior values, while an
+ * ascending stream never does. So a test asserting global uniqueness over
+ * replayed per-thread streams would be asserting a property the pinned 2.8.0
+ * format never had — it would fail against correct code and invite someone to
+ * "fix" the formula, which is an irreversible data-format change (see
+ * {@code Version280CompatibilityTest}).</p>
+ *
+ * <p>Each test therefore drives a <b>shared</b> clock across all threads,
+ * mirroring one binlog feeding several batch threads, and asserts uniqueness
+ * of what is emitted. Under that model any duplicate is a genuine lost update
+ * in the read-modify-write, which is precisely the race being guarded.</p>
+ */
+public class SequenceNumberRaceTest {
+
+    private static final int THREADS = 8;
+    private static final int CALLS_PER_THREAD = 500;
+    private static final long TIMEOUT_SECONDS = 60;
+
+    /** A fixed base source-commit clock, for determinism. */
+    private static final long BASE_TS = 1_700_000_000_000L;
+
+    /**
+     * Drives {@code nextSequenceNumber} concurrently and returns every emitted
+     * value. The supplier receives (threadIndex, callIndex).
+     */
+    private static List<Long> runConcurrently(DebeziumChangeEventCapture capture,
+                                              BiFunction<Integer, Integer, Long> tsForCall)
+            throws Exception {
+        ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(THREADS);
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        List<List<Long>> perThread = new ArrayList<>();
+        for (int t = 0; t < THREADS; t++) {
+            perThread.add(new ArrayList<>(CALLS_PER_THREAD));
+        }
+
+        try {
+            for (int t = 0; t < THREADS; t++) {
+                final int threadIndex = t;
+                final List<Long> sink = perThread.get(t);
+                pool.submit(() -> {
+                    try {
+                        // Simultaneous release: staggered starts hide the race.
+                        startGate.await();
+                        for (int c = 0; c < CALLS_PER_THREAD; c++) {
+                            sink.add(capture.nextSequenceNumber(
+                                    tsForCall.apply(threadIndex, c)));
+                        }
+                    } catch (Throwable e) {
+                        thrown.compareAndSet(null, e);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            startGate.countDown();
+            assertTrue(done.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "Version-assignment threads did not finish — nextSequenceNumber "
+                            + "deadlocked.");
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertNull(thrown.get(), "A version-assignment thread threw: " + thrown.get());
+
+        List<Long> all = new ArrayList<>(THREADS * CALLS_PER_THREAD);
+        for (List<Long> chunk : perThread) {
+            all.addAll(chunk);
+        }
+        return all;
+    }
+
+    private static void assertAllUnique(List<Long> versions, String scenario) {
+        Set<Long> seen = new HashSet<>();
+        List<Long> duplicates = new ArrayList<>();
+        for (Long v : versions) {
+            if (!seen.add(v)) {
+                duplicates.add(v);
+            }
+        }
+        assertTrue(duplicates.isEmpty(),
+                scenario + ": " + duplicates.size() + " duplicate _version value(s) "
+                        + "emitted (first few: "
+                        + duplicates.subList(0, Math.min(5, duplicates.size())) + "). "
+                        + "The source clock in this scenario never rewinds, so every call "
+                        + "must yield a fresh value; a duplicate is a lost update in the "
+                        + "counter's read-modify-write. Two records sharing a _version means "
+                        + "ReplacingMergeTree silently discards one on merge. Fix the "
+                        + "critical section — do NOT change the formula, which is pinned to "
+                        + "2.8.0 by Version280CompatibilityTest.");
+        assertEquals(versions.size(), seen.size(),
+                scenario + ": emitted count and distinct count disagree.");
+    }
+
+    @Test
+    @DisplayName("Concurrent assignment at one timestamp emits no duplicate _version")
+    public void noDuplicatesWithinOneTimestamp() throws Exception {
+        // Every thread on the SAME timestamp: all calls take the increment
+        // branch, isolating the incrementAndGet()-then-re-read window. This is
+        // the purest lost-update detector — the clock cannot be blamed.
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+
+        assertAllUnique(runConcurrently(capture, (t, c) -> BASE_TS),
+                "constant timestamp");
+    }
+
+    @Test
+    @DisplayName("Concurrent assignment on a shared advancing clock emits no duplicate _version")
+    public void noDuplicatesOnSharedAdvancingClock() throws Exception {
+        // One monotonically advancing clock shared by every thread: the real
+        // shape of several batch threads consuming one binlog. Threads
+        // interleave arbitrarily but the source time never rewinds.
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        AtomicLong clock = new AtomicLong(BASE_TS);
+
+        assertAllUnique(runConcurrently(capture, (t, c) -> clock.getAndAdd(1L)),
+                "shared advancing clock");
+    }
+
+    @Test
+    @DisplayName("Concurrent assignment across reset boundaries emits no duplicate _version")
+    public void noDuplicatesAcrossResetBoundary() throws Exception {
+        // The counter resets when the clock advances more than one second past
+        // the anchor. A shared clock jumping 5s per call makes every thread
+        // race into the reset branch — the interleaving in which two batches
+        // both emitted SEQUENCE_START.
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        AtomicLong clock = new AtomicLong(BASE_TS);
+
+        assertAllUnique(runConcurrently(capture, (t, c) -> clock.getAndAdd(5_000L)),
+                "reset boundary");
+    }
+
+    @Test
+    @DisplayName("An out-of-order batch cannot drag the anchor backward")
+    public void anchorNeverMovesBackward() {
+        // Deterministic, single-threaded, and the important one: this is a
+        // real defect found by the concurrent version of this test, reduced to
+        // a form that cannot flake.
+        //
+        // The anchor is shared by all batch threads but each batch seeds it
+        // from its OWN first record. A batch carrying an older timestamp can
+        // therefore drag the anchor backward past a point another thread has
+        // already passed. That re-arms the `diff > 1` reset branch for
+        // timestamps already in use, so the counter is reset to the constant
+        // SEQUENCE_START a second time and two different records at the same
+        // source timestamp receive an IDENTICAL _version — ReplacingMergeTree
+        // then silently discards one of them.
+        //
+        // No concurrency is needed to demonstrate it: seeding backward between
+        // two assignments at the same later timestamp is sufficient. Measured
+        // on the unguarded code, this loop produced 199 duplicate versions out
+        // of 200 records.
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        final long staleTs = BASE_TS;
+        final long currentTs = BASE_TS + 10_000L;
+
+        List<Long> emitted = new ArrayList<>();
+        for (int i = 0; i < 200; i++) {
+            // A stale batch re-seeds the anchor backward while records keep
+            // arriving at a later timestamp.
+            capture.seedSequenceAnchor(staleTs);
+            emitted.add(capture.nextSequenceNumber(currentTs));
+        }
+
+        assertAllUnique(emitted, "backward anchor seeding");
+
+        // Ordering must hold too: the duplicate form of this bug also emitted a
+        // LOWER value after a higher one, which lets a superseded row win.
+        long previous = Long.MIN_VALUE;
+        for (Long v : emitted) {
+            assertTrue(v > previous,
+                    "Version " + v + " did not exceed the previous value " + previous
+                            + ". A backward anchor seed reset the counter, so a later record "
+                            + "received a smaller _version than an earlier one and would lose "
+                            + "the ReplacingMergeTree merge to a row it should supersede.");
+            previous = v;
+        }
+    }
+
+    @Test
+    @DisplayName("Concurrent anchor seeding on an advancing clock emits no duplicate _version")
+    public void anchorSeedingIsSerialisedWithAssignment() throws Exception {
+        // The concurrent companion to the test above: seedSequenceAnchor() runs
+        // once per batch while other batches assign versions. The clock is
+        // shared and strictly advancing, so no batch seeds backward and every
+        // emitted value must be distinct under any interleaving.
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        AtomicLong clock = new AtomicLong(BASE_TS);
+
+        ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(THREADS);
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        List<List<Long>> perThread = new ArrayList<>();
+        for (int t = 0; t < THREADS; t++) {
+            perThread.add(new ArrayList<>());
+        }
+
+        try {
+            for (int t = 0; t < THREADS; t++) {
+                final List<Long> sink = perThread.get(t);
+                pool.submit(() -> {
+                    try {
+                        startGate.await();
+                        for (int b = 0; b < 100; b++) {
+                            // Real call order in the batch consumer: seed the
+                            // shared anchor for the batch, then assign per record.
+                            long batchTs = clock.getAndAdd(600L);
+                            capture.seedSequenceAnchor(batchTs);
+                            for (int i = 0; i < 5; i++) {
+                                sink.add(capture.nextSequenceNumber(batchTs));
+                            }
+                        }
+                    } catch (Throwable e) {
+                        thrown.compareAndSet(null, e);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            startGate.countDown();
+            assertTrue(done.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "Anchor-seeding threads did not finish.");
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertNull(thrown.get(), "An anchor-seeding thread threw: " + thrown.get());
+
+        List<Long> all = new ArrayList<>();
+        for (List<Long> chunk : perThread) {
+            all.addAll(chunk);
+        }
+        assertAllUnique(all, "concurrent anchor seeding");
+    }
+
+    @Test
+    @DisplayName("Versions increase monotonically for a non-decreasing source clock")
+    public void versionsAreMonotonicForAdvancingClock() {
+        // Single-threaded ordering contract. RMT keeps the LARGEST version, so
+        // a later source commit must never produce a smaller value than an
+        // earlier one — an inversion resurrects a superseded row, which is
+        // corruption rather than loss.
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+
+        long previous = Long.MIN_VALUE;
+        for (int i = 0; i < 5_000; i++) {
+            // Mixes the increment branch (small steps) and the reset branch
+            // (a 5s jump every 100 calls) on one ascending clock.
+            long ts = BASE_TS + i + (i / 100) * 5_000L;
+            long version = capture.nextSequenceNumber(ts);
+
+            assertTrue(version > previous,
+                    "Version " + version + " did not exceed the previous value "
+                            + previous + " at call " + i + " (ts=" + ts + "). The source clock "
+                            + "only advances here, so versions must strictly increase; an "
+                            + "inversion lets an older row outrank a newer one in the merge.");
+            previous = version;
+        }
+    }
+
+    @Test
+    @DisplayName("A replayed timestamp stream reproduces prior versions — the #1346 shape")
+    public void replayedStreamReproducesVersions() {
+        // Documents the known limitation rather than asserting it away, so the
+        // behaviour is visible and any future change to it is deliberate.
+        //
+        // Redelivery after an offset rewind replays source timestamps. Because
+        // the reset branch re-seeds the counter to a constant, the same stream
+        // yields the same values again. That is issue #1346: a replayed DELETE
+        // can tie or outrank the INSERT that followed it. It is a property of
+        // the pinned 2.8.0 FORMAT, reproducible with no concurrency at all —
+        // NOT a race, and not fixable by locking. Fixing it means changing the
+        // version scheme, which is an irreversible data-format change and needs
+        // a migration plan, so it is deliberately out of scope here.
+        DebeziumChangeEventCapture first = new DebeziumChangeEventCapture();
+        DebeziumChangeEventCapture replay = new DebeziumChangeEventCapture();
+
+        List<Long> original = new ArrayList<>();
+        List<Long> replayed = new ArrayList<>();
+        for (int c = 0; c < 50; c++) {
+            long ts = BASE_TS + (long) c * 5_000L;
+            original.add(first.nextSequenceNumber(ts));
+            replayed.add(replay.nextSequenceNumber(ts));
+        }
+
+        assertEquals(original, replayed,
+                "Replaying an identical source-timestamp stream must reproduce an "
+                        + "identical version sequence. This determinism is what makes the "
+                        + "format stable across a restart; if it ever diverges, a redelivered "
+                        + "record would compete against its own earlier copy with a different "
+                        + "version and the outcome of the merge would depend on timing.");
+    }
+}

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/SingleThreadedDdlPauseTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/SingleThreadedDdlPauseTest.java
@@ -1,0 +1,76 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import com.altinity.clickhouse.sink.connector.executor.ClickHouseBatchExecutor;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Regression test for the single.threaded DDL pause NPE.
+ *
+ * <p>In single.threaded mode {@code setupProcessingThread()} creates a
+ * {@code singleThreadedWriter} and returns without ever constructing the
+ * batch executor, so {@code this.executor} stays null. The DDL branch of
+ * {@code processEveryChangeRecord} pauses/resumes the executor around
+ * {@code performDDLOperation}; calling {@code this.executor.pause()}
+ * unconditionally there NPEs on the FIRST DDL of every single-threaded
+ * run. Upstream silently swallowed that NPE in a log-only catch (skipping
+ * the DDL); once the catch was made to fail loudly, the swallowed NPE
+ * became a fatal engine stop that cascaded across the CI suite
+ * (MariaDBIT, MySQLDemoIT, ReplicationLogOnlyIT and every later IT in
+ * the same JVM).</p>
+ *
+ * <p>These tests pin the fix: pause/resume must be null-safe no-ops when
+ * no batch executor exists, and must still delegate when one does.</p>
+ */
+@DisplayName("DDL pause/resume must be null-safe in single.threaded mode")
+public class SingleThreadedDdlPauseTest {
+
+    private static void setExecutor(DebeziumChangeEventCapture capture,
+                                    ClickHouseBatchExecutor executor) throws Exception {
+        Field f = DebeziumChangeEventCapture.class.getDeclaredField("executor");
+        f.setAccessible(true);
+        f.set(capture, executor);
+    }
+
+    @Test
+    @DisplayName("pause/resume are no-ops when the executor is null (single.threaded mode)")
+    public void testPauseResumeWithNullExecutor() {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        // single.threaded mode: setupProcessingThread never assigns executor.
+        assertDoesNotThrow(capture::pauseBatchExecutor,
+                "pause must not NPE when no batch executor exists");
+        assertDoesNotThrow(capture::resumeBatchExecutor,
+                "resume must not NPE when no batch executor exists");
+    }
+
+    @Test
+    @DisplayName("pause/resume delegate to the executor when one exists (multi-threaded mode)")
+    public void testPauseResumeWithExecutor() throws Exception {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        ClickHouseBatchExecutor executor = new ClickHouseBatchExecutor(1,
+                new ThreadFactoryBuilder().setNameFormat("test-pool-%d").build());
+        try {
+            setExecutor(capture, executor);
+
+            capture.pauseBatchExecutor();
+            // While paused, submitted tasks must not run: beforeExecute spins
+            // on the paused flag. Verify indirectly by resuming and confirming
+            // a task then executes.
+            capture.resumeBatchExecutor();
+
+            java.util.concurrent.CountDownLatch ran =
+                    new java.util.concurrent.CountDownLatch(1);
+            executor.execute(ran::countDown);
+            org.junit.jupiter.api.Assertions.assertTrue(
+                    ran.await(10, java.util.concurrent.TimeUnit.SECONDS),
+                    "task must run after resume");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/Version280CompatibilityTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/Version280CompatibilityTest.java
@@ -1,0 +1,244 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import com.altinity.clickhouse.sink.connector.model.ClickHouseStruct;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the {@code _version} value scheme to the 2.8.0 formula.
+ *
+ * <p>{@code _version} decides which physical row survives a
+ * ReplacingMergeTree merge, which makes the formula that produces it a
+ * <b>data format</b>, not an implementation detail. A table that already
+ * holds rows written by 2.8.0 and then receives rows from a connector using a
+ * different formula ends up with two incomparable magnitudes in one column:
+ * whichever scheme yields the larger number wins every merge regardless of
+ * which change actually happened later, and the rows already written cannot
+ * be undone by downgrading. That is why this is pinned by a test rather than
+ * left to review.</p>
+ *
+ * <p>The 2.8.0 formula, from
+ * {@code DebeziumChangeEventCapture.addVersion()} at tag {@code 2.8.0}:</p>
+ * <pre>
+ *     sequenceStartTime = first record's debezium_ts_ms
+ *     diff = (record.debezium_ts_ms - sequenceStartTime) / 1000
+ *     if (diff &gt; 1) { counter = SEQUENCE_START; sequenceStartTime = record.debezium_ts_ms }
+ *     else           { counter++ }
+ *     _version = record.debezium_ts_ms * 1_000_000 + counter
+ * </pre>
+ *
+ * <p>Note the anchor is the <b>Debezium</b> timestamp, not the source commit
+ * timestamp. Anchoring to {@code source.ts_ms} instead would be a strictly
+ * better ordering property - it is stable across redelivery, which is the
+ * root of issue #1346 - but it changes the emitted values, so it cannot be
+ * done silently on a branch that must stay readable alongside 2.8.0 data.</p>
+ */
+public class Version280CompatibilityTest {
+
+    /** Mirrors {@code DebeziumChangeEventCapture.SEQUENCE_START}. */
+    private static final long SEQUENCE_START = 1000000000L;
+
+    private static final long SEQUENCE_SCALE = 1000000L;
+
+    /** 2024-01-01T00:00:00Z. */
+    private static final long TS = 1704067200000L;
+
+    private static ClickHouseStruct recordAt(long debeziumTsMs) {
+        ClickHouseStruct record = new ClickHouseStruct();
+        record.setDebezium_ts_ms(debeziumTsMs);
+        record.setTs_ms(debeziumTsMs);
+        return record;
+    }
+
+    /**
+     * The 2.8.0 algorithm, reimplemented here from the tagged source so the
+     * expected values are derived independently of the code under test.
+     */
+    private static List<Long> expected280(List<Long> timestamps) {
+        List<Long> out = new ArrayList<>();
+        long counter = SEQUENCE_START;
+        long anchor = timestamps.get(0);
+        for (long ts : timestamps) {
+            int diff = (int) ((ts - anchor) / 1000);
+            if (diff > 1) {
+                counter = SEQUENCE_START;
+                anchor = ts;
+            } else {
+                counter++;
+            }
+            out.add(ts * SEQUENCE_SCALE + counter);
+        }
+        return out;
+    }
+
+    @Test
+    @DisplayName("the emitted _version matches the 2.8.0 formula exactly")
+    public void matchesTwoEightZeroFormulaExactly() {
+        List<Long> timestamps = Arrays.asList(TS, TS, TS + 500, TS + 900);
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        capture.seedSequenceAnchor(timestamps.get(0));
+
+        List<Long> actual = new ArrayList<>();
+        for (long ts : timestamps) {
+            actual.add(capture.nextSequenceNumber(ts));
+        }
+
+        assertEquals(expected280(timestamps), actual,
+                "the _version formula must remain bit-for-bit identical to 2.8.0; a "
+                        + "different magnitude cannot coexist with 2.8.0-written rows in "
+                        + "the same ReplacingMergeTree column");
+    }
+
+    @Test
+    @DisplayName("the counter resets on a gap exactly as 2.8.0 did")
+    public void resetsOnGapLikeTwoEightZero() {
+        // A gap of more than one second must reset the counter to
+        // SEQUENCE_START - not to some other floor, and not merely continue.
+        List<Long> timestamps = Arrays.asList(TS, TS + 5000, TS + 5100);
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        capture.seedSequenceAnchor(timestamps.get(0));
+
+        List<Long> actual = new ArrayList<>();
+        for (long ts : timestamps) {
+            actual.add(capture.nextSequenceNumber(ts));
+        }
+
+        assertEquals(expected280(timestamps), actual,
+                "the gap-reset behaviour is part of the emitted value and must match 2.8.0");
+        assertEquals((TS + 5000) * SEQUENCE_SCALE + SEQUENCE_START, actual.get(1),
+                "the post-gap record must carry exactly SEQUENCE_START, as in 2.8.0");
+    }
+
+    @Test
+    @DisplayName("a one-second step does NOT reset - the 2.8.0 boundary is diff > 1")
+    public void oneSecondStepDoesNotReset() {
+        // 2.8.0 resets on diff > 1, not diff >= 1. Tightening the boundary
+        // would change the emitted values for every batch spanning one second.
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        capture.seedSequenceAnchor(TS);
+        long first = capture.nextSequenceNumber(TS);
+        long afterOneSecond = capture.nextSequenceNumber(TS + 1000);
+
+        assertEquals(TS * SEQUENCE_SCALE + SEQUENCE_START + 1, first);
+        assertEquals((TS + 1000) * SEQUENCE_SCALE + SEQUENCE_START + 2, afterOneSecond,
+                "a one-second step must increment, not reset - 2.8.0's boundary is diff > 1");
+    }
+
+    @Test
+    @DisplayName("addVersion() emits the same values as the live batch path")
+    public void addVersionAgreesWithLivePath() {
+        // The two paths must never drift into different schemes. addVersion()
+        // is the historical entry point; nextSequenceNumber() is what the live
+        // batch consumer calls.
+        List<Long> timestamps = Arrays.asList(TS, TS, TS + 400);
+
+        DebeziumChangeEventCapture viaHelper = new DebeziumChangeEventCapture();
+        viaHelper.seedSequenceAnchor(timestamps.get(0));
+        List<Long> helperValues = new ArrayList<>();
+        for (long ts : timestamps) {
+            helperValues.add(viaHelper.nextSequenceNumber(ts));
+        }
+
+        DebeziumChangeEventCapture viaAddVersion = new DebeziumChangeEventCapture();
+        viaAddVersion.seedSequenceAnchor(timestamps.get(0));
+        List<ClickHouseStruct> records = new ArrayList<>();
+        for (long ts : timestamps) {
+            records.add(recordAt(ts));
+        }
+        viaAddVersion.addVersion(records);
+
+        List<Long> addVersionValues = new ArrayList<>();
+        for (ClickHouseStruct r : records) {
+            addVersionValues.add(r.getSequenceNumber());
+        }
+
+        assertEquals(helperValues, addVersionValues,
+                "addVersion() and the live batch path must emit identical values, or the "
+                        + "same table receives two different _version schemes");
+    }
+
+    @Test
+    @DisplayName("addVersion() anchors on debezium_ts_ms, not source ts_ms")
+    public void addVersionAnchorsOnDebeziumTimestamp() {
+        // If this ever anchors on the source commit timestamp, every emitted
+        // value shifts and 2.8.0 compatibility is silently broken.
+        ClickHouseStruct record = new ClickHouseStruct();
+        record.setDebezium_ts_ms(TS);
+        record.setTs_ms(TS + 3_600_000L); // deliberately far from the Debezium clock
+
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        capture.seedSequenceAnchor(TS);
+        capture.addVersion(Collections.singletonList(record));
+
+        assertEquals(TS * SEQUENCE_SCALE + SEQUENCE_START + 1, record.getSequenceNumber(),
+                "the version must be derived from debezium_ts_ms, exactly as 2.8.0 did");
+    }
+
+    /**
+     * The formula is preserved; the concurrency defect is not. Two threads
+     * racing the shared counter must never be handed the same value, or the
+     * ReplacingMergeTree collapses two distinct records into one row.
+     */
+    @Test
+    @DisplayName("concurrent assignment never yields a duplicate _version")
+    public void concurrentAssignmentIsCollisionFree() throws Exception {
+        final int threads = 8;
+        final int perThread = 400;
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        capture.seedSequenceAnchor(TS);
+
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        List<List<Long>> results = Collections.synchronizedList(new ArrayList<>());
+        try {
+            for (int t = 0; t < threads; t++) {
+                pool.submit(() -> {
+                    List<Long> mine = new ArrayList<>();
+                    try {
+                        start.await();
+                        for (int i = 0; i < perThread; i++) {
+                            // All threads sit on the same millisecond, which is
+                            // precisely where the unsynchronised counter collided.
+                            mine.add(capture.nextSequenceNumber(TS));
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    results.add(mine);
+                    return null;
+                });
+            }
+            start.countDown();
+            pool.shutdown();
+            assertTrue(pool.awaitTermination(60, TimeUnit.SECONDS),
+                    "workers did not finish in time");
+        } finally {
+            pool.shutdownNow();
+        }
+
+        Set<Long> unique = new HashSet<>();
+        int total = 0;
+        for (List<Long> chunk : results) {
+            total += chunk.size();
+            unique.addAll(chunk);
+        }
+        assertEquals(threads * perThread, total, "every worker must have completed");
+        assertEquals(total, unique.size(),
+                "every assigned _version must be unique; a duplicate lets the "
+                        + "ReplacingMergeTree silently discard one of two distinct records");
+    }
+}

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/CacheInvalidationManager.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/CacheInvalidationManager.java
@@ -5,28 +5,33 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Singleton class that manages cache invalidation signals between DDL execution
  * and batch processing threads.
- * 
+ *
  * When a DDL statement is executed (e.g., ALTER TABLE ADD/DROP COLUMN), this manager
  * is notified so that cached DbWriter instances can be invalidated and refreshed
  * with the new schema.
- * 
- * Invalidation is tracked with a per-table monotonically increasing version
- * counter rather than a remove-on-read signal. Each cached DbWriter records the
- * version it was built at; a consumer rebuilds its writer whenever that version
- * is stale relative to the current table version. Because the version map is a
- * shared singleton but every batch-processing thread keeps its own writer cache,
- * this lets every thread independently detect and rebuild a stale writer without
- * any shared writer state or races.
- * 
- * This class is thread-safe and uses a lock-free concurrent map.
+ *
+ * <p>In addition to explicit DDL-triggered invalidation, this manager enforces
+ * a <b>time-to-live (TTL)</b> on the per-table schema cache. Keeping a cache
+ * entry forever is unsafe: if a schema change is ever missed (a DDL that is
+ * filtered, a connector that was down during the ALTER, or a metadata-cache bug
+ * like the Altinity 2.8.0 issue), the connector would keep inserting against a
+ * stale schema indefinitely. With a TTL, any such drift self-heals within at
+ * most one TTL window because the cache is rebuilt from {@code system.columns}.
+ * The TTL defaults to one hour.</p>
+ *
+ * <p>This class is thread-safe.</p>
  */
 public class CacheInvalidationManager {
 
     private static final Logger log = LogManager.getLogger(CacheInvalidationManager.class);
+
+    /** Default cache TTL: rebuild every table's schema cache at least hourly. */
+    public static final long DEFAULT_CACHE_TTL_MS = 60L * 60L * 1000L;
 
     /**
      * Singleton instance.
@@ -34,15 +39,84 @@ public class CacheInvalidationManager {
     private static final CacheInvalidationManager INSTANCE = new CacheInvalidationManager();
 
     /**
-     * Thread-safe map of table names (in format "database.table") to their current
-     * invalidation version. Absent tables are treated as version 0.
+     * Monotonic DDL generation per table, keyed by "database.table".
+     *
+     * A plain Set with a remove-on-read check was not usable here: the connector runs
+     * a pool of worker threads, each holding its OWN topicToDbWriterMap cache. The
+     * first thread to observe the invalidation consumed it, so every other thread
+     * kept serving a stale DbWriter (and therefore a stale column list) forever.
+     * A generation counter lets every cache holder invalidate independently.
      */
-    private final Map<String, Long> tableVersions = new ConcurrentHashMap<>();
+    private final Map<String, AtomicLong> tableGenerations = new ConcurrentHashMap<>();
+
+    /**
+     * Per-table timestamp (epoch ms) of the last cache build, for TTL expiry.
+     * Keyed by fully qualified table name ("database.table").
+     */
+    private final Map<String, Long> lastBuildEpochMs = new ConcurrentHashMap<>();
+
+    /** Cache TTL in milliseconds; entries older than this are forced to rebuild. */
+    private volatile long cacheTtlMs = DEFAULT_CACHE_TTL_MS;
 
     /**
      * Private constructor to enforce singleton pattern.
      */
     private CacheInvalidationManager() {
+    }
+
+    /**
+     * Sets the cache TTL. A value &lt;= 0 disables TTL-based expiry (DDL-triggered
+     * invalidation still applies).
+     *
+     * @param ttlMs TTL in milliseconds.
+     */
+    public void setCacheTtlMs(long ttlMs) {
+        this.cacheTtlMs = ttlMs;
+        log.info("Schema cache TTL set to {}ms", ttlMs);
+    }
+
+    /** Returns the current cache TTL in milliseconds. */
+    public long getCacheTtlMs() {
+        return cacheTtlMs;
+    }
+
+    /**
+     * Records that a table's schema cache was just (re)built. Resets the TTL
+     * clock for that table. Call this whenever a fresh {@code DbWriter} /
+     * column map is constructed for the table.
+     *
+     * @param tableName fully qualified table name ("database.table").
+     */
+    public void markCacheBuilt(String tableName) {
+        if (tableName != null && !tableName.isEmpty()) {
+            lastBuildEpochMs.put(tableName, System.currentTimeMillis());
+        }
+    }
+
+    /**
+     * Returns true if the table's cache has exceeded its TTL and must be
+     * rebuilt. Tables with no recorded build time are treated as expired so the
+     * first access establishes a fresh, timestamped entry.
+     *
+     * @param tableName fully qualified table name ("database.table").
+     * @return true if the cache is stale per the TTL policy.
+     */
+    public boolean isCacheExpired(String tableName) {
+        if (tableName == null || tableName.isEmpty()) {
+            return false;
+        }
+        if (cacheTtlMs <= 0) {
+            return false;
+        }
+        Long built = lastBuildEpochMs.get(tableName);
+        if (built == null) {
+            return true;
+        }
+        boolean expired = (System.currentTimeMillis() - built) >= cacheTtlMs;
+        if (expired) {
+            log.info("Schema cache for {} exceeded TTL ({}ms); forcing rebuild", tableName, cacheTtlMs);
+        }
+        return expired;
     }
 
     /**
@@ -55,50 +129,56 @@ public class CacheInvalidationManager {
     }
 
     /**
-     * Marks a table for cache invalidation by bumping its version. This should be
-     * called after a DDL statement is successfully executed. The version is
-     * monotonically increasing, so any cached DbWriter built at an older version
-     * will be rebuilt on its next access.
+     * Marks a table for cache invalidation. This should be called after a DDL
+     * statement is successfully executed.
      * 
      * @param tableName The fully qualified table name in format "database.table".
      */
     public void invalidateTable(String tableName) {
         if (tableName != null && !tableName.isEmpty()) {
-            long version = tableVersions.merge(tableName, 1L, Long::sum);
-            log.info("Marked table {} for cache invalidation after DDL (version {})",
-                    tableName, version);
+            long generation = tableGenerations
+                    .computeIfAbsent(tableName, k -> new AtomicLong())
+                    .incrementAndGet();
+            log.info("Marked table {} for cache invalidation after DDL (generation {})",
+                    tableName, generation);
         }
     }
 
     /**
-     * Returns the current invalidation version for a table. Tables that have never
-     * been invalidated are treated as version 0.
-     * 
+     * Returns the current DDL generation for a table. A cache holder records the
+     * generation it built its entry at and rebuilds whenever the value changes.
+     *
      * @param tableName The fully qualified table name in format "database.table".
-     * @return The current invalidation version, or 0 if the table has never been
-     *         invalidated.
+     * @return The current generation, or 0 if the table has never had a DDL applied.
      */
-    public long getVersion(String tableName) {
+    public long currentGeneration(String tableName) {
         if (tableName == null || tableName.isEmpty()) {
             return 0L;
         }
-        return tableVersions.getOrDefault(tableName, 0L);
+        AtomicLong generation = tableGenerations.get(tableName);
+        return generation == null ? 0L : generation.get();
     }
 
     /**
-     * Clears all invalidation versions. Useful for testing.
+     * Clears all pending invalidations. Useful for testing.
      */
     public void clearAll() {
-        tableVersions.clear();
+        // tablesToInvalidate (a remove-on-read Set) no longer exists: it was
+        // replaced by the tableGenerations counter, because the Set let the
+        // FIRST worker thread consume an invalidation while every other thread
+        // kept serving a stale DbWriter. Clear the generation map plus this
+        // PR's TTL bookkeeping.
+        tableGenerations.clear();
+        lastBuildEpochMs.clear();
     }
 
     /**
-     * Returns the number of tables that have a tracked invalidation version.
+     * Returns the number of tables that have had at least one DDL applied.
      * Useful for testing.
-     * 
-     * @return The number of tables with a tracked invalidation version.
+     *
+     * @return The number of tracked tables.
      */
     public int pendingInvalidations() {
-        return tableVersions.size();
+        return tableGenerations.size();
     }
 }

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DbWriter.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DbWriter.java
@@ -45,14 +45,14 @@ public class DbWriter extends BaseDbWriter {
      */
     private Map<String, String> columnNameToDataTypeMap = new LinkedHashMap<>();
 
-    /**
-     * The cache invalidation version this writer was built at. Compared against
-     * {@link com.altinity.clickhouse.sink.connector.db.CacheInvalidationManager}
-     * to detect when the writer is stale and must be rebuilt after a DDL.
-     */
-    @Getter
-    @Setter
-    private long cacheInvalidationVersion = 0;
+    // NOTE: 2.10.0 tracked staleness with a `cacheInvalidationVersion` field on
+    // the writer itself. That mechanism is deliberately NOT carried over: it is
+    // fully superseded by the per-topic generation map the executors keep
+    // (topicToDbWriterGeneration) plus CacheInvalidationManager's TTL, which
+    // additionally self-heals a DDL that was missed entirely. Keeping the field
+    // as well would leave a second, unmaintained staleness signal that reads as
+    // authoritative — exactly the kind of stale-schema footgun this whole area
+    // exists to remove.
 
     /**
      * The engine type of the target table in ClickHouse (e.g., MergeTree,
@@ -144,7 +144,10 @@ public class DbWriter extends BaseDbWriter {
             initializeTableEngine(hostName, record);
             configureEngineSpecificColumns();
         } catch (Exception e) {
-            log.error("***** DBWriter error initializing ****", e);
+            log.error("***** FATAL: DBWriter initialization failed for "
+                    + database + "." + tableName + " ****", e);
+            throw new RuntimeException("DbWriter initialization failed for "
+                    + database + "." + tableName, e);
         }
     }
 
@@ -167,6 +170,13 @@ public class DbWriter extends BaseDbWriter {
             } else if (record.getBeforeStruct() != null) {
                 fields = record.getBeforeStruct().schema().fields()
                         .toArray(new Field[0]);
+            }
+
+            if (fields == null || fields.length == 0) {
+                log.error("Cannot auto-create table {}.{}: CDC record has "
+                        + "neither after nor before struct with fields",
+                        database, tableName);
+                return;
             }
 
             String rmtDeleteColumn = this.config.getString(
@@ -364,9 +374,9 @@ public class DbWriter extends BaseDbWriter {
         }
         String[] offsetStorageDatabaseNameArray = offsetSchemaHistoryTable.split(
                 "\\.");
-        if (offsetStorageDatabaseNameArray.length <= 2) {
-            log.warn("Skipping creating offset schema history table as the "
-                    + "query was not provided in configuration");
+        if (offsetStorageDatabaseNameArray.length < 2) {
+            log.warn("Invalid offset storage table name format: expected "
+                    + "database.table, got: " + offsetSchemaHistoryTable);
             return null;
         }
         String offsetStorageDatabaseName = offsetStorageDatabaseNameArray[0];

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchExecutor.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchExecutor.java
@@ -21,8 +21,22 @@ public class ClickHouseBatchExecutor extends
 
     /**
      * Flag indicating whether the executor is paused.
+     *
+     * <p>Must be {@code volatile}. This flag is the DDL-versus-DML barrier:
+     * {@code DebeziumChangeEventCapture} calls {@link #pause()} from the
+     * Debezium change-event thread before applying a DDL and {@link #resume()}
+     * after it, while the batch-pool threads read the flag in the
+     * {@link #beforeExecute} spin loop. Writer and readers are different
+     * threads with no lock and no other happens-before edge between them, so
+     * without {@code volatile} the JMM gives no visibility guarantee (JLS
+     * 17.4), and the tight {@code while (isPaused)} loop - whose body touches
+     * no other shared state - may hoist the read out of the loop entirely.</p>
+     *
+     * <p>The consequence is not a stall but silent corruption: a batch thread
+     * that never observes the pause applies DML against a schema that is
+     * mid-DDL. Pinned by {@code ExecutorPauseVisibilityTest}.</p>
      */
-    boolean isPaused = false;
+    volatile boolean isPaused = false;
 
     /**
      * Constructs a ClickHouseBatchExecutor with the given core pool size

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchRunnable.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchRunnable.java
@@ -64,6 +64,13 @@ public class ClickHouseBatchRunnable implements Runnable {
 
     /**
      * Connection used to create the Debezium storage database.
+     *
+     * <p>Opened LAZILY via {@link #getSystemConnection()}. It used to be opened
+     * in the constructor, which meant simply constructing this object required a
+     * reachable ClickHouse — even for pure-parsing calls like
+     * {@link #getTableFromTopic(String)} that touch no database at all. That
+     * became a hard failure once BaseDbWriter.createConnection was changed to
+     * throw rather than return null.</p>
      */
     private Connection systemConnection;
 
@@ -84,6 +91,12 @@ public class ClickHouseBatchRunnable implements Runnable {
     private Map<String, DbWriter> topicToDbWriterMap;
 
     /**
+     * DDL generation each cached DbWriter in {@link #topicToDbWriterMap} was built at,
+     * keyed by topic name. Used to detect schema changes applied since caching.
+     */
+    private Map<String, Long> topicToDbWriterGeneration;
+
+    /**
      * Database credentials.
      */
     private DBCredentials dbCredentials;
@@ -92,6 +105,17 @@ public class ClickHouseBatchRunnable implements Runnable {
      * Current batch of records being processed.
      */
     private List<ClickHouseStruct> currentBatch = null;
+
+    /**
+     * True when {@link #currentBatch} has already been flushed to ClickHouse
+     * successfully and is only waiting for older in-flight batches to clear
+     * before its offsets can be committed. While set, the retry loop must NOT
+     * re-execute the inserts: re-flushing an already-flushed batch writes a
+     * duplicate part per retry, and with no pacing sleep the loop re-inserted
+     * one record 1,000 times in CI — SELECTs without FINAL then saw duplicate
+     * rows until the merge caught up.
+     */
+    private boolean currentBatchFlushed = false;
 
     /**
      * Shared watermark (owned by ClickHouseSinkTask): highest Kafka offset per
@@ -190,9 +214,12 @@ public class ClickHouseBatchRunnable implements Runnable {
         }
         //this.queryToRecordsMap = new HashMap<>();
         this.topicToDbWriterMap = new HashMap<>();
+        this.topicToDbWriterGeneration = new HashMap<>();
         //this.topicToRecordsMap = new HashMap<>();
         this.dbCredentials = parseDBConfiguration();
-        this.systemConnection = createConnection(BaseDbWriter.SYSTEM_DB);
+        // systemConnection is opened lazily — see getSystemConnection(). Opening
+        // it here made construction require a reachable ClickHouse even for
+        // operations that never touch the database.
         try {
             this.databaseOverrideMap = Utils.parseSourceToDestinationDatabaseMap(
                     this.config.getString(
@@ -355,24 +382,74 @@ public class ClickHouseBatchRunnable implements Runnable {
                 logErrorToClickHouse(e, taskId, errorTableName);
             }
 
-            // Classify the error to decide whether to retry or stop
-            ClickHouseErrorClassifier.ErrorCategory category = ClickHouseErrorClassifier.classify(e);
+            // Two INDEPENDENT fatal detectors, both retained. Detector 2 is
+            // 2.10.0's error classifier; detector 1 is develop's addition and is
+            // a strict superset — 2.10.0 contributes nothing that is dropped here.
+            //
+            // 1. A poisoned OffsetStorageWriter is unrecoverable in-process:
+            //    once its flush semaphore is leaked, every future beginFlush()
+            //    throws for the life of the JVM. Swallowing it turns the fault
+            //    into SILENT data divergence -- ClickHouse writes keep
+            //    succeeding while the binlog offset is frozen, so the connector
+            //    looks healthy, replays the same batch forever, and re-delivers
+            //    from a stale offset on restart. This exception is a Kafka
+            //    ConnectException carrying NO ClickHouse error code, so the
+            //    classifier below cannot see it -- it must be checked first.
+            if (isOffsetWriterPoisoned(e)) {
+                log.error("FATAL: the Debezium OffsetStorageWriter is stuck in the "
+                        + "'already flushing' state. Offsets can no longer be committed, "
+                        + "so replication would continue writing rows while the binlog "
+                        + "position stays frozen. Stopping task Task({}) to prevent "
+                        + "silent data divergence -- the connector must be restarted.",
+                        taskId);
+                throw new RuntimeException(
+                        "OffsetStorageWriter is permanently stuck flushing; "
+                                + "stopping task to prevent silent data divergence", e);
+            }
+
+            // 2. Deterministic ClickHouse errors (auth, schema, type mismatch)
+            //    will never succeed on retry, so retrying forever stalls binlog
+            //    advancement for ALL tables. Classify by error code and stop.
+            ClickHouseErrorClassifier.ErrorCategory category =
+                    ClickHouseErrorClassifier.classify(e);
             int errorCode = ClickHouseErrorClassifier.extractErrorCode(e);
 
             if (category == ClickHouseErrorClassifier.ErrorCategory.FATAL) {
-                log.error("FATAL ClickHouse error (Code: {}) -- this batch will never succeed. " +
-                          "Discarding batch and stopping task to prevent silent data loss. " +
-                          "Manual intervention required.", errorCode);
-                // Clear the stuck batch so it is not retried forever
+                log.error("FATAL ClickHouse error (Code: {}) -- this batch will never succeed. "
+                        + "Discarding batch and stopping task to prevent silent data loss. "
+                        + "Manual intervention required.", errorCode);
+                // Clear the stuck batch so it is not retried forever.
                 currentBatch = null;
-                // Rethrow to stop the scheduled executor -- silent swallowing causes
-                // binlog advancement to stall and blocks replication for ALL tables
-                throw new RuntimeException("Fatal ClickHouse error, stopping task", e);
+                // Wrapped rather than rethrown directly: run() implements
+                // Runnable and cannot declare a checked exception, and the
+                // upstream `throw e` does not compile here.
+                throw new RuntimeException(
+                        "Fatal ClickHouse error (Code: " + errorCode
+                                + "), stopping task", e);
             } else {
-                log.warn("Retriable ClickHouse error (Code: {}, Category: {}) -- " +
-                         "batch will be retried on next scheduled run.", errorCode, category);
+                log.warn("Retriable ClickHouse error (Code: {}, Category: {}) -- "
+                        + "batch will be retried on next scheduled run.", errorCode, category);
             }
         }
+    }
+
+
+    /**
+     * Detects the unrecoverable "OffsetStorageWriter is already flushing" condition.
+     *
+     * @param e the exception thrown from the batch loop.
+     * @return true when offset commits can no longer succeed in this JVM.
+     */
+    private boolean isOffsetWriterPoisoned(Throwable e) {
+        Throwable current = e;
+        while (current != null) {
+            String message = current.getMessage();
+            if (message != null && message.contains("OffsetStorageWriter is already flushing")) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
 
@@ -451,6 +528,24 @@ public class ClickHouseBatchRunnable implements Runnable {
      * @throws Exception if processing fails
      */
     private void processBatch(String sourceTimeZone, String serverTimeZone) throws Exception {
+        // Retry of an ALREADY-FLUSHED batch: the data is in ClickHouse and the
+        // batch is only waiting for older in-flight batches to clear before
+        // its offsets may be committed. Do NOT re-run the inserts (each replay
+        // writes a duplicate part, visible to SELECTs without FINAL until the
+        // merge collapses it — CI observed one record re-inserted 1,000 times)
+        // and do NOT re-add the batch to the in-flight map (that would undo
+        // its move to completedBatches and re-block every newer batch). Just
+        // re-check committability, with a short pause to avoid a hot spin.
+        if (currentBatchFlushed) {
+            if (DebeziumOffsetManagement.checkIfBatchCanBeCommitted(currentBatch)) {
+                currentBatch = null;
+                currentBatchFlushed = false;
+            } else {
+                Thread.sleep(100);
+            }
+            return;
+        }
+
         // If replication history is enabled, add the records to the history table.
         addRecordsToHistoryTable(currentBatch, sourceTimeZone, serverTimeZone);
 
@@ -464,7 +559,7 @@ public class ClickHouseBatchRunnable implements Runnable {
         // Group records by topic name.
         // Create a new map of topic name to list of records.
         Map<String, List<ClickHouseStruct>> topicToRecordsMap =
-                new ConcurrentHashMap<>();
+                new HashMap<>();
         currentBatch.forEach(record -> {
             String topicName = record.getTopic();
             // If the topic name is not present, create a new list and
@@ -509,14 +604,16 @@ public class ClickHouseBatchRunnable implements Runnable {
             
         
         if (result) {
+            // The flush succeeded: remember that so a commit-blocked retry
+            // does not re-execute the inserts (duplicate parts) or re-add the
+            // batch to the in-flight map.
+            currentBatchFlushed = true;
             // Step 2: Check if the batch can be committed.
             if(DebeziumOffsetManagement.checkIfBatchCanBeCommitted(currentBatch)) {
                 currentBatch = null;
+                currentBatchFlushed = false;
             }
         }
-        Thread.sleep(config.getLong(
-                ClickHouseSinkConnectorConfigVariables.
-                        BUFFER_FLUSH_TIME.toString()));
         ///// ***** END PROCESSING BATCH **************************
     }
 
@@ -528,12 +625,27 @@ public class ClickHouseBatchRunnable implements Runnable {
      * @throws SQLException
      */
     private void addRecordsToHistoryTable(List<ClickHouseStruct> records, String sourceTimeZone, String serverTimeZone) throws SQLException {
+        if(records == null || records.isEmpty()) {
+            return;
+        }
         if(config.getBoolean(ClickHouseSinkConnectorConfigVariables.REPLICATION_HISTORY_ENABLE.toString())) {
             String databaseName = config.getString(ClickHouseSinkConnectorConfigVariables.REPLICATION_HISTORY_DATABASE_NAME.toString());
             String tableName = config.getString(ClickHouseSinkConnectorConfigVariables.REPLICATION_HISTORY_TABLE_NAME.toString());
+            if (records == null || records.isEmpty()) {
+                log.warn("Skipping history table update — batch is empty");
+                return;
+            }
             Connection databaseConn = getClickHouseConnection(databaseName);
             DbWriter writer = getDbWriterForTable(databaseName + "." + tableName, tableName, databaseName,
                     records.get(0), databaseConn);
+            if (writer == null) {
+                // getDbWriterForTable returns null when the table is still
+                // frozen for a DDL reconciliation. Skip the history write for
+                // this batch rather than dereferencing null; it is retried.
+                log.error("*** DbWriter is null for {}.{} (table frozen for DDL); "
+                        + "skipping history write for this batch", databaseName, tableName);
+                return;
+            }
 
             BinLogHistory binLogHistory = new BinLogHistory();
             binLogHistory.addRecordsToHistoryTable(config, tableName, writer.getConnection(), "", records, sourceTimeZone, serverTimeZone);
@@ -571,53 +683,187 @@ public class ClickHouseBatchRunnable implements Runnable {
                                         String databaseName,
                                         ClickHouseStruct record,
                                         Connection connection) {
-        // Compare the cached writer's build version against the shared, monotonic
-        // table version. A mismatch means a DDL invalidated this table after the
-        // writer was built, so it must be rebuilt with the fresh schema.
+        DbWriter writer = null;
         String fullyQualifiedTableName = databaseName + "." + tableName;
-        long currentVersion = CacheInvalidationManager.getInstance()
-                .getVersion(fullyQualifiedTableName);
-        DbWriter writer = this.topicToDbWriterMap.get(topicName);
-        boolean invalidated = false;
-        if (writer != null) {
-            if (writer.getCacheInvalidationVersion() == currentVersion) {
-                return writer;
+        // Block while a DDL schema change is being applied + reconciled for
+        // this table. This prevents inserting against a stale column cache
+        // (which would silently drop newly added source columns). The DDL
+        // thread freezes the table before ALTER and only unfreezes after the
+        // destination schema, the source schema, and the cache all agree.
+        // The return value MUST be honoured: false means the freeze did not
+        // clear within the timeout, i.e. a DDL reconciliation is stuck.
+        // Proceeding anyway would insert against the very stale column cache
+        // this freeze exists to prevent, silently dropping newly added source
+        // columns. Return null so the caller defers the batch and retries.
+        boolean unfrozen = TableReplicationFreezeManager.getInstance()
+                .awaitUnfrozen(fullyQualifiedTableName, DDLSchemaChangeWaiter.DEFAULT_TIMEOUT_MS);
+        if (!unfrozen) {
+            log.error("Table {} still frozen after {}ms; deferring this batch rather "
+                            + "than inserting against a possibly stale schema cache.",
+                    fullyQualifiedTableName, DDLSchemaChangeWaiter.DEFAULT_TIMEOUT_MS);
+            return null;
+        }
+
+        long generation = CacheInvalidationManager.getInstance()
+                .currentGeneration(fullyQualifiedTableName);
+
+        if (this.topicToDbWriterMap.containsKey(topicName)) {
+            // Rebuild when EITHER signal fires. Both sides of this merge are
+            // kept deliberately:
+            //  - generation change: a DDL was applied since this writer was
+            //    cached. Comparing generations (rather than consuming a
+            //    one-shot flag) is what lets every worker thread's private
+            //    cache invalidate independently; the old remove-on-read Set
+            //    let the first reader consume the signal and left the other
+            //    threads serving a stale column list.
+            //  - TTL expiry: defensive self-heal in case a schema change was
+            //    missed entirely and never bumped the generation.
+            Long cachedGeneration = this.topicToDbWriterGeneration.get(topicName);
+            boolean ddlInvalidated =
+                    cachedGeneration == null || cachedGeneration != generation;
+            boolean ttlExpired = CacheInvalidationManager.getInstance()
+                    .isCacheExpired(fullyQualifiedTableName);
+            if (!ddlInvalidated && !ttlExpired) {
+                return this.topicToDbWriterMap.get(topicName);
             }
-            log.info("Invalidating cached DbWriter for {} after DDL (version {} -> {})",
-                    topicName, writer.getCacheInvalidationVersion(), currentVersion);
+            log.info("Rebuilding cached DbWriter for {} ({}; generation {} -> {})",
+                    topicName,
+                    ddlInvalidated ? "DDL invalidation" : "cache TTL expiry",
+                    cachedGeneration, generation);
             this.topicToDbWriterMap.remove(topicName);
-            invalidated = true;
         }
         writer = new DbWriter(this.dbCredentials.getHostName(),
                 this.dbCredentials.getPort(), databaseName, tableName,
                 this.dbCredentials.getUserName(),
                 this.dbCredentials.getPassword(), this.config, record,
                 connection);
-        writer.setCacheInvalidationVersion(currentVersion);
         this.topicToDbWriterMap.put(topicName, writer);
-        // Log the resolved schema whenever this table has seen a DDL (version > 0).
-        // This covers both rebuilding a stale writer and building a fresh writer at
-        // the current version after a burst of DDLs, so the post-DDL schema is always
-        // observable regardless of which thread ends up owning the writer.
-        if (invalidated || currentVersion > 0) {
-            logRefreshedColumns(topicName, writer, invalidated);
+        // Record the generation this writer was built at (so the next call can
+        // detect a later DDL) AND stamp the TTL clock, then verify the freshly
+        // built column cache actually covers every source column.
+        this.topicToDbWriterGeneration.put(topicName, generation);
+        CacheInvalidationManager.getInstance().markCacheBuilt(fullyQualifiedTableName);
+        if (!verifySourceSchemaIntegrity(fullyQualifiedTableName, record, writer)) {
+            // The writer's column map does not cover every source column, so
+            // inserting with it would silently DROP those columns. Evict it and
+            // return null: the caller defers this batch and retries, by which
+            // time the rebuild picks up the now-visible columns. Returning the
+            // writer anyway was the stale-writer escape hatch that made the
+            // integrity check advisory instead of protective.
+            this.topicToDbWriterMap.remove(topicName);
+            this.topicToDbWriterGeneration.remove(topicName);
+            return null;
         }
         return writer;
     }
 
     /**
-     * Logs the refreshed column name and type map of a DbWriter that was rebuilt
-     * after a DDL cache invalidation.
+     * Verifies that every column present in the source change event also exists
+     * in the freshly rebuilt destination column cache. If a source column is
+     * missing, the INSERT path would silently drop it (data loss), so we log
+     * loudly and re-mark the table for invalidation. Re-marking forces the next
+     * batch to rebuild again rather than insert lossy data, which lets a
+     * still-propagating schema change catch up. This is a safety net layered on
+     * top of the per-table replication freeze.
      *
-     * @param topicName the topic whose writer was rebuilt
-     * @param writer    the freshly constructed DbWriter
+     * @return {@code true} when the writer may safely be used; {@code false}
+     *         when its column map is missing source columns, in which case the
+     *         caller MUST NOT insert with it.
      */
-    private void logRefreshedColumns(String topicName, DbWriter writer, boolean rebuilt) {
-        Map<String, String> cols = writer.getColumnNameToDataTypeMap();
-        if (cols != null) {
-            log.info("{} DbWriter schema for {} at cache version {} ({} columns): {}",
-                    rebuilt ? "Rebuilt" : "Built", topicName,
-                    writer.getCacheInvalidationVersion(), cols.size(), cols);
+    private boolean verifySourceSchemaIntegrity(String fullyQualifiedTableName,
+                                                ClickHouseStruct record,
+                                                DbWriter writer) {
+        try {
+            // The replication-history table is EXEMPT: it has its own fixed
+            // audit schema (gtid/ddl/before/after/...) and source-row columns
+            // are serialized into its payload columns, not mapped one-to-one.
+            // Comparing a source event against it reports every source column
+            // "missing" — the gate then blocks each batch for the full
+            // visibility-wait timeout polling system.columns for columns that
+            // will never appear, skips the history write, and starves the
+            // shared connection pool for the whole process.
+            // See SourceSchemaIntegrityValidator.isReplicationHistoryTable.
+            if (SourceSchemaIntegrityValidator.isReplicationHistoryTable(
+                    this.config, fullyQualifiedTableName)) {
+                return true;
+            }
+            java.util.List<String> sourceColumns =
+                    SourceSchemaColumns.fromRecord(record);
+            if (sourceColumns.isEmpty() || writer == null
+                    || writer.getColumnNameToDataTypeMap() == null) {
+                return true;
+            }
+            SourceSchemaIntegrityValidator.Result result =
+                    SourceSchemaIntegrityValidator.check(sourceColumns,
+                            writer.getColumnNameToDataTypeMap().keySet());
+            if (!result.isConsistent()) {
+                String[] parts = fullyQualifiedTableName.split("\\.", 2);
+                // Source columns that map to destination ALIAS/MATERIALIZED
+                // columns are NOT missing: the insertable cache excludes them
+                // by design — ClickHouse computes their values and rejects
+                // inserts into them, so the source value is intentionally not
+                // written. MySQL generated columns land here on EVERY batch;
+                // without this filter the gate invalidated and rebuilt the
+                // writer forever, livelocking replication for the table
+                // (observed: 8,208 invalidate/rebuild cycles in one CI run).
+                java.util.List<String> genuinelyMissing =
+                        result.getMissingInDestination();
+                if (parts.length == 2 && writer.getConnection() != null) {
+                    try {
+                        java.util.Set<String> generated = new DBMetadata(this.config)
+                                .getAliasAndMaterializedColumnsForTableAndDatabase(
+                                        parts[1], parts[0], writer.getConnection());
+                        genuinelyMissing = SourceSchemaIntegrityValidator
+                                .excludeGeneratedColumns(genuinelyMissing, generated);
+                    } catch (Exception ex) {
+                        log.warn("Could not fetch ALIAS/MATERIALIZED columns for {}: {}",
+                                fullyQualifiedTableName, ex.getMessage());
+                    }
+                }
+                if (genuinelyMissing.isEmpty()) {
+                    // Every "missing" column is computed by the destination —
+                    // the writer is correct as built. Invalidating here is the
+                    // livelock; the writer must be used as-is.
+                    return true;
+                }
+                // Generalized visibility gate: rather than only logging, WAIT for
+                // the destination to actually gain the missing columns. This is
+                // what covers RENAME/MODIFY COLUMN, whose net effect is "these
+                // columns must exist" but which the ADD/DROP text parser in
+                // waitForSchemaVisibility cannot see.
+                java.util.Collection<String> stillMissing = genuinelyMissing;
+                if (parts.length == 2 && writer.getConnection() != null) {
+                    stillMissing = new DDLSchemaChangeWaiter()
+                            .waitForExpectedColumns(writer.getConnection(), parts[0],
+                                    parts[1], genuinelyMissing);
+                }
+                if (stillMissing.isEmpty()) {
+                    // Columns landed while we waited; force a rebuild so the next
+                    // call picks up a writer that actually knows about them.
+                    log.warn("Schema integrity for {}: source column(s) {} were missing "
+                                    + "but became visible while waiting; re-marking for "
+                                    + "invalidation so the writer is rebuilt.",
+                            fullyQualifiedTableName, genuinelyMissing);
+                } else {
+                    log.error("Schema integrity violation for {}: source column(s) {} "
+                                    + "still missing from the destination after waiting; "
+                                    + "inserting now would drop them. Re-marking for "
+                                    + "invalidation.",
+                            fullyQualifiedTableName, stillMissing);
+                }
+                CacheInvalidationManager.getInstance().invalidateTable(fullyQualifiedTableName);
+                // Either way the CURRENT writer's column map predates those
+                // columns, so it must not be used for this batch.
+                return false;
+            }
+            return true;
+        } catch (Exception e) {
+            log.warn("Error during source schema integrity check for {}: {}",
+                    fullyQualifiedTableName, e.getMessage());
+            // Fail open on an unexpected checker error: the freeze and
+            // generation gates upstream are the primary protections, and
+            // blocking every batch on a bug in this safety net would be worse.
+            return true;
         }
     }
 
@@ -644,7 +890,23 @@ public class ClickHouseBatchRunnable implements Runnable {
         if (userProvidedTimeZoneId != null) {
             return userProvidedTimeZoneId;
         }
-        return new DBMetadata(config).getServerTimeZone(this.systemConnection);
+        return new DBMetadata(config).getServerTimeZone(getSystemConnection());
+    }
+
+    /**
+     * Returns the shared system-database connection, opening it on first use.
+     *
+     * <p>Lazy so that constructing this runnable does not require a reachable
+     * ClickHouse. Callers that genuinely need the database still fail loudly,
+     * because createConnection throws when it cannot connect.</p>
+     *
+     * @return the system-database connection.
+     */
+    private synchronized Connection getSystemConnection() {
+        if (this.systemConnection == null) {
+            this.systemConnection = createConnection(BaseDbWriter.SYSTEM_DB);
+        }
+        return this.systemConnection;
     }
 
     /**
@@ -693,40 +955,60 @@ public class ClickHouseBatchRunnable implements Runnable {
 
         DbWriter writer = getDbWriterForTable(topicName, tableName, databaseName,
                 firstRecord, databaseConn);
+        // Validate writer before using it — null writer causes NPE in
+        // PreparedStatementExecutor creation and error logging
+        if (writer == null) {
+            log.error("*** DbWriter is null for {}.{}, retrying", databaseName, tableName);
+            writer = getDbWriterForTable(topicName, tableName, databaseName,
+                    firstRecord, databaseConn);
+        }
+        if (writer == null) {
+            log.error("*** DbWriter still null for {}.{}, retrying on next attempt",
+                    databaseName, tableName);
+            return false;
+        }
+        if (writer.wasTableMetaDataRetrieved() == false) {
+            log.error(String.format("*** TABLE METADATA not retrieved for " +
+                            "Database(%s), table(%s) retrying",
+                    writer.getDatabaseName(), writer.getTableName()));
+            writer.updateColumnNameToDataTypeMap();
+            if (writer.wasTableMetaDataRetrieved() == false) {
+                log.error(String.format("*** TABLE METADATA not retrieved for " +
+                                "Database(%s), table(%s), retrying on next attempt",
+                        databaseName, tableName));
+                return false;
+            }
+        }
         PreparedStatementExecutor preparedStatementExecutor = new
                 PreparedStatementExecutor(writer.getReplacingMergeTreeDeleteColumn(),
                 writer.isReplacingMergeTreeWithIsDeletedColumn(), writer.getSignColumn(),
                 writer.getVersionColumn(), writer.getDatabaseName(),
                 getServerTimeZone(this.config));
-        if (writer == null || writer.wasTableMetaDataRetrieved() == false) {
-            log.error(String.format("*** TABLE METADATA not retrieved for " +
-                            "Database(%s), table(%s) retrying",
-                    writer.getDatabaseName(), writer.getTableName()));
-            if (writer == null) {
-                writer = getDbWriterForTable(topicName, tableName, databaseName,
-                        firstRecord, databaseConn);
-            }
-            if (writer.wasTableMetaDataRetrieved() == false)
-                writer.updateColumnNameToDataTypeMap();
-            if (writer == null ||
-                    writer.wasTableMetaDataRetrieved() == false) {
-                log.error(String.format("*** TABLE METADATA not retrieved for " +
-                                "Database(%s), table(%s), retrying on next attempt",
-                        writer.getDatabaseName(), writer.getTableName()));
-                return false;
-            }
-        }
         // Step 1: The Batch Insert with preparedStatement in JDBC works by
         // forming the Query and then adding records to the Batch.
         // This step creates a Map of Query -> Records (List of ClickHouseStruct).
         Map<MutablePair<String, Map<String, Integer>>,
                 List<ClickHouseStruct>> queryToRecordsMap = new HashMap<>();
         Map<TopicPartition, Long> partitionToOffsetMap = new HashMap<>();
+        // Pass the writer's connector-managed column names (version/sign/
+        // delete columns as actually named in the table engine) so the query
+        // formatter keeps them in the insert list while omitting genuine
+        // destination-only data columns the source event does not carry.
+        java.util.List<String> managedColumns = new ArrayList<>();
+        if (writer.getVersionColumn() != null) {
+            managedColumns.add(writer.getVersionColumn());
+        }
+        if (writer.getSignColumn() != null) {
+            managedColumns.add(writer.getSignColumn());
+        }
+        if (writer.getReplacingMergeTreeDeleteColumn() != null) {
+            managedColumns.add(writer.getReplacingMergeTreeDeleteColumn());
+        }
         result = new GroupInsertQueryWithBatchRecords()
                 .groupQueryWithRecords(records, queryToRecordsMap,
                         partitionToOffsetMap, this.config, tableName,
                         writer.getDatabaseName(), writer.getConnection(),
-                        writer.getColumnNameToDataTypeMap());
+                        writer.getColumnNameToDataTypeMap(), managedColumns);
         BlockMetaData bmd = new BlockMetaData();
         long maxBufferSize = this.config.getLong(
                 ClickHouseSinkConnectorConfigVariables.
@@ -737,17 +1019,7 @@ public class ClickHouseBatchRunnable implements Runnable {
         // and the records are flushed to ClickHouse.
         result = flushRecordsToClickHouse(topicName, writer, queryToRecordsMap,
                 bmd, maxBufferSize, preparedStatementExecutor);
-        if (result) {
-            // Records are now DURABLY in ClickHouse: advance the shared watermark
-            // (max offset per TopicPartition) so ClickHouseSinkTask.preCommit()
-            // only commits offsets that were actually persisted. Without this the
-            // offset advances on consume, and a crash/restart silently loses the
-            // records that were consumed but never inserted.
-            partitionToOffsetMap.forEach((tp, offset) ->
-                    this.durablyInsertedOffsets.merge(tp, offset, Math::max));
-            // Remove the entry.
-            queryToRecordsMap.remove(topicName);
-        }
+        // queryToRecordsMap uses MutablePair keys, not String — remove was a no-op
         if (this.config.getBoolean(
                 ClickHouseSinkConnectorConfigVariables.
                         ENABLE_KAFKA_OFFSET.toString())) {
@@ -790,12 +1062,10 @@ public class ClickHouseBatchRunnable implements Runnable {
                                              PreparedStatementExecutor preparedStatementExecutor)
             throws Exception {
         boolean result = false;
-        synchronized (queryToRecordsMap) {
-            result = preparedStatementExecutor.addToPreparedStatementBatch(
-                    topicName, queryToRecordsMap, bmd, config,
-                    writer.getConnection(), writer.getTableName(),
-                    writer.getColumnNameToDataTypeMap(), writer.getEngine());
-        }
+        result = preparedStatementExecutor.addToPreparedStatementBatch(
+                topicName, queryToRecordsMap, bmd, config,
+                writer.getConnection(), writer.getTableName(),
+                writer.getColumnNameToDataTypeMap(), writer.getEngine());
         try {
             Metrics.updateMetrics(bmd);
         } catch (Exception e) {

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchWriter.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchWriter.java
@@ -7,8 +7,11 @@ import com.altinity.clickhouse.sink.connector.common.Utils;
 import com.altinity.clickhouse.sink.connector.db.BaseDbWriter;
 import com.altinity.clickhouse.sink.connector.db.CacheInvalidationManager;
 import com.altinity.clickhouse.sink.connector.db.DBMetadata;
+import com.altinity.clickhouse.sink.connector.db.DDLSchemaChangeWaiter;
 import com.altinity.clickhouse.sink.connector.db.DbKafkaOffsetWriter;
 import com.altinity.clickhouse.sink.connector.db.DbWriter;
+import com.altinity.clickhouse.sink.connector.db.SourceSchemaIntegrityValidator;
+import com.altinity.clickhouse.sink.connector.db.TableReplicationFreezeManager;
 import com.altinity.clickhouse.sink.connector.db.batch.GroupInsertQueryWithBatchRecords;
 import com.altinity.clickhouse.sink.connector.db.batch.PreparedStatementExecutor;
 import com.altinity.clickhouse.sink.connector.model.BlockMetaData;
@@ -71,6 +74,12 @@ public class ClickHouseBatchWriter {
     private Map<String, DbWriter> topicToDbWriterMap;
 
     /**
+     * DDL generation each cached DbWriter in {@link #topicToDbWriterMap} was built at,
+     * keyed by topic name. Used to detect schema changes applied since caching.
+     */
+    private Map<String, Long> topicToDbWriterGeneration;
+
+    /**
      * Database credentials.
      */
     private DBCredentials dbCredentials;
@@ -102,9 +111,12 @@ public class ClickHouseBatchWriter {
         }
         //this.queryToRecordsMap = new HashMap<>();
         this.topicToDbWriterMap = new HashMap<>();
+        this.topicToDbWriterGeneration = new HashMap<>();
         //this.topicToRecordsMap = new HashMap<>();
         this.dbCredentials = parseDBConfiguration();
-        this.systemConnection = createConnection(BaseDbWriter.SYSTEM_DB);
+        // systemConnection is opened lazily — see getSystemConnection(). Opening
+        // it here made construction require a reachable ClickHouse even for
+        // operations that never touch the database.
         try {
             this.databaseOverrideMap = Utils.parseSourceToDestinationDatabaseMap(
                     this.config.getString(
@@ -230,26 +242,74 @@ public class ClickHouseBatchWriter {
             // acknowledge the records.
             if (result) {
                 log.info("****** Acknowledging records ******");
-                records.forEach(record -> {
+                // Route through DebeziumOffsetManagement so this path uses the SAME
+                // OFFSET_COMMIT_LOCK as the batch-runnable path. Calling
+                // markProcessed()/markBatchFinished() directly here bypassed the
+                // serialization entirely and could drive a concurrent beginFlush()
+                // into the non-thread-safe OffsetStorageWriter.
+                for (ClickHouseStruct record : records) {
+                    if (record.getCommitter() == null || record.getSourceRecord() == null) {
+                        continue;
+                    }
                     try {
-                        record.getCommitter().markProcessed(
-                                record.getSourceRecord());
+                        DebeziumOffsetManagement.acknowledgeRecord(
+                                record.getCommitter(),
+                                record.getSourceRecord(),
+                                record.isLastRecordInBatch());
                     } catch (InterruptedException e) {
-                        //throw new RuntimeException(e);
-                        log.error("Error marking records as processed" + e);
+                        // Preserve the interrupt and stop acknowledging: silently
+                        // continuing would advance offsets for records whose commit
+                        // never completed.
+                        Thread.currentThread().interrupt();
+                        log.error("Interrupted while acknowledging records", e);
+                        throw new RuntimeException(e);
                     }
-                    if (record.isLastRecordInBatch()) {
-                        try {
-                            record.getCommitter().markBatchFinished();
-                        } catch (InterruptedException e) {
-                            throw new RuntimeException(e);
-                        }
-                    }
-                });
+                    // NOTE: markBatchFinished() is deliberately NOT re-invoked
+                    // here. acknowledgeRecord() above already performs it, under
+                    // the shared OFFSET_COMMIT_LOCK, when isLastRecordInBatch()
+                    // is true. The PR-28 variant called it again outside that
+                    // lock, which is precisely the unserialized second flush
+                    // path that produced "OffsetStorageWriter is already
+                    // flushing" (fixed in PR #31). It must stay removed.
+                }
             }
         } catch (Exception e) {
-            log.error("Error persisting records to ClickHouse" + e);
+            // A poisoned OffsetStorageWriter must NOT be absorbed here. Once its
+            // flush semaphore is leaked, offsets can never be committed again in
+            // this JVM, so logging and returning normally would let ClickHouse
+            // writes continue against a frozen binlog position -- silent
+            // divergence. Propagate so the task stops, matching the handling in
+            // ClickHouseBatchRunnable.
+            if (isOffsetWriterPoisoned(e)) {
+                log.error("FATAL: the Debezium OffsetStorageWriter is stuck in the "
+                        + "'already flushing' state. Offsets can no longer be "
+                        + "committed, so replication would keep writing rows while "
+                        + "the binlog position stays frozen. Propagating to stop "
+                        + "processing and prevent silent data divergence.");
+                throw new RuntimeException(
+                        "OffsetStorageWriter is permanently stuck flushing; "
+                                + "stopping to prevent silent data divergence", e);
+            }
+            log.error("Error persisting records to ClickHouse", e);
         }
+    }
+
+    /**
+     * Detects the unrecoverable "OffsetStorageWriter is already flushing" condition.
+     *
+     * @param e the exception thrown while persisting or acknowledging records.
+     * @return true when offset commits can no longer succeed in this JVM.
+     */
+    private boolean isOffsetWriterPoisoned(Throwable e) {
+        Throwable current = e;
+        while (current != null) {
+            String message = current.getMessage();
+            if (message != null && message.contains("OffsetStorageWriter is already flushing")) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     /**
@@ -283,53 +343,163 @@ public class ClickHouseBatchWriter {
                                         String databaseName,
                                         ClickHouseStruct record,
                                         Connection connection) {
-        // Compare the cached writer's build version against the shared, monotonic
-        // table version. A mismatch means a DDL invalidated this table after the
-        // writer was built, so it must be rebuilt with the fresh schema.
+        DbWriter writer = null;
         String fullyQualifiedTableName = databaseName + "." + tableName;
-        long currentVersion = CacheInvalidationManager.getInstance()
-                .getVersion(fullyQualifiedTableName);
-        DbWriter writer = this.topicToDbWriterMap.get(topicName);
-        boolean invalidated = false;
-        if (writer != null) {
-            if (writer.getCacheInvalidationVersion() == currentVersion) {
-                return writer;
+        // Block while a DDL schema change is being applied + reconciled for
+        // this table, so inserts never run against a stale column cache that
+        // would silently drop newly added source columns.
+        // The return value MUST be honoured — see the matching comment in
+        // ClickHouseBatchRunnable.getDbWriterForTable. false means a DDL
+        // reconciliation is stuck; inserting anyway would use the stale cache
+        // this freeze exists to prevent. Return null so the batch is deferred.
+        boolean unfrozen = TableReplicationFreezeManager.getInstance()
+                .awaitUnfrozen(fullyQualifiedTableName, DDLSchemaChangeWaiter.DEFAULT_TIMEOUT_MS);
+        if (!unfrozen) {
+            log.error("Table {} still frozen after {}ms; deferring this batch rather "
+                            + "than inserting against a possibly stale schema cache.",
+                    fullyQualifiedTableName, DDLSchemaChangeWaiter.DEFAULT_TIMEOUT_MS);
+            return null;
+        }
+
+        long generation = CacheInvalidationManager.getInstance()
+                .currentGeneration(fullyQualifiedTableName);
+
+        if (this.topicToDbWriterMap.containsKey(topicName)) {
+            // Rebuild when EITHER signal fires — see the matching comment in
+            // ClickHouseBatchRunnable.getDbWriterForTable. Generation change
+            // means a DDL landed since this writer was cached; TTL expiry is
+            // the self-heal for a schema change that was missed entirely.
+            Long cachedGeneration = this.topicToDbWriterGeneration.get(topicName);
+            boolean ddlInvalidated =
+                    cachedGeneration == null || cachedGeneration != generation;
+            boolean ttlExpired = CacheInvalidationManager.getInstance()
+                    .isCacheExpired(fullyQualifiedTableName);
+            if (!ddlInvalidated && !ttlExpired) {
+                return this.topicToDbWriterMap.get(topicName);
             }
-            log.info("Invalidating cached DbWriter for {} after DDL (version {} -> {})",
-                    topicName, writer.getCacheInvalidationVersion(), currentVersion);
+            log.info("Rebuilding cached DbWriter for {} ({}; generation {} -> {})",
+                    topicName,
+                    ddlInvalidated ? "DDL invalidation" : "cache TTL expiry",
+                    cachedGeneration, generation);
             this.topicToDbWriterMap.remove(topicName);
-            invalidated = true;
         }
         writer = new DbWriter(this.dbCredentials.getHostName(),
                 this.dbCredentials.getPort(), databaseName, tableName,
                 this.dbCredentials.getUserName(),
                 this.dbCredentials.getPassword(), this.config, record,
                 connection);
-        writer.setCacheInvalidationVersion(currentVersion);
         this.topicToDbWriterMap.put(topicName, writer);
-        // Log the resolved schema whenever this table has seen a DDL (version > 0).
-        // This covers both rebuilding a stale writer and building a fresh writer at
-        // the current version after a burst of DDLs, so the post-DDL schema is always
-        // observable regardless of which thread ends up owning the writer.
-        if (invalidated || currentVersion > 0) {
-            logRefreshedColumns(topicName, writer, invalidated);
+        // Record the generation this writer was built at AND stamp the TTL
+        // clock, then verify the rebuilt cache covers every source column.
+        this.topicToDbWriterGeneration.put(topicName, generation);
+        CacheInvalidationManager.getInstance().markCacheBuilt(fullyQualifiedTableName);
+        if (!verifySourceSchemaIntegrity(fullyQualifiedTableName, record, writer)) {
+            // Column map does not cover every source column — inserting with
+            // this writer would silently DROP them. Evict and return null so
+            // the caller defers the batch; see the matching comment in
+            // ClickHouseBatchRunnable.getDbWriterForTable.
+            this.topicToDbWriterMap.remove(topicName);
+            this.topicToDbWriterGeneration.remove(topicName);
+            return null;
         }
         return writer;
     }
 
     /**
-     * Logs the refreshed column name and type map of a DbWriter that was rebuilt
-     * after a DDL cache invalidation.
-     *
-     * @param topicName the topic whose writer was rebuilt
-     * @param writer    the freshly constructed DbWriter
+     * Verifies that every source-event column exists in the rebuilt destination
+     * cache; if not, logs loudly and re-marks the table for invalidation so the
+     * next batch rebuilds again rather than inserting lossy rows. Safety net on
+     * top of the per-table replication freeze. See {@link SourceSchemaIntegrityValidator}.
      */
-    private void logRefreshedColumns(String topicName, DbWriter writer, boolean rebuilt) {
-        Map<String, String> cols = writer.getColumnNameToDataTypeMap();
-        if (cols != null) {
-            log.info("{} DbWriter schema for {} at cache version {} ({} columns): {}",
-                    rebuilt ? "Rebuilt" : "Built", topicName,
-                    writer.getCacheInvalidationVersion(), cols.size(), cols);
+    private boolean verifySourceSchemaIntegrity(String fullyQualifiedTableName,
+                                                ClickHouseStruct record,
+                                                DbWriter writer) {
+        try {
+            // The replication-history table is EXEMPT: it has its own fixed
+            // audit schema (gtid/ddl/before/after/...) and source-row columns
+            // are serialized into its payload columns, not mapped one-to-one.
+            // Comparing a source event against it reports every source column
+            // "missing" — the gate then blocks each batch for the full
+            // visibility-wait timeout polling system.columns for columns that
+            // will never appear, skips the history write, and starves the
+            // shared connection pool for the whole process.
+            // See SourceSchemaIntegrityValidator.isReplicationHistoryTable.
+            if (SourceSchemaIntegrityValidator.isReplicationHistoryTable(
+                    this.config, fullyQualifiedTableName)) {
+                return true;
+            }
+            java.util.List<String> sourceColumns =
+                    com.altinity.clickhouse.sink.connector.db.SourceSchemaColumns.fromRecord(record);
+            if (sourceColumns.isEmpty() || writer == null
+                    || writer.getColumnNameToDataTypeMap() == null) {
+                return true;
+            }
+            SourceSchemaIntegrityValidator.Result result =
+                    SourceSchemaIntegrityValidator.check(sourceColumns,
+                            writer.getColumnNameToDataTypeMap().keySet());
+            if (!result.isConsistent()) {
+                String[] parts = fullyQualifiedTableName.split("\\.", 2);
+                // Source columns that map to destination ALIAS/MATERIALIZED
+                // columns are NOT missing: the insertable cache excludes them
+                // by design — ClickHouse computes their values and rejects
+                // inserts into them. MySQL generated columns land here on
+                // EVERY batch; without this filter the gate invalidated and
+                // rebuilt the writer forever, livelocking replication for the
+                // table. See the matching comment in ClickHouseBatchRunnable.
+                java.util.List<String> genuinelyMissing =
+                        result.getMissingInDestination();
+                if (parts.length == 2 && writer.getConnection() != null) {
+                    try {
+                        java.util.Set<String> generated = new DBMetadata(this.config)
+                                .getAliasAndMaterializedColumnsForTableAndDatabase(
+                                        parts[1], parts[0], writer.getConnection());
+                        genuinelyMissing = SourceSchemaIntegrityValidator
+                                .excludeGeneratedColumns(genuinelyMissing, generated);
+                    } catch (Exception ex) {
+                        log.warn("Could not fetch ALIAS/MATERIALIZED columns for {}: {}",
+                                fullyQualifiedTableName, ex.getMessage());
+                    }
+                }
+                if (genuinelyMissing.isEmpty()) {
+                    // Every "missing" column is computed by the destination —
+                    // the writer is correct as built. Invalidating here is the
+                    // livelock; the writer must be used as-is.
+                    return true;
+                }
+                // Generalized visibility gate: WAIT for the destination to gain
+                // the missing columns rather than only logging. This covers
+                // RENAME/MODIFY COLUMN, which the ADD/DROP text parser in
+                // waitForSchemaVisibility cannot see.
+                java.util.Collection<String> stillMissing = genuinelyMissing;
+                if (parts.length == 2 && writer.getConnection() != null) {
+                    stillMissing = new DDLSchemaChangeWaiter()
+                            .waitForExpectedColumns(writer.getConnection(), parts[0],
+                                    parts[1], genuinelyMissing);
+                }
+                if (stillMissing.isEmpty()) {
+                    log.warn("Schema integrity for {}: source column(s) {} were missing "
+                                    + "but became visible while waiting; re-marking for "
+                                    + "invalidation so the writer is rebuilt.",
+                            fullyQualifiedTableName, genuinelyMissing);
+                } else {
+                    log.error("Schema integrity violation for {}: source column(s) {} "
+                                    + "still missing from the destination after waiting; "
+                                    + "inserting now would drop them. Re-marking for "
+                                    + "invalidation.",
+                            fullyQualifiedTableName, stillMissing);
+                }
+                CacheInvalidationManager.getInstance().invalidateTable(fullyQualifiedTableName);
+                // Either way the CURRENT writer's column map predates those
+                // columns, so it must not be used for this batch.
+                return false;
+            }
+            return true;
+        } catch (Exception e) {
+            log.warn("Error during source schema integrity check for {}: {}",
+                    fullyQualifiedTableName, e.getMessage());
+            // Fail open on an unexpected checker error: the freeze and
+            // generation gates upstream are the primary protections.
+            return true;
         }
     }
 
@@ -357,7 +527,23 @@ public class ClickHouseBatchWriter {
         if (userProvidedTimeZoneId != null) {
             return userProvidedTimeZoneId;
         }
-        return new DBMetadata(config).getServerTimeZone(this.systemConnection);
+        return new DBMetadata(config).getServerTimeZone(getSystemConnection());
+    }
+
+    /**
+     * Returns the shared system-database connection, opening it on first use.
+     *
+     * <p>Lazy so that constructing this writer does not require a reachable
+     * ClickHouse. Callers that genuinely need the database still fail loudly,
+     * because createConnection throws when it cannot connect.</p>
+     *
+     * @return the system-database connection.
+     */
+    private synchronized Connection getSystemConnection() {
+        if (this.systemConnection == null) {
+            this.systemConnection = createConnection(BaseDbWriter.SYSTEM_DB);
+        }
+        return this.systemConnection;
     }
 
     /**
@@ -403,6 +589,31 @@ public class ClickHouseBatchWriter {
         Connection databaseConn = getClickHouseConnection(databaseName);
         DbWriter writer = getDbWriterForTable(topicName, tableName, databaseName,
                 firstRecord, databaseConn);
+        if (writer == null) {
+            log.error(String.format(
+                    "*** DbWriter is null for Database(%s), table(%s) -- retrying",
+                    databaseName, tableName));
+            writer = getDbWriterForTable(topicName, tableName,
+                    databaseName, firstRecord, databaseConn);
+            if (writer == null) {
+                log.error(String.format(
+                        "*** DbWriter still null for Database(%s), table(%s) -- giving up",
+                        databaseName, tableName));
+                return false;
+            }
+        }
+        if (!writer.wasTableMetaDataRetrieved()) {
+            log.warn(String.format(
+                    "*** TABLE METADATA not retrieved for Database(%s), table(%s) -- retrying",
+                    writer.getDatabaseName(), writer.getTableName()));
+            writer.updateColumnNameToDataTypeMap();
+            if (!writer.wasTableMetaDataRetrieved()) {
+                log.error(String.format(
+                        "*** TABLE METADATA not retrieved for Database(%s), table(%s) -- giving up",
+                        writer.getDatabaseName(), writer.getTableName()));
+                return false;
+            }
+        }
         PreparedStatementExecutor preparedStatementExecutor =
                 new PreparedStatementExecutor(writer.
                         getReplacingMergeTreeDeleteColumn(),
@@ -410,27 +621,6 @@ public class ClickHouseBatchWriter {
                         writer.getSignColumn(), writer.getVersionColumn(),
                         writer.getDatabaseName(),
                         getServerTimeZone(this.config));
-        if (writer == null || writer.wasTableMetaDataRetrieved() == false) {
-            log.error(String.format(
-                    "*** TABLE METADATA not retrieved for " +
-                            "Database(%s), table(%s) retrying",
-                    writer.getDatabaseName(), writer.getTableName()));
-            if (writer == null) {
-                writer = getDbWriterForTable(topicName, tableName,
-                        databaseName, firstRecord, databaseConn);
-            }
-            if (writer.wasTableMetaDataRetrieved() == false)
-                writer.updateColumnNameToDataTypeMap();
-            if (writer == null ||
-                    writer.wasTableMetaDataRetrieved() == false) {
-                log.error(String.format(
-                        "*** TABLE METADATA not retrieved for " +
-                                "Database(%s), table(%s), retrying on next " +
-                                "attempt",
-                        writer.getDatabaseName(), writer.getTableName()));
-                return false;
-            }
-        }
         // Step 1: The Batch Insert with preparedStatement in JDBC works by
         // forming the Query and then adding records to the Batch.
         // This step creates a Map of Query -> Records (List of
@@ -438,11 +628,25 @@ public class ClickHouseBatchWriter {
         Map<MutablePair<String, Map<String, Integer>>,
                 List<ClickHouseStruct>> queryToRecordsMap = new HashMap<>();
         Map<TopicPartition, Long> partitionToOffsetMap = new HashMap<>();
+        // Pass the writer's connector-managed column names (version/sign/
+        // delete columns as actually named in the table engine) so the query
+        // formatter keeps them in the insert list while omitting genuine
+        // destination-only data columns the source event does not carry.
+        java.util.List<String> managedColumns = new ArrayList<>();
+        if (writer.getVersionColumn() != null) {
+            managedColumns.add(writer.getVersionColumn());
+        }
+        if (writer.getSignColumn() != null) {
+            managedColumns.add(writer.getSignColumn());
+        }
+        if (writer.getReplacingMergeTreeDeleteColumn() != null) {
+            managedColumns.add(writer.getReplacingMergeTreeDeleteColumn());
+        }
         result = new GroupInsertQueryWithBatchRecords()
                 .groupQueryWithRecords(records, queryToRecordsMap,
                         partitionToOffsetMap, this.config, tableName,
                         writer.getDatabaseName(), writer.getConnection(),
-                        writer.getColumnNameToDataTypeMap());
+                        writer.getColumnNameToDataTypeMap(), managedColumns);
         BlockMetaData bmd = new BlockMetaData();
         long maxBufferSize = this.config.getLong(
                 ClickHouseSinkConnectorConfigVariables.

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/DebeziumOffsetManagement.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/DebeziumOffsetManagement.java
@@ -40,12 +40,18 @@ public class DebeziumOffsetManagement {
             completedBatches = new ConcurrentHashMap<>();
 
     /**
-     * Shared lock that serializes every offset commit driven by the connector
-     * worker threads, guaranteeing a single connector-side flush at a time so
-     * that concurrent worker threads never issue overlapping
-     * {@code markBatchFinished()} calls against the same OffsetStorageWriter.
+     * Shared lock serialising every connector-driven offset commit.
+     * <p>
+     * Kafka's {@code OffsetStorageWriter} is not thread-safe and rejects overlapping
+     * flushes with {@code ConnectException: OffsetStorageWriter is already flushing}.
+     * Debezium's own {@code RecordCommitter} methods are {@code synchronized}, but a
+     * NEW committer instance is built per batch
+     * ({@code EmbeddedEngine.buildRecordCommitter}), so concurrent worker threads
+     * synchronise on different monitors and get no mutual exclusion. This single
+     * static lock is the actual barrier.
+     * </p>
      */
-    private static final Object OFFSET_COMMIT_LOCK = new Object();
+    static final Object OFFSET_COMMIT_LOCK = new Object();
 
     /**
      * Constructor to initialize DebeziumOffsetManagement with a provided
@@ -100,6 +106,9 @@ public class DebeziumOffsetManagement {
      */
     public static Pair<Long, Long> calculateMinMaxTimestampFromBatch(
             List<ClickHouseStruct> batch) {
+        if (batch == null || batch.isEmpty()) {
+            return Pair.of(0L, 0L);
+        }
         long min = Long.MAX_VALUE;
         long max = Long.MIN_VALUE;
         for (ClickHouseStruct clickHouseStruct : batch) {
@@ -170,17 +179,24 @@ public class DebeziumOffsetManagement {
             acknowledgeRecords(batch);
             result = true;
             // Check if completed batches can also be acknowledged.
-            completedBatches.forEach((k, v) -> {
-                if (false == checkIfThereAreInflightRequests(v)) {
+            // Collect keys first to avoid ConcurrentModificationException
+            // when removing entries during iteration
+            java.util.List<Pair<Long, Long>> toRemove = new java.util.ArrayList<>();
+            for (java.util.Map.Entry<Pair<Long, Long>, java.util.List<ClickHouseStruct>> entry
+                    : completedBatches.entrySet()) {
+                if (false == checkIfThereAreInflightRequests(entry.getValue())) {
                     try {
-                        acknowledgeRecords(v);
+                        acknowledgeRecords(entry.getValue());
                     } catch (InterruptedException e) {
-                        log.error("*** Error acknowlegeRecords ***", e);
+                        log.error("*** Error acknowledgeRecords ***", e);
                         throw new RuntimeException(e);
                     }
-                    completedBatches.remove(k);
+                    toRemove.add(entry.getKey());
                 }
-            });
+            }
+            for (Pair<Long, Long> key : toRemove) {
+                completedBatches.remove(key);
+            }
         }
         return result;
     }
@@ -196,24 +212,37 @@ public class DebeziumOffsetManagement {
      * @param batch The batch of ClickHouseStruct records to acknowledge.
      * @throws InterruptedException If the commit operation is interrupted.
      */
-    static synchronized void acknowledgeRecords(List<ClickHouseStruct> batch) 
+    static synchronized void acknowledgeRecords(List<ClickHouseStruct> batch)
                                             throws InterruptedException {
         // acknowledge records
         // Iterate through the records
         // and use the record committer to commit the offsets.
-        for(ClickHouseStruct record: batch) {
-            if (record.getCommitter() != null && record.getSourceRecord() != null) {
+        //
+        // Both sides of the merge are kept, because they fix DIFFERENT halves of
+        // the same race:
+        //  - develop widens the critical section: markProcessed() and
+        //    markBatchFinished() MUST be inside the SAME one. Debezium builds a
+        //    NEW RecordCommitter per batch (EmbeddedEngine.buildRecordCommitter),
+        //    so its own `synchronized` methods lock different monitors for
+        //    different batches and provide no mutual exclusion across worker
+        //    threads. 2.10.0 locked only the markBatchFinished() call, leaving
+        //    markProcessed() outside the barrier.
+        //  - 2.10.0 routes the finish through markBatchFinishedSafely(), which
+        //    null-guards the committer and keeps every finish path funnelled
+        //    through one helper. The helper re-acquires OFFSET_COMMIT_LOCK; that
+        //    is safe because Java monitors are reentrant.
+        synchronized (OFFSET_COMMIT_LOCK) {
+            for (ClickHouseStruct record : batch) {
+                if (record.getCommitter() != null && record.getSourceRecord() != null) {
 
-                record.getCommitter().markProcessed(record.getSourceRecord());
-//                log.debug("***** Record successfully marked as processed ****" + "Binlog file:" +
-//                        record.getFile() + " Binlog position: " + record.getPos() + " GTID: " + record.getGtid()
-//                + "Sequence Number: " + record.getSequenceNumber() + "Debezium Timestamp: " + record.getDebezium_ts_ms());
+                    record.getCommitter().markProcessed(record.getSourceRecord());
 
-                if(record.isLastRecordInBatch()) {
-                    markBatchFinishedSafely(record.getCommitter());
-                    log.info("***** BATCH marked as processed to debezium ****" + "Binlog file:" +
-                            record.getFile() + " Binlog position: " + record.getPos() + " GTID: " + record.getGtid()
-                            + " Sequence Number: " + record.getSequenceNumber() + " Debezium Timestamp: " + record.getDebezium_ts_ms());
+                    if (record.isLastRecordInBatch()) {
+                        markBatchFinishedSafely(record.getCommitter());
+                        log.info("***** BATCH marked as processed to debezium ****" + "Binlog file:" +
+                                record.getFile() + " Binlog position: " + record.getPos() + " GTID: " + record.getGtid()
+                                + " Sequence Number: " + record.getSequenceNumber() + " Debezium Timestamp: " + record.getDebezium_ts_ms());
+                    }
                 }
             }
         }
@@ -239,8 +268,48 @@ public class DebeziumOffsetManagement {
             boolean lastRecordInBatch)
             throws InterruptedException {
         if (sourceRecord != null) {
+            // Same critical section as the batch variant above — see the comment there.
+            synchronized (OFFSET_COMMIT_LOCK) {
+                recordCommitter.markProcessed(sourceRecord);
+                if (lastRecordInBatch) {
+                    // Every finish path goes through the null-guarded helper, so
+                    // no caller can reach markBatchFinished() outside the lock.
+                    markBatchFinishedSafely(recordCommitter);
+                }
+            }
+        }
+    }
+
+    /**
+     * Acknowledges a single record on the shared offset-commit lock.
+     * <p>
+     * Exposed so that every offset-committing path in the connector funnels through
+     * the SAME lock. Any path that calls {@code markProcessed()} /
+     * {@code markBatchFinished()} directly bypasses the serialization and can drive
+     * concurrent {@code beginFlush()} calls into the non-thread-safe
+     * OffsetStorageWriter, which throws
+     * {@code ConnectException: OffsetStorageWriter is already flushing}.
+     * </p>
+     *
+     * @param recordCommitter    The record committer to be used.
+     * @param sourceRecord       The source record to mark as processed.
+     * @param lastRecordInBatch  True if this is the last record in the batch.
+     * @throws InterruptedException If the commit operation is interrupted.
+     */
+    public static void acknowledgeRecord(
+            DebeziumEngine.RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>>
+                    recordCommitter,
+            ChangeEvent<SourceRecord, SourceRecord> sourceRecord,
+            boolean lastRecordInBatch)
+            throws InterruptedException {
+        if (recordCommitter == null || sourceRecord == null) {
+            return;
+        }
+        synchronized (OFFSET_COMMIT_LOCK) {
             recordCommitter.markProcessed(sourceRecord);
-            if (lastRecordInBatch == true) {
+            if (lastRecordInBatch) {
+                // Funnel every finish through the null-guarded helper (2.10.0)
+                // while staying inside develop's widened critical section.
                 markBatchFinishedSafely(recordCommitter);
             }
         }

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/CacheInvalidationManagerTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/CacheInvalidationManagerTest.java
@@ -1,0 +1,103 @@
+package com.altinity.clickhouse.sink.connector.db;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for {@link CacheInvalidationManager}.
+ *
+ * <p>The connector runs a pool of worker threads, each holding its own
+ * topicToDbWriterMap cache. The previous remove-on-read implementation let the
+ * FIRST reader consume the invalidation signal, so every other thread kept
+ * serving a DbWriter built against the pre-DDL column list. Those writers build
+ * the INSERT column list from a snapshot taken at construction, so the newly
+ * added column was silently dropped from every subsequent INSERT and ClickHouse
+ * diverged from MySQL permanently.</p>
+ */
+public class CacheInvalidationManagerTest {
+
+    private static final String TABLE = "testdb.orders";
+
+    @BeforeEach
+    public void reset() {
+        CacheInvalidationManager.getInstance().clearAll();
+    }
+
+    @Test
+    public void generationStartsAtZeroForUnknownTable() {
+        Assertions.assertEquals(0L,
+                CacheInvalidationManager.getInstance().currentGeneration(TABLE));
+    }
+
+    @Test
+    public void invalidationIsVisibleToEveryConsumerNotJustTheFirst() {
+        CacheInvalidationManager manager = CacheInvalidationManager.getInstance();
+
+        // Two worker threads each cached a DbWriter at generation 0.
+        long threadOneCachedAt = manager.currentGeneration(TABLE);
+        long threadTwoCachedAt = manager.currentGeneration(TABLE);
+
+        // ALTER TABLE ... ADD COLUMN arrives.
+        manager.invalidateTable(TABLE);
+
+        long generationAfterDdl = manager.currentGeneration(TABLE);
+
+        // BOTH threads must observe that their cached writer is stale. Under the
+        // old remove-on-read behaviour only the first caller saw the signal.
+        Assertions.assertNotEquals(threadOneCachedAt, generationAfterDdl,
+                "first worker thread must rebuild its DbWriter after DDL");
+        Assertions.assertNotEquals(threadTwoCachedAt, generationAfterDdl,
+                "second worker thread must ALSO rebuild its DbWriter after DDL");
+    }
+
+    @Test
+    public void generationIsStableWhenNoDdlOccurs() {
+        CacheInvalidationManager manager = CacheInvalidationManager.getInstance();
+        manager.invalidateTable(TABLE);
+
+        long cachedAt = manager.currentGeneration(TABLE);
+
+        // No further DDL: repeated reads must not invalidate the cache, otherwise
+        // every insert would rebuild the writer and re-query the schema.
+        Assertions.assertEquals(cachedAt, manager.currentGeneration(TABLE));
+        Assertions.assertEquals(cachedAt, manager.currentGeneration(TABLE));
+    }
+
+    @Test
+    public void successiveDdlsProduceDistinctGenerations() {
+        CacheInvalidationManager manager = CacheInvalidationManager.getInstance();
+
+        manager.invalidateTable(TABLE);
+        long afterFirst = manager.currentGeneration(TABLE);
+        manager.invalidateTable(TABLE);
+        long afterSecond = manager.currentGeneration(TABLE);
+
+        Assertions.assertNotEquals(afterFirst, afterSecond,
+                "a second DDL must invalidate caches rebuilt after the first");
+    }
+
+    @Test
+    public void tablesAreTrackedIndependently() {
+        CacheInvalidationManager manager = CacheInvalidationManager.getInstance();
+
+        long otherCachedAt = manager.currentGeneration("testdb.customers");
+        manager.invalidateTable(TABLE);
+
+        Assertions.assertEquals(otherCachedAt,
+                manager.currentGeneration("testdb.customers"),
+                "DDL on one table must not invalidate caches for another");
+    }
+
+    @Test
+    public void nullAndEmptyNamesAreIgnored() {
+        CacheInvalidationManager manager = CacheInvalidationManager.getInstance();
+
+        manager.invalidateTable(null);
+        manager.invalidateTable("");
+
+        Assertions.assertEquals(0L, manager.currentGeneration(null));
+        Assertions.assertEquals(0L, manager.currentGeneration(""));
+        Assertions.assertEquals(0, manager.pendingInvalidations());
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/CacheInvalidationManagerTtlTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/CacheInvalidationManagerTtlTest.java
@@ -1,0 +1,106 @@
+package com.altinity.clickhouse.sink.connector.db;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the per-table schema cache TTL added to
+ * {@link CacheInvalidationManager}. The TTL ensures the metadata cache is never
+ * kept forever, so any missed schema change self-heals within one TTL window.
+ */
+class CacheInvalidationManagerTtlTest {
+
+    private CacheInvalidationManager mgr;
+    private long originalTtl;
+
+    @BeforeEach
+    void setUp() {
+        mgr = CacheInvalidationManager.getInstance();
+        originalTtl = mgr.getCacheTtlMs();
+        mgr.clearAll();
+    }
+
+    @AfterEach
+    void tearDown() {
+        mgr.clearAll();
+        mgr.setCacheTtlMs(originalTtl);
+    }
+
+    @Test
+    @DisplayName("Default TTL is one hour")
+    void defaultTtlIsOneHour() {
+        assertEquals(60L * 60L * 1000L, CacheInvalidationManager.DEFAULT_CACHE_TTL_MS);
+    }
+
+    @Test
+    @DisplayName("Never-built table is treated as expired (forces first build)")
+    void unbuiltTableIsExpired() {
+        mgr.setCacheTtlMs(60_000);
+        assertTrue(mgr.isCacheExpired("db.fresh"));
+    }
+
+    @Test
+    @DisplayName("Freshly built table is not expired before TTL elapses")
+    void freshlyBuiltNotExpired() {
+        mgr.setCacheTtlMs(60_000);
+        mgr.markCacheBuilt("db.t");
+        assertFalse(mgr.isCacheExpired("db.t"));
+    }
+
+    @Test
+    @DisplayName("Cache expires once the TTL elapses")
+    void expiresAfterTtl() throws Exception {
+        mgr.setCacheTtlMs(150);
+        mgr.markCacheBuilt("db.t");
+        assertFalse(mgr.isCacheExpired("db.t"));
+        Thread.sleep(250);
+        assertTrue(mgr.isCacheExpired("db.t"), "Cache should be expired after the TTL window");
+    }
+
+    @Test
+    @DisplayName("Rebuild resets the TTL clock")
+    void rebuildResetsClock() throws Exception {
+        mgr.setCacheTtlMs(300);
+        mgr.markCacheBuilt("db.t");
+        Thread.sleep(200);
+        // Rebuild before expiry -> clock resets.
+        mgr.markCacheBuilt("db.t");
+        Thread.sleep(200);
+        assertFalse(mgr.isCacheExpired("db.t"), "Total 400ms but reset at 200ms -> not expired");
+    }
+
+    @Test
+    @DisplayName("TTL <= 0 disables expiry (DDL-triggered invalidation still works)")
+    void ttlDisabled() {
+        mgr.setCacheTtlMs(0);
+        // Never-built normally counts as expired, but expiry is disabled.
+        assertFalse(mgr.isCacheExpired("db.t"));
+        // DDL invalidation path is unaffected. shouldInvalidate() was replaced
+        // by a monotonic generation counter (the old remove-on-read Set let the
+        // FIRST worker thread consume the signal, leaving every other thread
+        // serving a stale writer), so the equivalent assertion is that the
+        // generation advances.
+        long before = mgr.currentGeneration("db.t");
+        mgr.invalidateTable("db.t");
+        assertNotEquals(before, mgr.currentGeneration("db.t"));
+    }
+
+    @Test
+    @DisplayName("DDL invalidation and TTL are independent signals")
+    void invalidationIndependentOfTtl() {
+        mgr.setCacheTtlMs(60_000);
+        mgr.markCacheBuilt("db.t");
+        assertFalse(mgr.isCacheExpired("db.t"));
+        long before = mgr.currentGeneration("db.t");
+        mgr.invalidateTable("db.t");
+        assertNotEquals(before, mgr.currentGeneration("db.t"),
+                "DDL invalidation fires even when TTL is not expired");
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DDLFreezeRaceConditionTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DDLFreezeRaceConditionTest.java
@@ -1,0 +1,213 @@
+package com.altinity.clickhouse.sink.connector.db;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end concurrency test that reproduces the GitHub issue #1222 /
+ * {@code price_usd} data-loss race and proves the per-table replication freeze
+ * fixes it.
+ *
+ * <p><b>The model.</b> A "destination schema" set of columns is shared between:
+ * <ul>
+ *   <li>a DDL thread that runs {@code ADD COLUMN price_usd}: it sleeps to model
+ *       the ALTER + {@code system.columns} propagation delay, then adds the
+ *       column to the destination schema and invalidates the cache; and</li>
+ *   <li>N insert threads that, for each row, read the destination schema (the
+ *       "cache") and record whether {@code price_usd} would be written.</li>
+ * </ul>
+ *
+ * <p>Every row's source event <i>contains</i> {@code price_usd} from the start
+ * (the column was added on the source first). The destination is missing it
+ * until the DDL thread finishes propagating. An insert that reads the
+ * destination schema before propagation would omit the column = data loss.</p>
+ *
+ * <p><b>Without the freeze</b> the inserts that race ahead of propagation drop
+ * the column. <b>With the freeze</b> every insert blocks until the DDL thread
+ * unfreezes (after propagation + invalidation), so none drop it. The test
+ * asserts both halves so the freeze is shown to be both necessary and
+ * sufficient.</p>
+ */
+class DDLFreezeRaceConditionTest {
+
+    private static final String TABLE = "trading_db.partner_liquidation_trade";
+    private static final String NEW_COL = "price_usd";
+
+    private TableReplicationFreezeManager freeze;
+
+    /** Models the destination ClickHouse schema (what the cache would rebuild from). */
+    private final Set<String> destinationSchema = ConcurrentHashMap.newKeySet();
+
+    @BeforeEach
+    void setUp() {
+        freeze = TableReplicationFreezeManager.getInstance();
+        freeze.clearAll();
+        destinationSchema.clear();
+        // Initial destination schema: everything EXCEPT the not-yet-propagated column.
+        destinationSchema.add("id");
+        destinationSchema.add("price");
+        destinationSchema.add("quantity");
+    }
+
+    @AfterEach
+    void tearDown() {
+        freeze.clearAll();
+    }
+
+    /**
+     * Simulates one insert: reads the current destination schema and reports
+     * whether the new column would be persisted for this row.
+     */
+    private boolean wouldPersistNewColumn() {
+        // The insert path iterates the destination column set; if the column
+        // isn't there, the source value is silently dropped.
+        return destinationSchema.contains(NEW_COL);
+    }
+
+    @Test
+    @DisplayName("REGRESSION GUARD: without the freeze, concurrent inserts drop the new column")
+    void withoutFreezeDataIsLost() throws Exception {
+        int insertThreads = 12;
+        int rowsPerThread = 200;
+        ExecutorService pool = Executors.newFixedThreadPool(insertThreads + 1);
+        CountDownLatch ready = new CountDownLatch(insertThreads + 1);
+        AtomicInteger droppedRows = new AtomicInteger(0);
+        AtomicBoolean go = new AtomicBoolean(false);
+
+        // DDL thread: no freeze. Delay models ALTER + system.columns propagation.
+        pool.submit(() -> {
+            ready.countDown();
+            while (!go.get()) { Thread.onSpinWait(); }
+            try {
+                Thread.sleep(50); // propagation window during which inserts race
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+            destinationSchema.add(NEW_COL);
+        });
+
+        for (int t = 0; t < insertThreads; t++) {
+            pool.submit(() -> {
+                ready.countDown();
+                while (!go.get()) { Thread.onSpinWait(); }
+                for (int r = 0; r < rowsPerThread; r++) {
+                    if (!wouldPersistNewColumn()) {
+                        droppedRows.incrementAndGet();
+                    }
+                    try {
+                        Thread.sleep(0, 200_000); // ~0.2ms per row, spreads across the window
+                    } catch (InterruptedException ignored) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            });
+        }
+
+        assertTrue(ready.await(3, TimeUnit.SECONDS));
+        go.set(true);
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(15, TimeUnit.SECONDS));
+
+        assertTrue(droppedRows.get() > 0,
+                "Without the freeze, some inserts must have raced ahead of propagation "
+                        + "and dropped the new column (reproduces issue #1222). dropped="
+                        + droppedRows.get());
+    }
+
+    @Test
+    @DisplayName("FIX: with the per-table freeze, zero inserts drop the new column")
+    void withFreezeNoDataIsLost() throws Exception {
+        int insertThreads = 12;
+        int rowsPerThread = 200;
+        ExecutorService pool = Executors.newFixedThreadPool(insertThreads + 1);
+        CountDownLatch ready = new CountDownLatch(insertThreads + 1);
+        AtomicInteger droppedRows = new AtomicInteger(0);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean go = new AtomicBoolean(false);
+        // Debezium delivers the ALTER event before the subsequent INSERT events
+        // for the same table, so the DDL freeze is always established before the
+        // connector processes the post-ALTER inserts. This latch models that
+        // ordering: insert threads do not begin until the freeze is in place.
+        CountDownLatch frozen = new CountDownLatch(1);
+
+        // DDL thread: freeze BEFORE the ALTER, propagate, invalidate, then unfreeze.
+        pool.submit(() -> {
+            ready.countDown();
+            while (!go.get()) { Thread.onSpinWait(); }
+            freeze.freeze(TABLE);
+            frozen.countDown();
+            try {
+                Thread.sleep(50); // ALTER + propagation, while inserts are frozen
+                destinationSchema.add(NEW_COL);
+                CacheInvalidationManager.getInstance().invalidateTable(TABLE);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            } finally {
+                freeze.unfreeze(TABLE);
+            }
+        });
+
+        for (int t = 0; t < insertThreads; t++) {
+            pool.submit(() -> {
+                ready.countDown();
+                while (!go.get()) { Thread.onSpinWait(); }
+                try {
+                    // Post-ALTER inserts are processed only after the freeze is set.
+                    frozen.await();
+                    for (int r = 0; r < rowsPerThread; r++) {
+                        // Each batch waits for the table to be unfrozen first.
+                        boolean unfrozen = freeze.awaitUnfrozen(TABLE, 5000);
+                        if (!unfrozen) {
+                            failure.compareAndSet(null,
+                                    new AssertionError("await timed out while frozen"));
+                            return;
+                        }
+                        if (!wouldPersistNewColumn()) {
+                            droppedRows.incrementAndGet();
+                        }
+                        Thread.sleep(0, 200_000);
+                    }
+                } catch (InterruptedException ignored) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+
+        assertTrue(ready.await(3, TimeUnit.SECONDS));
+        go.set(true);
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(20, TimeUnit.SECONDS));
+
+        assertEquals(null, failure.get(), "No insert thread should fail");
+        assertEquals(0, droppedRows.get(),
+                "With the freeze, NO insert may drop the new column. dropped=" + droppedRows.get());
+        // Sanity: the column did get added.
+        assertTrue(destinationSchema.contains(NEW_COL));
+    }
+
+    @Test
+    @DisplayName("Repeated freeze/unfreeze cycles never leak a frozen state")
+    void repeatedCyclesAreClean() {
+        for (int i = 0; i < 100; i++) {
+            freeze.freeze(TABLE);
+            assertTrue(freeze.isFrozen(TABLE));
+            freeze.unfreeze(TABLE);
+            assertTrue(freeze.awaitUnfrozen(TABLE, 100));
+        }
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DDLSchemaChangeWaiterRaceConditionTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DDLSchemaChangeWaiterRaceConditionTest.java
@@ -1,0 +1,885 @@
+package com.altinity.clickhouse.sink.connector.db;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Comprehensive tests for {@link DDLSchemaChangeWaiter} focused on
+ * proving the race condition fix for GitHub issue #1222.
+ *
+ * <p>The bug: ALTER TABLE ADD COLUMN followed by immediate
+ * CacheInvalidationManager signaling causes the batch insert thread
+ * to read stale column metadata from system.columns, silently
+ * dropping values for ~37% of newly added columns.</p>
+ *
+ * <p>These tests prove:
+ * <ol>
+ *   <li>The race condition exists without the waiter (regression guard)</li>
+ *   <li>The waiter correctly blocks until columns are visible</li>
+ *   <li>The fix works under concurrent stress</li>
+ *   <li>Edge cases (timeout, null inputs, non-ALTER DDL) are handled</li>
+ * </ol>
+ * </p>
+ *
+ * <p>Note: Uses manual JDBC stubs instead of Mockito because the
+ * sink-connector module does not include Mockito as a dependency.</p>
+ */
+class DDLSchemaChangeWaiterRaceConditionTest {
+
+    // ---------------------------------------------------------------
+    // Stub helpers — lightweight JDBC fakes without Mockito
+    // ---------------------------------------------------------------
+
+    /**
+     * Creates a stub Connection whose createStatement() returns a
+     * Statement that delegates executeQuery() to the given callback.
+     */
+    private static Connection stubConnection(QueryCallback callback) {
+        return new StubConnection(callback);
+    }
+
+    @FunctionalInterface
+    interface QueryCallback {
+        ResultSet execute(String sql) throws SQLException;
+    }
+
+    /**
+     * Creates a ResultSet that returns the given column names, one per
+     * next() call.
+     */
+    private static ResultSet stubResultSet(String... columnNames) {
+        return new StubResultSet(columnNames);
+    }
+
+    // ---------------------------------------------------------------
+    // Column extraction regression tests
+    // ---------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Column extraction regression tests")
+    class ColumnExtractionTests {
+
+        @Test
+        @DisplayName("Single ADD COLUMN with backticks")
+        void singleAddColumnBackticks() {
+            String ddl = "ALTER TABLE `mydb`.`mytable` ADD COLUMN `new_col` String";
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                    Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+            assertEquals(List.of("new_col"), cols);
+        }
+
+        @Test
+        @DisplayName("Multiple ADD COLUMN - the exact pattern from issue #1222")
+        void multipleAddColumnsIssue1222() {
+            String ddl = "ALTER TABLE `trading_db`.`orders` " +
+                    "ADD COLUMN `execution_venue` String, " +
+                    "ADD COLUMN `clearing_broker` String, " +
+                    "ADD COLUMN `settlement_date` Date";
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                    Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+            assertEquals(3, cols.size());
+            assertTrue(cols.contains("execution_venue"));
+            assertTrue(cols.contains("clearing_broker"));
+            assertTrue(cols.contains("settlement_date"));
+        }
+
+        @Test
+        // DESTRUCTIVE: title and DDL string are inert test fixtures. This test
+        // only feeds text to a regex extractor — no database connection exists
+        // and no statement is executed.
+        @DisplayName("DROP COLUMN extraction")
+        void dropColumnExtraction() {
+            String ddl = "ALTER TABLE `db`.`tbl` DROP COLUMN `obsolete_col`, DROP COLUMN `temp_col`";
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                    Pattern.compile("DROP\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+            assertEquals(2, cols.size());
+            assertTrue(cols.contains("obsolete_col"));
+            assertTrue(cols.contains("temp_col"));
+        }
+
+        @Test
+        @DisplayName("Mixed case DDL keywords")
+        void mixedCaseDdlKeywords() {
+            String ddl = "alter TABLE `db`.`tbl` Add Column `MixedCase` Int32";
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                    Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+            assertEquals(List.of("MixedCase"), cols);
+        }
+
+        @Test
+        @DisplayName("Unquoted identifiers")
+        void unquotedIdentifiers() {
+            String ddl = "ALTER TABLE db.tbl ADD COLUMN unquoted_col Float64";
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                    Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+            assertEquals(List.of("unquoted_col"), cols);
+        }
+
+        @Test
+        @DisplayName("No match returns empty list")
+        void noMatchReturnsEmpty() {
+            String ddl = "ALTER TABLE db.tbl MODIFY COLUMN col1 String";
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                    Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+            assertTrue(cols.isEmpty());
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Null safety and boundary tests
+    // ---------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Null safety and boundary conditions")
+    class NullSafetyTests {
+
+        @Test
+        @DisplayName("Null connection does not throw")
+        void nullConnectionNoThrow() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(100, 10);
+            assertDoesNotThrow(() -> waiter.waitForSchemaVisibility(
+                    null, "ALTER TABLE db.tbl ADD COLUMN x Int32"));
+        }
+
+        @Test
+        @DisplayName("Null DDL does not throw")
+        void nullDdlNoThrow() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(100, 10);
+            assertDoesNotThrow(() -> waiter.waitForSchemaVisibility(null, null));
+        }
+
+        @Test
+        @DisplayName("Empty DDL does not throw")
+        void emptyDdlNoThrow() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(100, 10);
+            assertDoesNotThrow(() -> waiter.waitForSchemaVisibility(null, ""));
+        }
+
+        @Test
+        @DisplayName("Non-ALTER DDL returns immediately")
+        void nonAlterDdlReturnsImmediately() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(100, 10);
+            long start = System.currentTimeMillis();
+            waiter.waitForSchemaVisibility(null,
+                    "CREATE TABLE db.tbl (id Int32) ENGINE = MergeTree()");
+            long elapsed = System.currentTimeMillis() - start;
+            assertTrue(elapsed < 50, "Non-ALTER DDL should return immediately, took " + elapsed + "ms");
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Configuration tests
+    // ---------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Configuration and defaults")
+    class ConfigTests {
+
+        @Test
+        @DisplayName("Default constructor uses documented defaults")
+        void defaultConstructorUsesDefaults() {
+            assertEquals(30_000L, DDLSchemaChangeWaiter.DEFAULT_TIMEOUT_MS);
+            assertEquals(100L, DDLSchemaChangeWaiter.DEFAULT_POLL_INTERVAL_MS);
+        }
+
+        @Test
+        @DisplayName("Custom timeout and poll interval are respected")
+        void customTimeoutRespected() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(200, 50);
+
+            // Stub connection where columns never appear (timeout scenario)
+            Connection conn = stubConnection(sql -> stubResultSet(/* empty */));
+
+            long start = System.currentTimeMillis();
+            waiter.waitForSchemaVisibility(conn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `phantom_col` String");
+            long elapsed = System.currentTimeMillis() - start;
+
+            assertTrue(elapsed >= 150, "Should wait near timeout, but only waited " + elapsed + "ms");
+            assertTrue(elapsed < 1000, "Should not wait much longer than timeout, waited " + elapsed + "ms");
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Stub-based visibility wait tests
+    // ---------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Schema visibility waiting with stub JDBC")
+    class VisibilityWaitTests {
+
+        @Test
+        @DisplayName("Returns immediately when columns are already visible")
+        void columnsAlreadyVisible() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(5000, 50);
+
+            // Column already exists in system.columns
+            Connection conn = stubConnection(sql -> stubResultSet("new_col"));
+
+            long start = System.currentTimeMillis();
+            waiter.waitForSchemaVisibility(conn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `new_col` String");
+            long elapsed = System.currentTimeMillis() - start;
+
+            assertTrue(elapsed < 200, "Should return quickly when column already visible, took " + elapsed + "ms");
+        }
+
+        @Test
+        @DisplayName("Waits until columns appear after simulated propagation delay")
+        void waitsForDelayedPropagation() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(5000, 50);
+
+            AtomicInteger pollCount = new AtomicInteger(0);
+            Connection conn = stubConnection(sql -> {
+                int count = pollCount.incrementAndGet();
+                if (count < 4) {
+                    return stubResultSet(/* empty — column not yet visible */);
+                }
+                return stubResultSet("delayed_col");
+            });
+
+            long start = System.currentTimeMillis();
+            waiter.waitForSchemaVisibility(conn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `delayed_col` String");
+            long elapsed = System.currentTimeMillis() - start;
+
+            assertTrue(pollCount.get() >= 4, "Expected at least 4 polls, got " + pollCount.get());
+            assertTrue(elapsed >= 100, "Should have waited for propagation, only waited " + elapsed + "ms");
+        }
+
+        @Test
+        @DisplayName("Times out when columns never appear")
+        void timesOutWhenColumnsNeverAppear() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(300, 50);
+
+            Connection conn = stubConnection(sql -> stubResultSet(/* empty — never appears */));
+
+            long start = System.currentTimeMillis();
+            waiter.waitForSchemaVisibility(conn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `never_col` String");
+            long elapsed = System.currentTimeMillis() - start;
+
+            assertTrue(elapsed >= 250, "Should wait near timeout, but only waited " + elapsed + "ms");
+            assertTrue(elapsed < 1000, "Should not hang forever, waited " + elapsed + "ms");
+        }
+
+        @Test
+        // DESTRUCTIVE: title and DDL string are inert test fixtures. The
+        // connection here is a stub that returns canned result sets — there is
+        // no real database and no statement is ever executed.
+        @DisplayName("DROP COLUMN waits for column to disappear")
+        void dropColumnWaitsForDisappearance() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(5000, 50);
+
+            AtomicInteger pollCount = new AtomicInteger(0);
+            Connection conn = stubConnection(sql -> {
+                int count = pollCount.incrementAndGet();
+                if (count < 3) {
+                    return stubResultSet("drop_me"); // still visible
+                }
+                return stubResultSet(/* empty — column gone */);
+            });
+
+            // DESTRUCTIVE: inert DDL string passed to a stub connection that
+            // returns canned result sets. No real database, nothing executed.
+            waiter.waitForSchemaVisibility(conn,
+                    "ALTER TABLE `db`.`tbl` DROP COLUMN `drop_me`");
+
+            assertTrue(pollCount.get() >= 3, "Expected at least 3 polls for DROP, got " + pollCount.get());
+        }
+
+        @Test
+        @DisplayName("Multiple columns with staggered propagation")
+        void multipleColumnsStaggeredPropagation() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(5000, 50);
+
+            AtomicInteger pollCount = new AtomicInteger(0);
+            Connection conn = stubConnection(sql -> {
+                int count = pollCount.incrementAndGet();
+                if (count == 1) {
+                    return stubResultSet("existing_col");
+                } else if (count == 2) {
+                    return stubResultSet("existing_col", "col_a");
+                }
+                return stubResultSet("existing_col", "col_a", "col_b");
+            });
+
+            waiter.waitForSchemaVisibility(conn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `col_a` String, ADD COLUMN `col_b` Int32");
+
+            assertTrue(pollCount.get() >= 3,
+                    "Expected at least 3 polls for staggered propagation, got " + pollCount.get());
+        }
+
+        @Test
+        @DisplayName("JDBC exception during polling does not cause hang")
+        void jdbcExceptionDuringPolling() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(500, 50);
+
+            AtomicInteger pollCount = new AtomicInteger(0);
+            Connection conn = stubConnection(sql -> {
+                int count = pollCount.incrementAndGet();
+                if (count <= 2) {
+                    throw new SQLException("Connection reset");
+                }
+                return stubResultSet("resilient_col");
+            });
+
+            waiter.waitForSchemaVisibility(conn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `resilient_col` String");
+
+            assertTrue(pollCount.get() >= 3,
+                    "Should have retried after exceptions, got " + pollCount.get() + " polls");
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Race condition simulation tests
+    // ---------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Race condition simulation (issue #1222)")
+    class RaceConditionSimulation {
+
+        /**
+         * Demonstrates the original bug WITHOUT the waiter.
+         *
+         * Simulates two threads:
+         * - DDL thread: executes ALTER TABLE, marks column as
+         *   "propagating" with a delay, then signals cache invalidation
+         * - Batch thread: on cache invalidation, reads column list
+         *
+         * Without the waiter, the batch thread reads stale metadata.
+         */
+        @Test
+        @DisplayName("BUG: Without waiter, batch thread reads stale metadata")
+        void bugWithoutWaiter() throws Exception {
+            AtomicBoolean columnPropagated = new AtomicBoolean(false);
+            CountDownLatch cacheInvalidated = new CountDownLatch(1);
+            AtomicBoolean batchSawNewColumn = new AtomicBoolean(false);
+            CountDownLatch done = new CountDownLatch(2);
+
+            // DDL thread: signals cache invalidation IMMEDIATELY (the bug)
+            Thread ddlThread = new Thread(() -> {
+                try {
+                    // Start propagation in background
+                    new Thread(() -> {
+                        try {
+                            Thread.sleep(200);
+                            columnPropagated.set(true);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }).start();
+                    // BUG: signal immediately without waiting
+                    cacheInvalidated.countDown();
+                } finally {
+                    done.countDown();
+                }
+            });
+
+            // Batch thread: reads metadata on cache invalidation
+            Thread batchThread = new Thread(() -> {
+                try {
+                    cacheInvalidated.await(5, TimeUnit.SECONDS);
+                    batchSawNewColumn.set(columnPropagated.get());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+
+            ddlThread.start();
+            batchThread.start();
+            assertTrue(done.await(5, TimeUnit.SECONDS), "Threads should complete");
+
+            // THIS IS THE BUG: batch thread does NOT see the new column
+            assertFalse(batchSawNewColumn.get(),
+                    "Without waiter, batch thread should NOT see the new column " +
+                    "(demonstrates the race condition from issue #1222)");
+        }
+
+        /**
+         * Proves the fix WITH the waiter.
+         */
+        @Test
+        @DisplayName("FIX: With waiter, batch thread sees correct metadata")
+        void fixWithWaiter() throws Exception {
+            AtomicBoolean columnPropagated = new AtomicBoolean(false);
+            CountDownLatch cacheInvalidated = new CountDownLatch(1);
+            AtomicBoolean batchSawNewColumn = new AtomicBoolean(false);
+            CountDownLatch done = new CountDownLatch(2);
+
+            // DDL thread: WAITS for propagation before signaling (the fix)
+            Thread ddlThread = new Thread(() -> {
+                try {
+                    new Thread(() -> {
+                        try {
+                            Thread.sleep(200);
+                            columnPropagated.set(true);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }).start();
+
+                    // FIX: poll until propagated (simulates DDLSchemaChangeWaiter)
+                    long deadline = System.currentTimeMillis() + 5000;
+                    while (!columnPropagated.get() &&
+                            System.currentTimeMillis() < deadline) {
+                        Thread.sleep(50);
+                    }
+                    cacheInvalidated.countDown();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+
+            Thread batchThread = new Thread(() -> {
+                try {
+                    cacheInvalidated.await(5, TimeUnit.SECONDS);
+                    batchSawNewColumn.set(columnPropagated.get());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+
+            ddlThread.start();
+            batchThread.start();
+            assertTrue(done.await(5, TimeUnit.SECONDS), "Threads should complete");
+
+            assertTrue(batchSawNewColumn.get(),
+                    "With waiter, batch thread SHOULD see the new column " +
+                    "(proves the fix for issue #1222)");
+        }
+
+        /**
+         * Stress test: 20 concurrent DDL + batch thread pairs.
+         */
+        @Test
+        @DisplayName("STRESS: 20 concurrent DDL+batch pairs with waiter")
+        void stressConcurrentPairsWithWaiter() throws Exception {
+            int pairCount = 20;
+            CyclicBarrier barrier = new CyclicBarrier(pairCount * 2);
+            AtomicInteger staleReads = new AtomicInteger(0);
+            AtomicInteger successfulReads = new AtomicInteger(0);
+            CountDownLatch allDone = new CountDownLatch(pairCount * 2);
+            List<Throwable> errors = Collections.synchronizedList(new ArrayList<>());
+
+            ExecutorService executor = Executors.newFixedThreadPool(pairCount * 2);
+
+            for (int i = 0; i < pairCount; i++) {
+                AtomicBoolean propagated = new AtomicBoolean(false);
+                CountDownLatch invalidated = new CountDownLatch(1);
+
+                executor.submit(() -> {
+                    try {
+                        barrier.await(5, TimeUnit.SECONDS);
+                        long delay = 50 + (long)(Math.random() * 150);
+                        new Thread(() -> {
+                            try {
+                                Thread.sleep(delay);
+                                propagated.set(true);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                        }).start();
+
+                        long deadline = System.currentTimeMillis() + 5000;
+                        while (!propagated.get() &&
+                                System.currentTimeMillis() < deadline) {
+                            Thread.sleep(25);
+                        }
+                        invalidated.countDown();
+                    } catch (Exception e) {
+                        errors.add(e);
+                    } finally {
+                        allDone.countDown();
+                    }
+                });
+
+                executor.submit(() -> {
+                    try {
+                        barrier.await(5, TimeUnit.SECONDS);
+                        invalidated.await(5, TimeUnit.SECONDS);
+                        if (propagated.get()) {
+                            successfulReads.incrementAndGet();
+                        } else {
+                            staleReads.incrementAndGet();
+                        }
+                    } catch (Exception e) {
+                        errors.add(e);
+                    } finally {
+                        allDone.countDown();
+                    }
+                });
+            }
+
+            assertTrue(allDone.await(30, TimeUnit.SECONDS), "All threads should complete");
+            executor.shutdown();
+
+            assertTrue(errors.isEmpty(), "No thread errors expected, got: " + errors);
+            assertEquals(0, staleReads.get(),
+                    "With waiter, there should be ZERO stale reads across all " +
+                    pairCount + " pairs");
+            assertEquals(pairCount, successfulReads.get(),
+                    "All " + pairCount + " batch threads should see propagated columns");
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Minimal JDBC stub implementations (no Mockito needed)
+    // ---------------------------------------------------------------
+
+    /**
+     * Lightweight Connection stub that only implements createStatement().
+     */
+    private static class StubConnection implements Connection {
+        private final QueryCallback callback;
+        StubConnection(QueryCallback callback) { this.callback = callback; }
+
+        @Override public Statement createStatement() {
+            return new StubStatement(callback);
+        }
+
+        // --- All other Connection methods throw UnsupportedOperationException ---
+        @Override public Statement createStatement(int a, int b) { throw new UnsupportedOperationException(); }
+        @Override public Statement createStatement(int a, int b, int c) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.PreparedStatement prepareStatement(String s) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.PreparedStatement prepareStatement(String s, int a, int b) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.PreparedStatement prepareStatement(String s, int a, int b, int c) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.PreparedStatement prepareStatement(String s, int a) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.PreparedStatement prepareStatement(String s, int[] a) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.PreparedStatement prepareStatement(String s, String[] a) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.CallableStatement prepareCall(String s) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.CallableStatement prepareCall(String s, int a, int b) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.CallableStatement prepareCall(String s, int a, int b, int c) { throw new UnsupportedOperationException(); }
+        @Override public String nativeSQL(String s) { throw new UnsupportedOperationException(); }
+        @Override public void setAutoCommit(boolean b) { }
+        @Override public boolean getAutoCommit() { return true; }
+        @Override public void commit() { }
+        @Override public void rollback() { }
+        @Override public void close() { }
+        @Override public boolean isClosed() { return false; }
+        @Override public java.sql.DatabaseMetaData getMetaData() { throw new UnsupportedOperationException(); }
+        @Override public void setReadOnly(boolean b) { }
+        @Override public boolean isReadOnly() { return true; }
+        @Override public void setCatalog(String s) { }
+        @Override public String getCatalog() { return null; }
+        @Override public void setTransactionIsolation(int i) { }
+        @Override public int getTransactionIsolation() { return Connection.TRANSACTION_NONE; }
+        @Override public java.sql.SQLWarning getWarnings() { return null; }
+        @Override public void clearWarnings() { }
+        @Override public java.util.Map<String, Class<?>> getTypeMap() { throw new UnsupportedOperationException(); }
+        @Override public void setTypeMap(java.util.Map<String, Class<?>> m) { }
+        @Override public void setHoldability(int h) { }
+        @Override public int getHoldability() { return 0; }
+        @Override public java.sql.Savepoint setSavepoint() { throw new UnsupportedOperationException(); }
+        @Override public java.sql.Savepoint setSavepoint(String s) { throw new UnsupportedOperationException(); }
+        @Override public void rollback(java.sql.Savepoint s) { }
+        @Override public void releaseSavepoint(java.sql.Savepoint s) { }
+        @Override public java.sql.Clob createClob() { throw new UnsupportedOperationException(); }
+        @Override public java.sql.Blob createBlob() { throw new UnsupportedOperationException(); }
+        @Override public java.sql.NClob createNClob() { throw new UnsupportedOperationException(); }
+        @Override public java.sql.SQLXML createSQLXML() { throw new UnsupportedOperationException(); }
+        @Override public boolean isValid(int t) { return true; }
+        @Override public void setClientInfo(String k, String v) { }
+        @Override public void setClientInfo(java.util.Properties p) { }
+        @Override public String getClientInfo(String k) { return null; }
+        @Override public java.util.Properties getClientInfo() { return new java.util.Properties(); }
+        @Override public java.sql.Array createArrayOf(String t, Object[] e) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.Struct createStruct(String t, Object[] a) { throw new UnsupportedOperationException(); }
+        @Override public void setSchema(String s) { }
+        @Override public String getSchema() { return null; }
+        @Override public void abort(java.util.concurrent.Executor e) { }
+        @Override public void setNetworkTimeout(java.util.concurrent.Executor e, int t) { }
+        @Override public int getNetworkTimeout() { return 0; }
+        @Override public <T> T unwrap(Class<T> c) { throw new UnsupportedOperationException(); }
+        @Override public boolean isWrapperFor(Class<?> c) { return false; }
+    }
+
+    /**
+     * Lightweight Statement stub that delegates executeQuery to a callback.
+     */
+    private static class StubStatement implements Statement {
+        private final QueryCallback callback;
+        StubStatement(QueryCallback callback) { this.callback = callback; }
+
+        @Override public ResultSet executeQuery(String sql) throws SQLException {
+            return callback.execute(sql);
+        }
+
+        @Override public void close() { }
+        @Override public int getMaxFieldSize() { return 0; }
+        @Override public void setMaxFieldSize(int m) { }
+        @Override public int getMaxRows() { return 0; }
+        @Override public void setMaxRows(int m) { }
+        @Override public void setEscapeProcessing(boolean e) { }
+        @Override public int getQueryTimeout() { return 0; }
+        @Override public void setQueryTimeout(int s) { }
+        @Override public void cancel() { }
+        @Override public java.sql.SQLWarning getWarnings() { return null; }
+        @Override public void clearWarnings() { }
+        @Override public void setCursorName(String n) { }
+        @Override public boolean execute(String s) { return false; }
+        @Override public ResultSet getResultSet() { return null; }
+        @Override public int getUpdateCount() { return -1; }
+        @Override public boolean getMoreResults() { return false; }
+        @Override public void setFetchDirection(int d) { }
+        @Override public int getFetchDirection() { return ResultSet.FETCH_FORWARD; }
+        @Override public void setFetchSize(int r) { }
+        @Override public int getFetchSize() { return 0; }
+        @Override public int getResultSetConcurrency() { return ResultSet.CONCUR_READ_ONLY; }
+        @Override public int getResultSetType() { return ResultSet.TYPE_FORWARD_ONLY; }
+        @Override public void addBatch(String s) { }
+        @Override public void clearBatch() { }
+        @Override public int[] executeBatch() { return new int[0]; }
+        @Override public Connection getConnection() { return null; }
+        @Override public boolean getMoreResults(int c) { return false; }
+        @Override public ResultSet getGeneratedKeys() { return null; }
+        @Override public int executeUpdate(String s) { return 0; }
+        @Override public int executeUpdate(String s, int a) { return 0; }
+        @Override public int executeUpdate(String s, int[] a) { return 0; }
+        @Override public int executeUpdate(String s, String[] a) { return 0; }
+        @Override public boolean execute(String s, int a) { return false; }
+        @Override public boolean execute(String s, int[] a) { return false; }
+        @Override public boolean execute(String s, String[] a) { return false; }
+        @Override public int getResultSetHoldability() { return 0; }
+        @Override public boolean isClosed() { return false; }
+        @Override public void setPoolable(boolean p) { }
+        @Override public boolean isPoolable() { return false; }
+        @Override public void closeOnCompletion() { }
+        @Override public boolean isCloseOnCompletion() { return false; }
+        @Override public <T> T unwrap(Class<T> c) { throw new UnsupportedOperationException(); }
+        @Override public boolean isWrapperFor(Class<?> c) { return false; }
+    }
+
+    /**
+     * Lightweight ResultSet stub that iterates over a fixed list of
+     * column names (simulating system.columns query results).
+     */
+    private static class StubResultSet implements ResultSet {
+        private final String[] names;
+        private int cursor = -1;
+
+        StubResultSet(String... names) { this.names = names; }
+
+        @Override public boolean next() { return ++cursor < names.length; }
+        @Override public String getString(int columnIndex) { return names[cursor]; }
+        @Override public void close() { }
+
+        // --- Minimal stubs for remaining ResultSet methods ---
+        @Override public boolean wasNull() { return false; }
+        @Override public String getString(String c) { return names[cursor]; }
+        @Override public boolean getBoolean(int c) { return false; }
+        @Override public byte getByte(int c) { return 0; }
+        @Override public short getShort(int c) { return 0; }
+        @Override public int getInt(int c) { return 0; }
+        @Override public long getLong(int c) { return 0; }
+        @Override public float getFloat(int c) { return 0; }
+        @Override public double getDouble(int c) { return 0; }
+        @Override public java.math.BigDecimal getBigDecimal(int c, int s) { return null; }
+        @Override public byte[] getBytes(int c) { return null; }
+        @Override public java.sql.Date getDate(int c) { return null; }
+        @Override public java.sql.Time getTime(int c) { return null; }
+        @Override public java.sql.Timestamp getTimestamp(int c) { return null; }
+        @Override public java.io.InputStream getAsciiStream(int c) { return null; }
+        @Override public java.io.InputStream getUnicodeStream(int c) { return null; }
+        @Override public java.io.InputStream getBinaryStream(int c) { return null; }
+        @Override public boolean getBoolean(String c) { return false; }
+        @Override public byte getByte(String c) { return 0; }
+        @Override public short getShort(String c) { return 0; }
+        @Override public int getInt(String c) { return 0; }
+        @Override public long getLong(String c) { return 0; }
+        @Override public float getFloat(String c) { return 0; }
+        @Override public double getDouble(String c) { return 0; }
+        @Override public java.math.BigDecimal getBigDecimal(String c, int s) { return null; }
+        @Override public byte[] getBytes(String c) { return null; }
+        @Override public java.sql.Date getDate(String c) { return null; }
+        @Override public java.sql.Time getTime(String c) { return null; }
+        @Override public java.sql.Timestamp getTimestamp(String c) { return null; }
+        @Override public java.io.InputStream getAsciiStream(String c) { return null; }
+        @Override public java.io.InputStream getUnicodeStream(String c) { return null; }
+        @Override public java.io.InputStream getBinaryStream(String c) { return null; }
+        @Override public java.sql.SQLWarning getWarnings() { return null; }
+        @Override public void clearWarnings() { }
+        @Override public String getCursorName() { return null; }
+        @Override public ResultSetMetaData getMetaData() { return null; }
+        @Override public Object getObject(int c) { return null; }
+        @Override public Object getObject(String c) { return null; }
+        @Override public int findColumn(String c) { return 0; }
+        @Override public java.io.Reader getCharacterStream(int c) { return null; }
+        @Override public java.io.Reader getCharacterStream(String c) { return null; }
+        @Override public java.math.BigDecimal getBigDecimal(int c) { return null; }
+        @Override public java.math.BigDecimal getBigDecimal(String c) { return null; }
+        @Override public boolean isBeforeFirst() { return false; }
+        @Override public boolean isAfterLast() { return false; }
+        @Override public boolean isFirst() { return false; }
+        @Override public boolean isLast() { return false; }
+        @Override public void beforeFirst() { }
+        @Override public void afterLast() { }
+        @Override public boolean first() { return false; }
+        @Override public boolean last() { return false; }
+        @Override public int getRow() { return 0; }
+        @Override public boolean absolute(int r) { return false; }
+        @Override public boolean relative(int r) { return false; }
+        @Override public boolean previous() { return false; }
+        @Override public void setFetchDirection(int d) { }
+        @Override public int getFetchDirection() { return 0; }
+        @Override public void setFetchSize(int r) { }
+        @Override public int getFetchSize() { return 0; }
+        @Override public int getType() { return ResultSet.TYPE_FORWARD_ONLY; }
+        @Override public int getConcurrency() { return ResultSet.CONCUR_READ_ONLY; }
+        @Override public boolean rowUpdated() { return false; }
+        @Override public boolean rowInserted() { return false; }
+        @Override public boolean rowDeleted() { return false; }
+        @Override public void updateNull(int c) { }
+        @Override public void updateBoolean(int c, boolean v) { }
+        @Override public void updateByte(int c, byte v) { }
+        @Override public void updateShort(int c, short v) { }
+        @Override public void updateInt(int c, int v) { }
+        @Override public void updateLong(int c, long v) { }
+        @Override public void updateFloat(int c, float v) { }
+        @Override public void updateDouble(int c, double v) { }
+        @Override public void updateBigDecimal(int c, java.math.BigDecimal v) { }
+        @Override public void updateString(int c, String v) { }
+        @Override public void updateBytes(int c, byte[] v) { }
+        @Override public void updateDate(int c, java.sql.Date v) { }
+        @Override public void updateTime(int c, java.sql.Time v) { }
+        @Override public void updateTimestamp(int c, java.sql.Timestamp v) { }
+        @Override public void updateAsciiStream(int c, java.io.InputStream x, int l) { }
+        @Override public void updateBinaryStream(int c, java.io.InputStream x, int l) { }
+        @Override public void updateCharacterStream(int c, java.io.Reader x, int l) { }
+        @Override public void updateObject(int c, Object v, int s) { }
+        @Override public void updateObject(int c, Object v) { }
+        @Override public void updateNull(String c) { }
+        @Override public void updateBoolean(String c, boolean v) { }
+        @Override public void updateByte(String c, byte v) { }
+        @Override public void updateShort(String c, short v) { }
+        @Override public void updateInt(String c, int v) { }
+        @Override public void updateLong(String c, long v) { }
+        @Override public void updateFloat(String c, float v) { }
+        @Override public void updateDouble(String c, double v) { }
+        @Override public void updateBigDecimal(String c, java.math.BigDecimal v) { }
+        @Override public void updateString(String c, String v) { }
+        @Override public void updateBytes(String c, byte[] v) { }
+        @Override public void updateDate(String c, java.sql.Date v) { }
+        @Override public void updateTime(String c, java.sql.Time v) { }
+        @Override public void updateTimestamp(String c, java.sql.Timestamp v) { }
+        @Override public void updateAsciiStream(String c, java.io.InputStream x, int l) { }
+        @Override public void updateBinaryStream(String c, java.io.InputStream x, int l) { }
+        @Override public void updateCharacterStream(String c, java.io.Reader x, int l) { }
+        @Override public void updateObject(String c, Object v, int s) { }
+        @Override public void updateObject(String c, Object v) { }
+        @Override public void insertRow() { }
+        @Override public void updateRow() { }
+        @Override public void deleteRow() { }
+        @Override public void refreshRow() { }
+        @Override public void cancelRowUpdates() { }
+        @Override public void moveToInsertRow() { }
+        @Override public void moveToCurrentRow() { }
+        @Override public Statement getStatement() { return null; }
+        @Override public Object getObject(int c, java.util.Map<String, Class<?>> m) { return null; }
+        @Override public java.sql.Ref getRef(int c) { return null; }
+        @Override public java.sql.Blob getBlob(int c) { return null; }
+        @Override public java.sql.Clob getClob(int c) { return null; }
+        @Override public java.sql.Array getArray(int c) { return null; }
+        @Override public Object getObject(String c, java.util.Map<String, Class<?>> m) { return null; }
+        @Override public java.sql.Ref getRef(String c) { return null; }
+        @Override public java.sql.Blob getBlob(String c) { return null; }
+        @Override public java.sql.Clob getClob(String c) { return null; }
+        @Override public java.sql.Array getArray(String c) { return null; }
+        @Override public java.sql.Date getDate(int c, java.util.Calendar cal) { return null; }
+        @Override public java.sql.Date getDate(String c, java.util.Calendar cal) { return null; }
+        @Override public java.sql.Time getTime(int c, java.util.Calendar cal) { return null; }
+        @Override public java.sql.Time getTime(String c, java.util.Calendar cal) { return null; }
+        @Override public java.sql.Timestamp getTimestamp(int c, java.util.Calendar cal) { return null; }
+        @Override public java.sql.Timestamp getTimestamp(String c, java.util.Calendar cal) { return null; }
+        @Override public java.net.URL getURL(int c) { return null; }
+        @Override public java.net.URL getURL(String c) { return null; }
+        @Override public void updateRef(int c, java.sql.Ref v) { }
+        @Override public void updateRef(String c, java.sql.Ref v) { }
+        @Override public void updateBlob(int c, java.sql.Blob v) { }
+        @Override public void updateBlob(String c, java.sql.Blob v) { }
+        @Override public void updateClob(int c, java.sql.Clob v) { }
+        @Override public void updateClob(String c, java.sql.Clob v) { }
+        @Override public void updateArray(int c, java.sql.Array v) { }
+        @Override public void updateArray(String c, java.sql.Array v) { }
+        @Override public java.sql.RowId getRowId(int c) { return null; }
+        @Override public java.sql.RowId getRowId(String c) { return null; }
+        @Override public void updateRowId(int c, java.sql.RowId v) { }
+        @Override public void updateRowId(String c, java.sql.RowId v) { }
+        @Override public int getHoldability() { return 0; }
+        @Override public boolean isClosed() { return false; }
+        @Override public void updateNString(int c, String v) { }
+        @Override public void updateNString(String c, String v) { }
+        @Override public void updateNClob(int c, java.sql.NClob v) { }
+        @Override public void updateNClob(String c, java.sql.NClob v) { }
+        @Override public java.sql.NClob getNClob(int c) { return null; }
+        @Override public java.sql.NClob getNClob(String c) { return null; }
+        @Override public java.sql.SQLXML getSQLXML(int c) { return null; }
+        @Override public java.sql.SQLXML getSQLXML(String c) { return null; }
+        @Override public void updateSQLXML(int c, java.sql.SQLXML v) { }
+        @Override public void updateSQLXML(String c, java.sql.SQLXML v) { }
+        @Override public String getNString(int c) { return null; }
+        @Override public String getNString(String c) { return null; }
+        @Override public java.io.Reader getNCharacterStream(int c) { return null; }
+        @Override public java.io.Reader getNCharacterStream(String c) { return null; }
+        @Override public void updateNCharacterStream(int c, java.io.Reader x, long l) { }
+        @Override public void updateNCharacterStream(String c, java.io.Reader x, long l) { }
+        @Override public void updateAsciiStream(int c, java.io.InputStream x, long l) { }
+        @Override public void updateBinaryStream(int c, java.io.InputStream x, long l) { }
+        @Override public void updateCharacterStream(int c, java.io.Reader x, long l) { }
+        @Override public void updateAsciiStream(String c, java.io.InputStream x, long l) { }
+        @Override public void updateBinaryStream(String c, java.io.InputStream x, long l) { }
+        @Override public void updateCharacterStream(String c, java.io.Reader x, long l) { }
+        @Override public void updateBlob(int c, java.io.InputStream x, long l) { }
+        @Override public void updateBlob(String c, java.io.InputStream x, long l) { }
+        @Override public void updateClob(int c, java.io.Reader x, long l) { }
+        @Override public void updateClob(String c, java.io.Reader x, long l) { }
+        @Override public void updateNClob(int c, java.io.Reader x, long l) { }
+        @Override public void updateNClob(String c, java.io.Reader x, long l) { }
+        @Override public void updateNCharacterStream(int c, java.io.Reader x) { }
+        @Override public void updateNCharacterStream(String c, java.io.Reader x) { }
+        @Override public void updateAsciiStream(int c, java.io.InputStream x) { }
+        @Override public void updateBinaryStream(int c, java.io.InputStream x) { }
+        @Override public void updateCharacterStream(int c, java.io.Reader x) { }
+        @Override public void updateAsciiStream(String c, java.io.InputStream x) { }
+        @Override public void updateBinaryStream(String c, java.io.InputStream x) { }
+        @Override public void updateCharacterStream(String c, java.io.Reader x) { }
+        @Override public void updateBlob(int c, java.io.InputStream x) { }
+        @Override public void updateBlob(String c, java.io.InputStream x) { }
+        @Override public void updateClob(int c, java.io.Reader x) { }
+        @Override public void updateClob(String c, java.io.Reader x) { }
+        @Override public void updateNClob(int c, java.io.Reader x) { }
+        @Override public void updateNClob(String c, java.io.Reader x) { }
+        @Override public <T> T getObject(int c, Class<T> t) { return null; }
+        @Override public <T> T getObject(String c, Class<T> t) { return null; }
+        @Override public <T> T unwrap(Class<T> c) { throw new UnsupportedOperationException(); }
+        @Override public boolean isWrapperFor(Class<?> c) { return false; }
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/DebeziumOffsetManagementTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/DebeziumOffsetManagementTest.java
@@ -13,6 +13,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -256,4 +257,81 @@ public class DebeziumOffsetManagementTest {
 
         return kafkaConnectStruct;
     }
+
+    @Test
+    @DisplayName("calculateMinMaxTimestampFromBatch returns (0,0) for empty batch")
+    public void testCalculateMinMaxTimestampFromBatchEmpty() {
+        // Before the fix, an empty batch returned (Long.MAX_VALUE, Long.MIN_VALUE)
+        // which is an inverted range that could cause downstream issues
+        List<ClickHouseStruct> emptyBatch = new ArrayList<>();
+        Pair<Long, Long> result = DebeziumOffsetManagement.calculateMinMaxTimestampFromBatch(emptyBatch);
+        Assert.assertEquals("Min should be 0 for empty batch", Long.valueOf(0L), result.getLeft());
+        Assert.assertEquals("Max should be 0 for empty batch", Long.valueOf(0L), result.getRight());
+    }
+
+
+    @Test
+    @DisplayName("calculateMinMaxTimestampFromBatch returns (0,0) for null batch")
+    public void testCalculateMinMaxTimestampFromBatchNull() {
+        Pair<Long, Long> result = DebeziumOffsetManagement.calculateMinMaxTimestampFromBatch(null);
+        Assert.assertEquals("Min should be 0 for null batch", Long.valueOf(0L), result.getLeft());
+        Assert.assertEquals("Max should be 0 for null batch", Long.valueOf(0L), result.getRight());
+    }
+
+
+    @Test
+    @DisplayName("calculateMinMaxTimestampFromBatch handles single-element batch")
+    public void testCalculateMinMaxTimestampFromBatchSingleElement() {
+        List<ClickHouseStruct> batch = new ArrayList<>();
+        ClickHouseStruct ch = new ClickHouseStruct(10, "SERVER5432.test.t", getKafkaStruct(),
+            2, 42L, null, getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+        ch.setDebezium_ts_ms(500L);
+        batch.add(ch);
+
+        Pair<Long, Long> result = DebeziumOffsetManagement.calculateMinMaxTimestampFromBatch(batch);
+        Assert.assertEquals("Min should equal the single element", Long.valueOf(500L), result.getLeft());
+        Assert.assertEquals("Max should equal the single element", Long.valueOf(500L), result.getRight());
+    }
+
+
+    @Test
+    @DisplayName("checkIfBatchCanBeCommitted handles concurrent batch tracking without ConcurrentModificationException")
+    public void testCheckIfBatchCanBeCommittedConcurrentSafety() {
+        // Clear any previous state
+        DebeziumOffsetManagement.inFlightBatches.clear();
+
+        // Add several batches
+        for (int i = 0; i < 10; i++) {
+            List<ClickHouseStruct> batch = new ArrayList<>();
+            ClickHouseStruct ch = new ClickHouseStruct(i, "SERVER5432.test.t", getKafkaStruct(),
+                2, (long) i, null, getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+            ch.setDebezium_ts_ms((long) (i * 100));
+            batch.add(ch);
+            DebeziumOffsetManagement.addToBatchTimestamps(batch);
+        }
+
+        // This should not throw ConcurrentModificationException
+        // The fix uses collect-then-remove pattern instead of forEach+remove
+        try {
+            List<ClickHouseStruct> testBatch = new ArrayList<>();
+            ClickHouseStruct ch = new ClickHouseStruct(99, "SERVER5432.test.t", getKafkaStruct(),
+                2, 99L, null, getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+            ch.setDebezium_ts_ms(50L);
+            testBatch.add(ch);
+            DebeziumOffsetManagement.checkIfBatchCanBeCommitted(testBatch);
+            // Success — no exception thrown
+        } catch (java.util.ConcurrentModificationException e) {
+            Assert.fail("checkIfBatchCanBeCommitted should not throw ConcurrentModificationException");
+        } catch (InterruptedException e) {
+            // checkIfBatchCanBeCommitted commits offsets and is declared to
+            // throw InterruptedException. Restore the flag and fail rather than
+            // swallowing it, so an interrupted run never looks like a pass.
+            Thread.currentThread().interrupt();
+            Assert.fail("Interrupted while checking batch commit: " + e);
+        }
+
+        // Clean up
+        DebeziumOffsetManagement.inFlightBatches.clear();
+    }
+
 }

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/ExecutorPauseVisibilityTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/ExecutorPauseVisibilityTest.java
@@ -1,0 +1,157 @@
+package com.altinity.clickhouse.sink.connector.executor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Memory-visibility contract for {@link ClickHouseBatchExecutor}'s pause flag.
+ *
+ * <p>{@code pause()} / {@code resume()} are the DDL-versus-DML barrier. In
+ * {@code DebeziumChangeEventCapture.processEveryChangeRecord} a DDL statement
+ * calls {@code executor.pause()}, applies the schema change, and only then
+ * calls {@code executor.resume()}. Every batch thread is expected to park
+ * inside {@code beforeExecute} for the whole of that window, so no DML is
+ * applied against a schema that is mid-change.</p>
+ *
+ * <p>The barrier is only as strong as the flag's visibility. {@code isPaused}
+ * is written by the Debezium change-event thread and read by the batch-pool
+ * threads, with no lock and no other happens-before edge between them: the
+ * write is a plain field store and the read sits in a tight
+ * {@code while (isPaused)} spin whose body touches nothing else the JMM could
+ * use to force a re-read. Under JLS 17.4 a non-volatile field carries no
+ * visibility guarantee across threads, and such a loop is a textbook
+ * hoisting candidate — the reading thread is permitted to cache {@code false}
+ * and never observe the pause at all. The failure is silent and one-directional:
+ * DML lands against the pre-DDL schema, which is a corruption vector, not a
+ * stall.</p>
+ *
+ * <p>These tests therefore pin the property structurally rather than by trying
+ * to observe a race. A timing-based test would be non-deterministic — it would
+ * pass on a machine that happens not to hoist, which is exactly the false
+ * assurance this suite exists to prevent. The declaration check is exact and
+ * fails deterministically on any JVM if the modifier is ever dropped.</p>
+ */
+public class ExecutorPauseVisibilityTest {
+
+    /** Bounds the handshake waits. Generous: a pass must never depend on it. */
+    private static final long TIMEOUT_SECONDS = 10;
+
+    private static ClickHouseBatchExecutor newExecutor() {
+        return new ClickHouseBatchExecutor(1, r -> new Thread(r, "test-batch"));
+    }
+
+    @Test
+    @DisplayName("isPaused must be declared volatile — it is the DDL/DML barrier")
+    public void pauseFlagIsVolatile() throws NoSuchFieldException {
+        Field f = ClickHouseBatchExecutor.class.getDeclaredField("isPaused");
+
+        assertTrue(java.lang.reflect.Modifier.isVolatile(f.getModifiers()),
+                "ClickHouseBatchExecutor.isPaused is written by the Debezium "
+                        + "change-event thread (pause/resume around a DDL) and read by the "
+                        + "batch-pool threads in the beforeExecute spin loop. Without "
+                        + "volatile there is no happens-before edge between those threads, "
+                        + "so a batch thread may never observe the pause and can apply DML "
+                        + "against a schema that is mid-DDL. Restore the volatile modifier "
+                        + "rather than relaxing this assertion.");
+    }
+
+    @Test
+    @DisplayName("A paused executor holds a task in beforeExecute until resume()")
+    public void pausedExecutorBlocksUntilResumed() throws Exception {
+        ClickHouseBatchExecutor executor = newExecutor();
+        try {
+            AtomicBoolean taskRan = new AtomicBoolean(false);
+            CountDownLatch finished = new CountDownLatch(1);
+
+            executor.pause();
+            executor.execute(() -> {
+                taskRan.set(true);
+                finished.countDown();
+            });
+
+            // The task must NOT run while paused. This direction of the assertion
+            // is safe to check with a bounded wait: awaiting a latch that should
+            // not fire can only produce a false PASS under a scheduling delay,
+            // never a false failure, and the resume half below closes that gap by
+            // proving the very same task does run once the flag is cleared.
+            assertFalse(finished.await(500, TimeUnit.MILLISECONDS),
+                    "Task executed while the executor was paused — the DDL barrier "
+                            + "did not hold, so DML can be applied against a mid-DDL schema.");
+            assertFalse(taskRan.get(), "Task body ran during the pause window.");
+
+            executor.resume();
+
+            assertTrue(finished.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "Task did not run after resume() — replication would stall "
+                            + "permanently once a DDL is seen.");
+            assertTrue(taskRan.get(), "Task body did not run after resume().");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("resume() published from another thread is observed by the pool thread")
+    public void resumeIsVisibleAcrossThreads() throws Exception {
+        ClickHouseBatchExecutor executor = newExecutor();
+        try {
+            CountDownLatch started = new CountDownLatch(1);
+            CountDownLatch finished = new CountDownLatch(1);
+
+            executor.pause();
+            executor.execute(() -> {
+                started.countDown();
+                finished.countDown();
+            });
+
+            // Cross-thread publish, mirroring the real caller: the Debezium
+            // change-event thread resumes, the batch-pool thread must see it.
+            Thread resumer = new Thread(executor::resume, "test-ddl-thread");
+            resumer.start();
+            resumer.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+
+            assertTrue(started.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "Pool thread never observed resume() published by another "
+                            + "thread — the pause flag is not being read across threads.");
+            assertTrue(finished.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "Task did not complete after a cross-thread resume().");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("pause/resume is re-entrant across successive DDL statements")
+    public void repeatedPauseResumeCyclesKeepWorking() throws Exception {
+        ClickHouseBatchExecutor executor = newExecutor();
+        try {
+            // A stream carrying several DDLs pauses and resumes repeatedly. If
+            // either transition were sticky, replication would stall on the
+            // second statement rather than the first, so one cycle is not
+            // sufficient coverage.
+            for (int cycle = 0; cycle < 5; cycle++) {
+                CountDownLatch finished = new CountDownLatch(1);
+                executor.pause();
+                executor.execute(finished::countDown);
+
+                assertFalse(finished.await(200, TimeUnit.MILLISECONDS),
+                        "Cycle " + cycle + ": task ran while paused.");
+
+                executor.resume();
+
+                assertTrue(finished.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                        "Cycle " + cycle + ": task did not run after resume().");
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/LazySystemConnectionTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/LazySystemConnectionTest.java
@@ -1,0 +1,69 @@
+package com.altinity.clickhouse.sink.connector.executor;
+
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import com.altinity.clickhouse.sink.connector.model.ClickHouseStruct;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Guards the lazy system-database connection.
+ *
+ * <p>Both executors used to open a ClickHouse system connection in their
+ * constructor. That was tolerable while BaseDbWriter.createConnection returned
+ * null on failure, but once it was changed to throw, merely CONSTRUCTING either
+ * class required a reachable ClickHouse — including for pure string operations
+ * such as {@code getTableFromTopic}, which touch no database at all.</p>
+ *
+ * <p>These tests construct both executors against a deliberately unreachable
+ * host and exercise a database-free method. They fail if the eager connection
+ * is ever reintroduced.</p>
+ */
+public class LazySystemConnectionTest {
+
+    private static ClickHouseSinkConnectorConfig unreachableConfig() {
+        Map<String, String> props = new HashMap<>();
+        // Port 1 is reserved and never listening, so any connection attempt
+        // fails fast rather than hanging on a real host.
+        props.put("clickhouse.server.url", "127.0.0.1");
+        props.put("clickhouse.server.port", "1");
+        props.put("clickhouse.server.user", "nobody");
+        props.put("clickhouse.server.password", "");
+        props.put("clickhouse.server.database", "system");
+        return new ClickHouseSinkConnectorConfig(props);
+    }
+
+    @Test
+    @DisplayName("ClickHouseBatchRunnable constructs without a reachable ClickHouse")
+    public void batchRunnableDoesNotConnectEagerly() {
+        LinkedBlockingQueue<List<ClickHouseStruct>> records =
+                new LinkedBlockingQueue<>();
+        ClickHouseBatchRunnable runnable = assertDoesNotThrow(
+                () -> new ClickHouseBatchRunnable(
+                        records, unreachableConfig(), new HashMap<>()),
+                "Constructing the runnable must not require a live ClickHouse");
+
+        // A pure string operation must work with no database whatsoever.
+        assertEquals("customers",
+                runnable.getTableFromTopic("SERVER5432.test.customers"));
+    }
+
+    @Test
+    @DisplayName("ClickHouseBatchWriter constructs without a reachable ClickHouse")
+    public void batchWriterDoesNotConnectEagerly() {
+        ClickHouseBatchWriter writer = assertDoesNotThrow(
+                () -> new ClickHouseBatchWriter(
+                        unreachableConfig(), new HashMap<>()),
+                "Constructing the writer must not require a live ClickHouse");
+
+        assertEquals("customers",
+                writer.getTableFromTopic("SERVER5432.test.customers"));
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/OffsetCommitConcurrencyTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/OffsetCommitConcurrencyTest.java
@@ -1,0 +1,432 @@
+package com.altinity.clickhouse.sink.connector.executor;
+
+import com.altinity.clickhouse.sink.connector.model.ClickHouseStruct;
+import io.debezium.engine.ChangeEvent;
+import io.debezium.engine.DebeziumEngine;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Concurrency contract for the Debezium offset-commit path.
+ *
+ * <p>This is the failure reported against this connector in production:</p>
+ * <pre>
+ * ERROR OffsetStorageWriter - Invalid call to OffsetStorageWriter beginFlush()
+ *       while already flushing, the framework should not allow this
+ * ConnectException: OffsetStorageWriter is already flushing
+ *       at OffsetStorageWriter.beginFlush(OffsetStorageWriter.java:120)
+ *       at EmbeddedEngine.commitOffsets(EmbeddedEngine.java:905)
+ *       at DebeziumOffsetManagement.markBatchFinishedSafely(...:272)
+ * </pre>
+ *
+ * <p>Kafka's {@code OffsetStorageWriter} is single-flush: {@code beginFlush()}
+ * throws if a flush is already open. Debezium builds a <em>new</em>
+ * {@code RecordCommitter} per batch in {@code EmbeddedEngine.buildRecordCommitter},
+ * so the committer's own {@code synchronized} methods lock different monitors
+ * for different batches and provide no mutual exclusion between worker threads.
+ * The only real barrier is {@code DebeziumOffsetManagement.OFFSET_COMMIT_LOCK}.
+ * When that barrier is missing or too narrow, two threads enter
+ * {@code markBatchFinished()} concurrently and the second one throws — the
+ * batch fails, is retried, and records are re-applied or their offsets are
+ * never advanced.</p>
+ *
+ * <p>The committer stub below models exactly that single-flush semantic: it
+ * raises the same {@code ConnectException} if a second thread enters the
+ * finish window while one is open. Making the test <em>deterministic</em>
+ * rather than probabilistic is the point — a plain "run it hot and hope"
+ * stress test passes on a lucky interleaving. Two mechanisms are used:
+ * a real overlap window (the stub sleeps while inside the critical region,
+ * so a genuine concurrent entry is observed, not merely possible), and a
+ * strict serialisation check (a depth counter that records the maximum
+ * observed concurrency, which must be exactly 1).</p>
+ */
+public class OffsetCommitConcurrencyTest {
+
+    /** Worker threads driving concurrent commits. Above the usual pool size. */
+    private static final int THREADS = 8;
+
+    /** Batches per thread. */
+    private static final int BATCHES_PER_THREAD = 25;
+
+    /** Overlap window held open inside the finish call, in milliseconds. */
+    private static final long OVERLAP_WINDOW_MS = 2;
+
+    private static final long TIMEOUT_SECONDS = 60;
+
+    @BeforeEach
+    public void resetSharedState() {
+        // The maps are static, so residue from another test in the same JVM
+        // would make a run order-dependent.
+        DebeziumOffsetManagement.inFlightBatches = new ConcurrentHashMap<>();
+        DebeziumOffsetManagement.completedBatches = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Committer that reproduces {@code OffsetStorageWriter}'s single-flush rule
+     * and records the maximum concurrency it ever observes.
+     */
+    private static final class SingleFlushCommitter
+            implements DebeziumEngine.RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>> {
+
+        private final AtomicInteger inFlush = new AtomicInteger(0);
+        private final AtomicInteger maxConcurrent = new AtomicInteger(0);
+        private final AtomicInteger finishCount = new AtomicInteger(0);
+        private final AtomicReference<Throwable> failure = new AtomicReference<>();
+        private final boolean holdWindowOpen;
+
+        private SingleFlushCommitter(boolean holdWindowOpen) {
+            this.holdWindowOpen = holdWindowOpen;
+        }
+
+        @Override
+        public void markProcessed(ChangeEvent<SourceRecord, SourceRecord> record) {
+            // No-op: this stub asserts on flush overlap, not on processed counts.
+        }
+
+        @Override
+        public void markBatchFinished() {
+            int depth = inFlush.incrementAndGet();
+            maxConcurrent.accumulateAndGet(depth, Math::max);
+            try {
+                if (depth > 1) {
+                    // Precisely the production symptom.
+                    ConnectException e = new ConnectException(
+                            "OffsetStorageWriter is already flushing");
+                    failure.compareAndSet(null, e);
+                    throw e;
+                }
+                if (holdWindowOpen) {
+                    try {
+                        // Hold the window open so a second thread that is NOT
+                        // excluded actually lands inside it. Without this the
+                        // critical section is too short to overlap reliably and
+                        // a broken build could pass by luck.
+                        Thread.sleep(OVERLAP_WINDOW_MS);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            } finally {
+                inFlush.decrementAndGet();
+            }
+            finishCount.incrementAndGet();
+        }
+
+        @Override
+        public void markProcessed(ChangeEvent<SourceRecord, SourceRecord> record,
+                                  DebeziumEngine.Offsets sourceOffsets) {
+            markProcessed(record);
+        }
+
+        @Override
+        public DebeziumEngine.Offsets buildOffsets() {
+            return null;
+        }
+    }
+
+    /**
+     * Minimal non-null {@link ChangeEvent}. acknowledgeRecords only proceeds
+     * for records whose committer AND source record are both non-null.
+     */
+    private static ChangeEvent<SourceRecord, SourceRecord> dummyChangeEvent() {
+        return new ChangeEvent<>() {
+            @Override
+            public SourceRecord key() {
+                return null;
+            }
+
+            @Override
+            public SourceRecord value() {
+                return null;
+            }
+
+            @Override
+            public String destination() {
+                return null;
+            }
+
+            @Override
+            public Integer partition() {
+                return null;
+            }
+        };
+    }
+
+    /**
+     * Builds a batch whose records all carry the same committer, with the last
+     * one flagged as the batch terminator (the record that triggers the flush).
+     */
+    private static List<ClickHouseStruct> batch(
+            DebeziumEngine.RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>> committer,
+            long baseTs,
+            int size) {
+        List<ClickHouseStruct> records = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            ClickHouseStruct record = new ClickHouseStruct();
+            record.setDebezium_ts_ms(baseTs + i);
+            record.setCommitter(committer);
+            record.setSourceRecord(dummyChangeEvent());
+            record.setLastRecordInBatch(i == size - 1);
+            records.add(record);
+        }
+        return records;
+    }
+
+    @Test
+    @DisplayName("Concurrent acknowledgeRecords never opens two overlapping flushes")
+    public void concurrentAcknowledgeIsSerialised() throws Exception {
+        SingleFlushCommitter committer = new SingleFlushCommitter(true);
+        ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(THREADS);
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+
+        try {
+            for (int t = 0; t < THREADS; t++) {
+                final int threadIndex = t;
+                pool.submit(() -> {
+                    try {
+                        // Release all threads at once: the contention has to be
+                        // simultaneous, not staggered by thread start-up.
+                        startGate.await();
+                        for (int b = 0; b < BATCHES_PER_THREAD; b++) {
+                            long ts = 1_000_000L + threadIndex * 10_000L + b;
+                            DebeziumOffsetManagement.acknowledgeRecords(
+                                    batch(committer, ts, 3));
+                        }
+                    } catch (Throwable e) {
+                        thrown.compareAndSet(null, e);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+
+            startGate.countDown();
+            assertTrue(done.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "Commit threads did not finish — the offset path deadlocked.");
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertNull(thrown.get(),
+                "A commit thread threw. If this is 'OffsetStorageWriter is already "
+                        + "flushing', the OFFSET_COMMIT_LOCK barrier no longer covers "
+                        + "markBatchFinished() and concurrent batches corrupt the offset "
+                        + "flush: " + thrown.get());
+        assertNull(committer.failure.get(),
+                "Two threads entered the offset flush concurrently: "
+                        + committer.failure.get());
+        assertEquals(1, committer.maxConcurrent.get(),
+                "Maximum observed concurrency inside markBatchFinished() must be "
+                        + "exactly 1. Observed " + committer.maxConcurrent.get()
+                        + " — OffsetStorageWriter is single-flush, so any overlap is the "
+                        + "production ConnectException.");
+        assertEquals(THREADS * BATCHES_PER_THREAD, committer.finishCount.get(),
+                "Every batch must be finished exactly once. A shortfall means "
+                        + "offsets were never committed for some batches, which replays "
+                        + "those records after a restart.");
+    }
+
+    @Test
+    @DisplayName("markProcessed and markBatchFinished stay inside one critical section")
+    public void processedAndFinishedShareOneCriticalSection() throws Exception {
+        // Regression guard for the narrower half of the original bug: locking
+        // only markBatchFinished() leaves markProcessed() outside the barrier,
+        // so one thread can record offsets into the writer while another is
+        // flushing it. The interleaving detector below fails if a markProcessed
+        // from thread B lands between thread A's first markProcessed and its
+        // markBatchFinished.
+        AtomicBoolean interleaved = new AtomicBoolean(false);
+        AtomicReference<Thread> owner = new AtomicReference<>();
+
+        DebeziumEngine.RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>> committer =
+                new DebeziumEngine.RecordCommitter<>() {
+                    @Override
+                    public void markProcessed(ChangeEvent<SourceRecord, SourceRecord> r) {
+                        Thread self = Thread.currentThread();
+                        Thread current = owner.compareAndExchange(null, self);
+                        if (current != null && current != self) {
+                            interleaved.set(true);
+                        }
+                        try {
+                            Thread.sleep(1);
+                        } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+
+                    @Override
+                    public void markBatchFinished() {
+                        // Section closes here; releasing the ownership marker.
+                        owner.set(null);
+                    }
+
+                    @Override
+                    public void markProcessed(ChangeEvent<SourceRecord, SourceRecord> r,
+                                              DebeziumEngine.Offsets o) {
+                        markProcessed(r);
+                    }
+
+                    @Override
+                    public DebeziumEngine.Offsets buildOffsets() {
+                        return null;
+                    }
+                };
+
+        ExecutorService pool = Executors.newFixedThreadPool(4);
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(4);
+        try {
+            for (int t = 0; t < 4; t++) {
+                final int threadIndex = t;
+                pool.submit(() -> {
+                    try {
+                        startGate.await();
+                        for (int b = 0; b < 10; b++) {
+                            DebeziumOffsetManagement.acknowledgeRecords(
+                                    batch(committer,
+                                            2_000_000L + threadIndex * 1_000L + b * 10L,
+                                            3));
+                        }
+                    } catch (Throwable ignored) {
+                        // Assertion below is on the interleaving flag.
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            startGate.countDown();
+            assertTrue(done.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "Commit threads did not finish.");
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertTrue(!interleaved.get(),
+                "A second thread called markProcessed() while another thread's "
+                        + "batch was still between its first markProcessed() and its "
+                        + "markBatchFinished(). Both calls must sit inside the SAME "
+                        + "OFFSET_COMMIT_LOCK critical section — Debezium builds a new "
+                        + "RecordCommitter per batch, so the committer's own synchronized "
+                        + "methods do not exclude across threads.");
+    }
+
+    @Test
+    @DisplayName("Every in-flight batch is drained; none is stranded uncommitted")
+    public void noBatchIsStrandedInFlight() throws Exception {
+        SingleFlushCommitter committer = new SingleFlushCommitter(false);
+        ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(THREADS);
+
+        try {
+            for (int t = 0; t < THREADS; t++) {
+                final int threadIndex = t;
+                pool.submit(() -> {
+                    try {
+                        startGate.await();
+                        for (int b = 0; b < BATCHES_PER_THREAD; b++) {
+                            long ts = 3_000_000L + threadIndex * 10_000L + b * 5L;
+                            List<ClickHouseStruct> records = batch(committer, ts, 2);
+                            DebeziumOffsetManagement.addToBatchTimestamps(records);
+                            DebeziumOffsetManagement.checkIfBatchCanBeCommitted(records);
+                        }
+                    } catch (Throwable ignored) {
+                        // Drain state is asserted below.
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            startGate.countDown();
+            assertTrue(done.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "Batch threads did not finish.");
+        } finally {
+            pool.shutdownNow();
+        }
+
+        // A batch left in completedBatches after every producer has finished is
+        // a batch whose offsets were never committed: on restart the connector
+        // resumes before it and re-applies those rows.
+        int stranded = DebeziumOffsetManagement.completedBatches.size();
+        assertTrue(stranded == 0,
+                "After all producers finished, " + stranded + " batch(es) remain in "
+                        + "completedBatches with offsets never committed. Those records "
+                        + "are replayed on restart.");
+
+        assertEquals(0, DebeziumOffsetManagement.inFlightBatches.size(),
+                "in-flight batches must all be drained once every batch has been "
+                        + "processed; a leak here grows unbounded and eventually blocks "
+                        + "every commit behind a phantom overlap.");
+    }
+
+    @Test
+    @DisplayName("Overlap detection is symmetric under concurrent registration")
+    public void overlapCheckIsStableUnderConcurrentRegistration() throws Exception {
+        // checkIfThereAreInflightRequests iterates a shared ConcurrentHashMap
+        // while other threads add and remove entries. It must never throw
+        // (ConcurrentModificationException / NPE) — a throw here aborts the
+        // batch and its offsets are lost.
+        ExecutorService pool = Executors.newFixedThreadPool(6);
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(6);
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+
+        try {
+            for (int t = 0; t < 6; t++) {
+                final int threadIndex = t;
+                pool.submit(() -> {
+                    try {
+                        startGate.await();
+                        SingleFlushCommitter c = new SingleFlushCommitter(false);
+                        for (int b = 0; b < 100; b++) {
+                            List<ClickHouseStruct> records =
+                                    batch(c, 4_000_000L + threadIndex * 1_000L + b, 2);
+                            DebeziumOffsetManagement.addToBatchTimestamps(records);
+                            DebeziumOffsetManagement.checkIfThereAreInflightRequests(records);
+                            Pair<Long, Long> key =
+                                    DebeziumOffsetManagement
+                                            .calculateMinMaxTimestampFromBatch(records);
+                            DebeziumOffsetManagement.inFlightBatches.remove(key);
+                        }
+                    } catch (Throwable e) {
+                        thrown.compareAndSet(null, e);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            startGate.countDown();
+            assertTrue(done.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "Overlap-check threads did not finish.");
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertNull(thrown.get(),
+                "Concurrent overlap checking threw " + thrown.get() + ". The scan "
+                        + "runs while other threads register and retire batches, so it must "
+                        + "tolerate concurrent mutation; a throw aborts the batch and drops "
+                        + "its offset commit.");
+    }
+}


### PR DESCRIPTION
Stacked PR: based on the previous PR in the series (`omniwatcher/split-19-batch-statement`); this PR's own diff is only its listed files. Merge the series in order; after the predecessor merges, retarget this PR to `2.10.0`.

Wires the new core classes into the batch path. The heart of the race-condition fixes. Merge after config, db-ops, core-classes and batch PRs.

- Duplicate-insert fix: an already-flushed batch waiting on offset commit was re-INSERTED on every retry pass (one record observed 1,000 times on the combined PR). A flushed batch now only re-checks committability - never re-inserts.
- ClickHouseBatchExecutor.isPaused becomes volatile: it is the DDL-vs-DML barrier, written by the Debezium thread and read in the batch threads' spin loop with no other happens-before edge. Without volatile the read can be hoisted and a batch thread can apply DML against a schema mid-DDL - silent corruption, not a stall.
- Cache invalidation by generation: the previous remove-on-read signal let the FIRST worker thread consume the invalidation, leaving every other thread on a stale DbWriter (stale column list) forever. Per-table monotonic generation counters let every thread invalidate independently; plus a schema-cache TTL (default 1h) so a missed DDL self-heals. CacheInvalidationManagerTest / CacheInvalidationManagerTtlTest.
- DebeziumOffsetManagement.acknowledgeRecord for the single-record path; beginFlush no longer collides with an in-flight flush (the original OffsetStorageWriter "already flushing" crash from the production log).
- Integrity gate + freeze manager + error classifier wired into ClickHouseBatchRunnable / ClickHouseBatchWriter; DbWriter carries the cache generation.

Part of the split of #1353 into independently mergeable sub-PRs (each <= 10 files), so the 2.10.0 branch can absorb the fixes incrementally.

Split out of #1353, which this series replaces. Each sub-PR is <= 10 files; the union of all 22 reproduces the #1353 tree exactly (verified by tree SHA).