### PR TITLE
[split 21/22] tests: race-condition suites for DDL waiter, offset commit, pause visibility (test-only)

### DIFF
--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
@@ -11,8 +11,10 @@ import com.altinity.clickhouse.sink.connector.common.Utils;
 import com.altinity.clickhouse.sink.connector.converters.ClickHouseConverter;
 import com.altinity.clickhouse.sink.connector.db.BaseDbWriter;
 import com.altinity.clickhouse.sink.connector.db.CacheInvalidationManager;
+import com.altinity.clickhouse.sink.connector.db.DDLSchemaChangeWaiter;
 import com.altinity.clickhouse.sink.connector.db.DBMetadata;
 import com.altinity.clickhouse.sink.connector.db.ErrorLogger;
+import com.altinity.clickhouse.sink.connector.db.TableReplicationFreezeManager;
 import com.altinity.clickhouse.sink.connector.db.operations.ClickHouseAlterTable;
 import com.altinity.clickhouse.sink.connector.db.operations.ClickHouseAutoCreateTable;
 import com.altinity.clickhouse.sink.connector.executor.ClickHouseBatchExecutor;
@@ -45,6 +47,7 @@ import java.sql.SQLException;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -89,12 +92,25 @@ public class DebeziumChangeEventCapture {
     /**
      * Flag indicating if a new replacing merge tree engine is used.
      */
-    static public boolean isNewReplacingMergeTreeEngine = true;
+    static public volatile boolean isNewReplacingMergeTreeEngine = true;
 
     /**
      * Executor service for single-thread Debezium event processing.
      */
     final ExecutorService singleThreadDebeziumEventExecutor;
+
+    /**
+     * Executor that performs engine restarts after a failure.
+     *
+     * <p>Deliberately separate from {@link #singleThreadDebeziumEventExecutor}.
+     * The restart is triggered from the engine's completion callback; running
+     * it there, or on the thread that runs the engine, would build the
+     * replacement engine underneath the failed one and nest one stack frame
+     * per attempt. A dedicated single thread lets the callback return and
+     * unwind before the next attempt begins, so retries are sequential and
+     * each starts from a clean stack.</p>
+     */
+    final ExecutorService debeziumRestartExecutor;
 
     /**
      * Debezium engine for capturing change events.
@@ -139,6 +155,12 @@ public class DebeziumChangeEventCapture {
      */
     public DebeziumChangeEventCapture() {
         singleThreadDebeziumEventExecutor = Executors.newFixedThreadPool(1);
+        debeziumRestartExecutor = Executors.newSingleThreadExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "Sink connector Debezium Restart Thread");
+            // Daemon: a pending back-off sleep must never hold up JVM shutdown.
+            thread.setDaemon(true);
+            return thread;
+        });
         this.debeziumJdbcStorageOperations = new DebeziumJdbcStorageOperations();
     }
 
@@ -146,7 +168,7 @@ public class DebeziumChangeEventCapture {
      * Maximum number of retries for Debezium setup and other operations.
      * Default value, can be overridden by errors.max.retries configuration.
      */
-    public static int MAX_RETRIES = 10;
+    public static volatile int MAX_RETRIES = 10;
 
     /**
      * Sleep time (in milliseconds) between retries.
@@ -156,7 +178,7 @@ public class DebeziumChangeEventCapture {
     /**
      * This field tracks how many times an operation has been retried.
      */
-    public int numRetries = 0;
+    public volatile int numRetries = 0;
 
     /**
      * Starting sequence number for versioning.
@@ -169,9 +191,50 @@ public class DebeziumChangeEventCapture {
     public static final long SEQUENCE_START_INITIAL = 500000000;
     
     /**
-         * Global sequence number.
-    */
-    public static long sequenceNumber = SEQUENCE_START;
+     * Global sequence number.
+     *
+     * <p>Must be an AtomicLong, not a primitive: this counter feeds
+     * ClickHouseStruct.sequenceNumber, which becomes the {@code _version}
+     * used by ReplacingMergeTree to decide which row version wins. It is
+     * incremented from the Debezium change-event thread while being read
+     * elsewhere, so a non-atomic read-modify-write could hand two records
+     * the same version and let RMT silently collapse them, or emit a torn
+     * value on a 32-bit-split long read. Every call site below uses
+     * set()/get()/incrementAndGet().</p>
+     */
+    private final AtomicLong sequenceNumber = new AtomicLong(SEQUENCE_START);
+
+    /**
+     * Guards the counter together with its source-timestamp anchor.
+     *
+     * <p>Assigning a version is a check-and-act over TWO pieces of state: the
+     * time anchor is read to decide whether the second boundary was crossed,
+     * and only then is the counter reset or incremented. An atomic counter
+     * alone cannot make that pair consistent — two threads crossing the same
+     * boundary would both reset and emit an identical {@code _version},
+     * which ReplacingMergeTree would silently collapse. Every read and write
+     * of the counter/anchor pair happens while holding this lock.</p>
+     */
+    private final Object sequenceLock = new Object();
+
+    /**
+     * Sentinel meaning the source-timestamp anchor has not been set yet.
+     */
+    private static final long UNANCHORED = Long.MIN_VALUE;
+
+    /**
+     * Source-commit-timestamp anchor the sequence counter is measured from.
+     *
+     * <p>Instance state, deliberately NOT a per-call local. Re-seeding it from
+     * record[0] on every call made the reset branch reachable by every batch
+     * that spanned a time gap, and each such batch assigned the same constant
+     * {@link #SEQUENCE_START} — so two concurrent batches produced an
+     * identical {@code _version} and ReplacingMergeTree collapsed one of the
+     * rows. Persisting the anchor means the counter re-anchors once when the
+     * source clock advances, and later records at that timestamp increment.
+     * Guarded by {@link #sequenceLock}.</p>
+     */
+    private long sequenceStartTime = UNANCHORED;
 
 
     /**
@@ -238,8 +301,16 @@ public class DebeziumChangeEventCapture {
 
                     ChangeEvent<SourceRecord, SourceRecord> changeEvent = list.get(0);
                     long debeziumTsMs = ClickHouseStruct.getDebeziumTsFromChangeEvent(changeEvent);
-                    long sequenceStartTime = debeziumTsMs ;
-                    
+                    // Anchor this batch, but do NOT shadow the instance field with a
+                    // batch-local: the counter it gates is shared across batch
+                    // threads, so an anchor that is private to one batch lets two
+                    // batches independently decide to reset and hand their first
+                    // record the same SEQUENCE_START value. Seeding the shared
+                    // anchor under the same lock that guards the counter keeps the
+                    // pair consistent.
+                    seedSequenceAnchor(debeziumTsMs);
+
+
                     List<ClickHouseStruct> batch = new ArrayList<>();
                     for (int i = 0; i < list.size(); i++) {
                         ChangeEvent<SourceRecord, SourceRecord> record = list.get(i);
@@ -248,14 +319,31 @@ public class DebeziumChangeEventCapture {
                             lastRecordInBatch = true;
                         }
                         long recordTs = ClickHouseStruct.getDebeziumTsFromChangeEvent(record);
-                        int diff = (int) ((recordTs - sequenceStartTime) / 1000);
-                        if (diff > 1) {
-                            sequenceNumber = SEQUENCE_START;
-                            sequenceStartTime = recordTs;
-                        } else
-                            sequenceNumber++;
-
-                        long recordSequenceNumber = recordTs * 1000000 + sequenceNumber;
+                        // The VALUE SCHEME here is deliberately identical to 2.8.0:
+                        //     _version = debezium_ts_ms * 1_000_000 + counter
+                        // anchored to the Debezium timestamp, with the counter reset
+                        // when the clock advances more than one second past the
+                        // anchor. It must stay identical: _version decides which row
+                        // survives a ReplacingMergeTree merge, so a table already
+                        // holding 2.8.0-written rows and a connector emitting values
+                        // from a different scheme put two incomparable magnitudes in
+                        // the same column. Whichever scheme yields the larger number
+                        // wins every merge regardless of which change actually
+                        // happened later, and no downgrade can undo the rows already
+                        // written. Changing this formula is a one-way door.
+                        //
+                        // Only the ASSIGNMENT is made safe. Read-modify-write over
+                        // the shared counter was not atomic: the reset branch is a
+                        // check-and-act over two pieces of state (read the anchor,
+                        // decide, then reset the counter and re-anchor), and the
+                        // increment branch did incrementAndGet() and then a separate
+                        // get(). Two batch threads interleaving in either window
+                        // observe the same counter and hand two different records an
+                        // identical _version, which the ReplacingMergeTree then
+                        // silently collapses to one row. Serialising the decision
+                        // closes both windows, and the value used is the one produced
+                        // inside the critical section rather than a later re-read.
+                        long recordSequenceNumber = nextSequenceNumber(recordTs);
 
                         ClickHouseStruct chStruct = processEveryChangeRecord(props, record,
                                 debeziumRecordParserService, config, recordCommitter, lastRecordInBatch, recordSequenceNumber);
@@ -277,25 +365,35 @@ public class DebeziumChangeEventCapture {
                         @Override
                         public void handle(boolean success, String message, Throwable throwable) {
                             if (success == false) {
-                                log.error("Error starting connector" + throwable + " Message:" + message);
+                                log.error("Error starting connector: " + message, throwable);
                                 if (throwable != null && throwable.getCause() != null &&
                                         throwable.getCause().getLocalizedMessage() != null)
-                                    log.error("Error stating connector: Cause" +
+                                    log.error("Error starting connector: Cause: " +
                                             throwable.getCause().getLocalizedMessage());
-                                log.error("Retrying - try number:" + numRetries);
+                                // The engine has stopped. Nothing else restarts it:
+                                // setup() calls setupDebeziumEventCapture() exactly once
+                                // and returns, so if this callback does not retry, the
+                                // connector stays down for the rest of the process and
+                                // every subsequent change is silently never replicated.
+                                //
+                                // Retry must NOT run on this thread. The callback is
+                                // invoked from the engine's own completion path, so
+                                // calling setupDebeziumEventCapture() inline builds the
+                                // next engine underneath the failed one's frame and each
+                                // further failure nests again — MAX_RETRIES deep, which
+                                // is what previously overflowed the stack. Handing the
+                                // restart to a separate single-thread executor lets this
+                                // callback return and unwind first, so every attempt
+                                // starts from a fresh stack while the retry budget and
+                                // back-off are still honoured.
+                                // Bound matches upstream (<=), so the retry budget is
+                                // unchanged by this PR: MAX_RETRIES+1 attempts.
                                 if (numRetries++ <= MAX_RETRIES) {
-                                    try {
-                                        Thread.sleep(SLEEP_TIME);
-                                    } catch (InterruptedException e) {
-                                        log.error("Error sleeping", e);
-                                        throw new RuntimeException(e);
-                                    }
-                                    try {
-                                        setupDebeziumEventCapture(props, debeziumRecordParserService, config);
-                                    } catch (IOException | ClassNotFoundException e) {
-                                        log.error("Error setting up debezium event capture", e);
-                                        throw new RuntimeException(e);
-                                    }
+                                    log.error("Retrying - try number:" + numRetries);
+                                    scheduleDebeziumRestart(props, debeziumRecordParserService, config);
+                                } else {
+                                    log.error("Connector failed after " + numRetries + " retries. "
+                                            + "The connector will need to be restarted externally.");
                                 }
                             }
                             log.debug("Completion callback");
@@ -360,6 +458,53 @@ public class DebeziumChangeEventCapture {
     }
 
     /**
+     * Rebuilds the Debezium engine after a failure, off the callback thread.
+     *
+     * <p>Called from the engine's completion callback when the engine has
+     * stopped with an error and the retry budget is not yet exhausted. The
+     * work is handed to {@link #debeziumRestartExecutor} rather than done
+     * inline so that the failing callback returns and its frame unwinds
+     * before the replacement engine is constructed; building it inline is
+     * what made repeated failures nest one stack frame per attempt.</p>
+     *
+     * <p>The executor is single-threaded, so restarts are serialised and two
+     * failures can never race to build two engines.</p>
+     *
+     * @param props                       The connector properties.
+     * @param debeziumRecordParserService The service to parse change events.
+     * @param config                      The ClickHouse sink connector config.
+     */
+    private void scheduleDebeziumRestart(Properties props,
+                                         DebeziumRecordParserService debeziumRecordParserService,
+                                         ClickHouseSinkConnectorConfig config) {
+        try {
+            debeziumRestartExecutor.submit(() -> {
+                try {
+                    Thread.sleep(SLEEP_TIME);
+                } catch (InterruptedException e) {
+                    // Shutdown requested during back-off: restore the flag and
+                    // abandon the restart rather than reconnecting into a
+                    // connector that is on its way down.
+                    Thread.currentThread().interrupt();
+                    log.error("Interrupted while waiting to restart Debezium event capture", e);
+                    return;
+                }
+                try {
+                    setupDebeziumEventCapture(props, debeziumRecordParserService, config);
+                } catch (Exception e) {
+                    // Never rethrow here. This runs on the restart executor, so
+                    // an escaping exception would be swallowed into a Future
+                    // nobody reads and the failure would go unreported.
+                    log.error("Error restarting Debezium event capture", e);
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            // Expected when stop() has already shut the executor down.
+            log.warn("Debezium restart not scheduled - connector is shutting down");
+        }
+    }
+
+    /**
      * Sets up the Debezium engine and processing thread.
      *
      * @param props                       The connector properties.
@@ -378,7 +523,7 @@ public class DebeziumChangeEventCapture {
             int maxQueueSize = Integer.parseInt(props.getProperty(ClickHouseSinkConnectorConfigVariables.MAX_QUEUE_SIZE.toString()));
             this.records = new LinkedBlockingQueue<>(maxQueueSize);
         } else {
-            this.records = new LinkedBlockingQueue<>();
+            this.records = new LinkedBlockingQueue<>(10000);
         }
 
         try {
@@ -404,6 +549,18 @@ public class DebeziumChangeEventCapture {
         // Start Debezium event loop if it is requested from REST API.
         if (!config.getBoolean(ClickHouseSinkConnectorConfigVariables.SKIP_REPLICA_START.toString())
                 || forceStart) {
+
+            // Advisory check: snapshot.mode=initial re-snapshots and wipes offset state,
+            // so warn when existing replication state is present. This is WARN-ONLY by
+            // default and must stay that way: snapshot.mode=initial is the documented
+            // default, so refusing to start on it would break every ordinary restart of
+            // an already-replicating connector. Operators who want the hard stop opt in
+            // with snapshot.initial.require.confirmation=true.
+            String snapshotMode = props.getProperty("snapshot.mode", "");
+            if (snapshotMode.equalsIgnoreCase("initial")) {
+                validateInitialSnapshotSafety(props, config);
+            }
+
             this.setupProcessingThread(config);
             setupDebeziumEventCapture(props, debeziumRecordParserService, config);
         } else {
@@ -413,11 +570,120 @@ public class DebeziumChangeEventCapture {
     }
 
     /**
+     * Validates that it is safe to run with snapshot.mode=initial.
+     * <p>
+     * When snapshot.mode is set to "initial", Debezium performs a full re-snapshot
+     * which resets offset tracking and re-reads all data from the source database.
+     * This is destructive if replication was previously running, as it wipes the
+     * stored binlog position and schema history.
+     * </p>
+     * <p>
+     * This method checks whether offset storage or schema history tables already
+     * contain data and logs a prominent warning if they do.
+     * </p>
+     * <p>
+     * The check is advisory by default and never blocks startup. {@code initial} is
+     * the documented default snapshot mode, so a connector that has been replicating
+     * for a while still has it set; failing startup on that condition would turn
+     * every routine restart into an outage requiring manual intervention on the host.
+     * </p>
+     * <p>
+     * Deployments that would rather not start at all than re-snapshot can opt in to
+     * the hard stop with {@code snapshot.initial.require.confirmation=true}. In that
+     * mode a {@code .confirm_initial_snapshot} file in the working directory permits
+     * one run and is renamed to {@code .confirm_initial_snapshot.used} so it cannot
+     * be re-used on the next restart.
+     * </p>
+     *
+     * @param props  The connector properties.
+     * @param config The ClickHouse sink connector configuration.
+     * @throws RuntimeException only when {@code snapshot.initial.require.confirmation}
+     *                          is enabled, existing state is found, and no confirmation
+     *                          file exists.
+     */
+    private void validateInitialSnapshotSafety(Properties props, ClickHouseSinkConnectorConfig config) {
+        log.warn("snapshot.mode=initial detected — checking for existing replication state");
+
+        boolean hasExistingState = false;
+        String stateDetails = "";
+
+        try {
+            // Check if offset storage table has data
+            DebeziumJdbcStorageOperations storageOps = new DebeziumJdbcStorageOperations();
+            if (systemDbConnection != null) {
+                String status = storageOps.getDebeziumStorageStatus(systemDbConnection, config, props);
+                if (status != null && !status.isEmpty() && !status.equals("[]")) {
+                    hasExistingState = true;
+                    stateDetails = "Offset storage contains existing replication state. ";
+                    log.warn("Found existing offset storage data: " + status);
+                }
+            }
+        } catch (Exception e) {
+            // If we can't check, it might be a fresh install — allow startup
+            log.info("Could not check existing offset state (may be fresh install): " + e.getMessage());
+        }
+
+        if (hasExistingState) {
+            String warning = "snapshot.mode=initial was requested but existing replication "
+                    + "state was found. " + stateDetails
+                    + "Running with snapshot.mode=initial will WIPE the current binlog position "
+                    + "and re-snapshot ALL data from the source database. "
+                    + "If you want to resume replication from where it left off, "
+                    + "change snapshot.mode to 'schema_only' or 'when_needed'.";
+
+            // Opt-in only. Defaulting this to fatal would stop a healthy connector from
+            // restarting, which is a worse failure than the re-snapshot it guards against.
+            boolean requireConfirmation = Boolean.parseBoolean(
+                    props.getProperty("snapshot.initial.require.confirmation", "false"));
+
+            if (!requireConfirmation) {
+                log.warn(warning);
+                log.warn("Proceeding anyway. Set snapshot.initial.require.confirmation=true "
+                        + "to refuse startup in this situation.");
+                return;
+            }
+
+            java.io.File confirmFile = new java.io.File(".confirm_initial_snapshot");
+            if (!confirmFile.exists()) {
+                String errorMsg = "SAFETY GUARD: " + warning
+                        + " snapshot.initial.require.confirmation is enabled, so startup is "
+                        + "refused. To confirm this is intentional, create a file named "
+                        + "'.confirm_initial_snapshot' in the sink-connector working directory "
+                        + "(touch .confirm_initial_snapshot) and restart.";
+                log.error(errorMsg);
+                throw new RuntimeException(errorMsg);
+            } else {
+                log.warn("Confirmation file .confirm_initial_snapshot found — proceeding with initial snapshot");
+                // Rename the file to prevent accidental re-use on next restart
+                java.io.File usedFile = new java.io.File(".confirm_initial_snapshot.used");
+                if (!confirmFile.renameTo(usedFile)) {
+                    log.warn("Could not rename .confirm_initial_snapshot to .confirm_initial_snapshot.used");
+                }
+            }
+        } else {
+            log.info("No existing replication state found — safe to proceed with initial snapshot");
+        }
+    }
+
+    /**
      * Stops the Debezium engine and shuts down all executor services.
      *
      * @throws IOException If an I/O error occurs during shutdown.
      */
     public void stop() throws IOException {
+        // Shut the restart executor down FIRST, and interrupt it: a retry that
+        // is mid-back-off would otherwise wake up after the engine has been
+        // closed and build a fresh engine on a connector that is shutting down.
+        // shutdownNow() both cancels queued restarts and interrupts the sleep.
+        try {
+            if (this.debeziumRestartExecutor != null) {
+                this.debeziumRestartExecutor.shutdownNow();
+                this.debeziumRestartExecutor.awaitTermination(60, TimeUnit.SECONDS);
+            }
+        } catch (Exception e) {
+            log.error("Error stopping debezium restart executor", e);
+        }
+
         try {
             if (this.executor != null) {
                 this.executor.shutdown();
@@ -442,6 +708,24 @@ public class DebeziumChangeEventCapture {
             }
         } catch (Exception e) {
             log.error("Error stopping debezium engine", e);
+        }
+
+        try {
+            if (this.systemDbConnection != null) {
+                this.systemDbConnection.close();
+                this.systemDbConnection = null;
+            }
+        } catch (Exception e) {
+            log.error("Error closing system DB connection", e);
+        }
+
+        try {
+            if (this.replicationHistoryDbConnection != null) {
+                this.replicationHistoryDbConnection.close();
+                this.replicationHistoryDbConnection = null;
+            }
+        } catch (Exception e) {
+            log.error("Error closing replication history DB connection", e);
         }
 
         Metrics.stop();
@@ -499,13 +783,33 @@ public class DebeziumChangeEventCapture {
         StringBuffer clickHouseQuery = new StringBuffer();
         AtomicBoolean isDropOrTruncate = new AtomicBoolean(false);
 
-        if (checkIfDDLNeedsToBeIgnored(DDL, props, sr, isDropOrTruncate)) {
-            log.info("Ignored Source DB DDL: " + DDL + " Snapshot:" + isSnapshotDDL(sr));
-            return;
-        }
-
+        // The DDL MUST be parsed before checkIfDDLNeedsToBeIgnored() is consulted.
+        // parseSql() is what populates isDropOrTruncate, and the DISABLE_DROP_TRUNCATE
+        // guard inside checkIfDDLNeedsToBeIgnored() reads that flag. Calling the guard
+        // first made it observe the freshly-initialised `false` on every invocation, so
+        // DISABLE_DROP_TRUNCATE=true silently allowed every DROP/TRUNCATE through to
+        // ClickHouse. The guard could only ever fail open.
         MySQLDDLParserService mySQLDDLParserService = new MySQLDDLParserService(writer, config, databaseName);
         mySQLDDLParserService.parseSql(DDL, "", clickHouseQuery, isDropOrTruncate);
+
+        if (checkIfDDLNeedsToBeIgnored(DDL, props, sr, isDropOrTruncate)) {
+            log.info("Ignored Source DB DDL: " + DDL + " Snapshot:" + isSnapshotDDL(sr));
+            // Acknowledge offset even for ignored DDL to prevent replication from
+            // getting stuck replaying the same ignored DDL repeatedly.
+            // acknowledgeRecords() is a checked-exception method (it commits
+            // offsets under the shared lock); on interrupt, restore the flag and
+            // return WITHOUT acknowledging rather than swallowing it — a silent
+            // failure here would advance the offset past a DDL whose commit
+            // never completed.
+            try {
+                DebeziumOffsetManagement.acknowledgeRecords(
+                        recordCommitter, cdcRecord, lastRecordInBatch);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("Interrupted while acknowledging ignored DDL: " + DDL, e);
+            }
+            return;
+        }
 
 
         log.info("Executed Source DB DDL: " + DDL + " Snapshot:" + isSnapshotDDL(sr));
@@ -522,6 +826,38 @@ public class DebeziumChangeEventCapture {
             retryDDLProperty = true;
         }
 
+        // Freeze replication for this table BEFORE executing the ALTER, so no
+        // batch insert thread can write rows against the stale (pre-ALTER)
+        // column cache while the schema change is in flight. The freeze is held
+        // until the destination schema is visible, the cache has been
+        // invalidated, and (on the insert side) source-vs-destination integrity
+        // is confirmed. This closes the race behind GitHub issue #1222, where a
+        // column added by an in-flight ALTER replicated as NULL for historical
+        // rows. Freeze is best-effort: if the table name cannot be resolved we
+        // proceed without it (the DDL waiter still runs).
+        String ddlFreezeTable = null;
+        try {
+            // Pass the DDL text: getTableName now resolves the table from the
+            // statement itself. The old record-key lookup ALWAYS returned null
+            // (Debezium's SchemaChangeKey carries only databaseName), which
+            // would have made this freeze silently never engage.
+            String tableName = getTableName(sr, DDL);
+            if (tableName != null) {
+                // The freeze key MUST be built the same way the batch consumers
+                // build their lookup key — i.e. with clickhouse.database.override.map
+                // applied. Freezing "sourcedb.tbl" while the insert path awaits
+                // "destdb.tbl" means the freeze never blocks anything, which is
+                // exactly the stale-column-cache race it exists to prevent.
+                ddlFreezeTable =
+                        resolveInvalidationDatabaseName(databaseName, config)
+                                + "." + tableName;
+                TableReplicationFreezeManager.getInstance().freeze(ddlFreezeTable);
+            }
+        } catch (Exception e) {
+            log.warn("Could not resolve table for DDL freeze: " + DDL, e);
+        }
+
+        try {
         while (numRetries < MAX_DDL_RETRIES) {
             try {
 
@@ -538,22 +874,53 @@ public class DebeziumChangeEventCapture {
                 // here. We intentionally start from the real source-mapped database
                 // (getDatabaseName(sr)), not the replication-history override above.
                 try {
-                    String invalidationDatabaseName = getDatabaseName(sr);
-                    String overrideMapConfig = config.getString(
-                            ClickHouseSinkConnectorConfigVariables.CLICKHOUSE_DATABASE_OVERRIDE_MAP.toString());
-                    if (overrideMapConfig != null) {
-                        Map<String, String> databaseOverrideMap =
-                                Utils.parseSourceToDestinationDatabaseMap(overrideMapConfig);
-                        if (databaseOverrideMap.containsKey(invalidationDatabaseName)) {
-                            invalidationDatabaseName = databaseOverrideMap.get(invalidationDatabaseName);
+                    // Both sides of the merge are kept, because each fixes a
+                    // DIFFERENT half of the invalidation key:
+                    //  - 2.10.0 fixes the DATABASE half: the key must be the
+                    //    override-mapped DESTINATION database (see
+                    //    resolveInvalidationDatabaseName), which is what the
+                    //    batch consumers use. Using the raw `databaseName`
+                    //    here skips clickhouse.database.override.map, so the
+                    //    key never matches the consumer's.
+                    //  - develop fixes the TABLE half: resolve every affected
+                    //    table, and never silently skip a table-scoped DDL.
+                    // 2.10.0 resolves tables from the record value's
+                    // tableChanges array (so multi-table DDL invalidates all of
+                    // them); develop resolves it from the DDL text. Try the
+                    // value first, fall back to the text, and only then report.
+                    String invalidationDatabaseName =
+                            resolveInvalidationDatabaseName(databaseName, config);
+                    List<String> affectedTables = getTableNamesFromDDL(sr);
+                    if (affectedTables.isEmpty()) {
+                        String parsedTableName = getTableName(sr, DDL);
+                        if (parsedTableName != null) {
+                            affectedTables = java.util.Collections
+                                    .singletonList(parsedTableName);
                         }
                     }
-                    for (String tableName : getTableNamesFromDDL(sr)) {
-                        CacheInvalidationManager.getInstance()
-                                .invalidateTable(invalidationDatabaseName + "." + tableName);
+                    if (!affectedTables.isEmpty()) {
+                        for (String tableName : affectedTables) {
+                            CacheInvalidationManager.getInstance()
+                                    .invalidateTable(invalidationDatabaseName + "." + tableName);
+                        }
+                    } else if (isTableScopedDDL(DDL)) {
+                        // Never silently skip invalidation for a TABLE-scoped DDL: a
+                        // cached DbWriter that is not rebuilt keeps writing the pre-DDL
+                        // column list, so the new column is dropped from every
+                        // subsequent INSERT and ClickHouse diverges from MySQL
+                        // permanently. Surface it loudly instead.
+                        log.error("Could not determine the table affected by DDL, so the "
+                                + "DbWriter schema cache could NOT be invalidated. Subsequent "
+                                + "inserts may use a stale column list and silently diverge "
+                                + "from the source. DDL: {}", DDL);
+                    } else {
+                        // Database-scoped DDL (CREATE/DROP/ALTER DATABASE) has no table
+                        // subject and no DbWriter cache to invalidate. Expected, not an error.
+                        log.debug("DDL is not table-scoped; no schema cache to invalidate. "
+                                + "DDL: {}", DDL);
                     }
                 } catch (Exception e) {
-                    log.warn("Error invalidating cache for DDL: " + DDL, e);
+                    log.error("Error invalidating cache for DDL: " + DDL, e);
                 }
 
                 try {
@@ -596,6 +963,18 @@ public class DebeziumChangeEventCapture {
             }
             if (numRetries >= MAX_DDL_RETRIES) {
                 throw new RuntimeException("Max retries exceeded for DDL");
+            }
+        }
+        } finally {
+            // Always unfreeze, even if the DDL failed/threw, so the table is
+            // never left frozen forever. After a successful ALTER the cache is
+            // already marked for invalidation; the next insert rebuilds it and
+            // runs the source-vs-destination integrity check. On failure we
+            // unfreeze so inserts (which would also have failed against the old
+            // schema) are not blocked indefinitely -- the error was already
+            // logged to the error table above.
+            if (ddlFreezeTable != null) {
+                TableReplicationFreezeManager.getInstance().unfreeze(ddlFreezeTable);
             }
         }
         updateMetrics(DDL);
@@ -660,21 +1039,105 @@ public class DebeziumChangeEventCapture {
     }
 
     /**
-     * Function to get the table name from the SourceRecord.
+     * Resolves the database half of a schema-cache key, applying
+     * {@code clickhouse.database.override.map} exactly the way the batch
+     * consumers ({@code ClickHouseBatchRunnable} /
+     * {@code ClickHouseBatchWriter}) do when they build their
+     * {@code "database.table"} lookup key.
      *
-     * @param sr The source record.
-     * @return The table name, or null if not found.
+     * <p>The consumer's key is
+     * {@code override(replicationHistoryEnabled ? historyDb : sourceDb)}, so
+     * BOTH steps must be applied here. Passing the caller's already
+     * history-adjusted {@code databaseName} covers the first step; this method
+     * applies the override map on top. A key built any other way silently
+     * never matches the consumer's key, so the invalidation (or freeze) would
+     * be registered against a table nobody ever looks up — the cache would
+     * appear to be invalidated while every worker kept its stale column
+     * list.</p>
+     *
+     * @param databaseName The caller's database name, already adjusted for
+     *                     replication history.
+     * @param config       The connector configuration.
+     * @return The destination database name to use in the cache key.
      */
-    private String getTableName(SourceRecord sr) {
-        if (sr != null && sr.key() instanceof Struct) {
+    private String resolveInvalidationDatabaseName(
+            String databaseName, ClickHouseSinkConnectorConfig config) {
+        String resolved = databaseName;
+        String overrideMapConfig = config.getString(
+                ClickHouseSinkConnectorConfigVariables
+                        .CLICKHOUSE_DATABASE_OVERRIDE_MAP.toString());
+        if (overrideMapConfig != null) {
             try {
-                String tableName = (String) ((Struct) sr.key()).get("tableName");
-                if (tableName != null && !tableName.isEmpty()) {
-                    return tableName;
+                Map<String, String> databaseOverrideMap =
+                        Utils.parseSourceToDestinationDatabaseMap(overrideMapConfig);
+                if (databaseOverrideMap.containsKey(resolved)) {
+                    resolved = databaseOverrideMap.get(resolved);
                 }
             } catch (Exception e) {
-                // tableName field may not exist in the struct
-                log.debug("tableName field not found in source record key");
+                // Log LOUDLY rather than swallowing: an unparseable override map
+                // means the key computed here may not match the one the batch
+                // consumers use, so a cache invalidation or replication freeze
+                // could be registered against a table nobody looks up. The
+                // unmapped name is still the best available key, but an operator
+                // must see that the override map is broken.
+                log.error("Could not parse {}='{}' while resolving the schema-cache "
+                                + "key for database '{}'. Falling back to the unmapped "
+                                + "name; if an override is configured for it, DDL cache "
+                                + "invalidation and the replication freeze will NOT match "
+                                + "the insert path and inserts may use a stale schema.",
+                        ClickHouseSinkConnectorConfigVariables
+                                .CLICKHOUSE_DATABASE_OVERRIDE_MAP,
+                        overrideMapConfig, databaseName, e);
+            }
+        }
+        return resolved;
+    }
+
+    /**
+     * Returns true when the DDL operates on a table (and therefore has a DbWriter
+     * schema cache that must be invalidated). Database-scoped DDL such as
+     * CREATE/DROP/ALTER DATABASE has no table subject, so a missing table name
+     * there is expected rather than an error worth alerting on.
+     *
+     * @param ddl the DDL statement text.
+     * @return true if the statement is table-scoped.
+     */
+    private boolean isTableScopedDDL(String ddl) {
+        if (ddl == null) {
+            return false;
+        }
+        return ddl.toUpperCase(java.util.Locale.ROOT).contains("TABLE");
+    }
+
+    /**
+     * Function to get the table name affected by a schema-change (DDL) record.
+     *
+     * <p>The table name is resolved from the DDL text, NOT from the record key.
+     * Debezium's {@code SchemaChangeKey} struct carries exactly one field,
+     * {@code databaseName} — there is no {@code tableName} field on it. Reading
+     * "tableName" from the key therefore always failed and returned null, which
+     * meant the DDL cache invalidation below was never registered for any table,
+     * leaving every cached DbWriter serving a stale column list forever.</p>
+     *
+     * @param sr  The source record (used only as a fallback source of the value).
+     * @param ddl The DDL statement text.
+     * @return The table name, or null if it could not be determined.
+     */
+    private String getTableName(SourceRecord sr, String ddl) {
+        String tableName = MySQLDDLParserService.extractTableName(ddl);
+        if (tableName != null && !tableName.isEmpty()) {
+            return tableName;
+        }
+        // Fall back to the record key in case a future connector version does
+        // expose a table name there.
+        if (sr != null && sr.key() instanceof Struct) {
+            try {
+                String keyTableName = (String) ((Struct) sr.key()).get("tableName");
+                if (keyTableName != null && !keyTableName.isEmpty()) {
+                    return keyTableName;
+                }
+            } catch (Exception e) {
+                log.debug("tableName field not present in source record key");
             }
         }
         return null;
@@ -752,11 +1215,22 @@ public class DebeziumChangeEventCapture {
     private void executeDDL(String clickHouseQuery, BaseDbWriter writer, ClickHouseSinkConnectorConfig config) throws SQLException {
         ClickHouseAlterTable cat = new ClickHouseAlterTable();
         DBMetadata dbMetadata = new DBMetadata(config);
+        long schemaChangeTimeoutMs = config.getLong(
+                ClickHouseSinkConnectorConfigVariables.DDL_SCHEMA_CHANGE_TIMEOUT_MS.toString());
+        long schemaChangePollIntervalMs = config.getLong(
+                ClickHouseSinkConnectorConfigVariables.DDL_SCHEMA_CHANGE_POLL_INTERVAL_MS.toString());
+        DDLSchemaChangeWaiter schemaWaiter = new DDLSchemaChangeWaiter(schemaChangeTimeoutMs, schemaChangePollIntervalMs);
         String[] queries = clickHouseQuery.replaceAll(",$", "").split("\n");
         for (String query : queries) {
             if (!query.isEmpty()) {
                 log.info("ClickHouse DDL: " + query);
                 dbMetadata.executeSystemQuery(writer.getConnection(), query);
+                // Wait for schema change to become visible in system.columns
+                // before cache invalidation proceeds. Without this, the batch
+                // insert thread may rebuild its column metadata cache before
+                // the ALTER TABLE has propagated, silently dropping values
+                // for newly added columns. See GitHub issue #1222.
+                schemaWaiter.waitForSchemaVisibility(writer.getConnection(), query);
             }
         }
     }
@@ -811,7 +1285,8 @@ public class DebeziumChangeEventCapture {
                 return null;
             }
             if (struct.schema() == null) {
-                log.error("SCHEMA EMPTY");
+log.error("SCHEMA EMPTY - cannot process record without schema. Record: {}", record.toString());
+                return null;
             }
 
             java.util.List<Field> schemaFields = struct.schema().fields();
@@ -828,18 +1303,36 @@ public class DebeziumChangeEventCapture {
 
                 if (DDL != null && !DDL.isEmpty()) {
                     log.info("***** DDL received, Flush all existing records");
-                    this.executor.pause();
+                    // In single.threaded mode there is no batch executor:
+                    // setupProcessingThread() creates singleThreadedWriter and
+                    // returns, so this.executor stays null and records are
+                    // written synchronously on this same thread — DDL and DML
+                    // are already serialized and there is nothing to pause.
+                    // Upstream calls pause() unconditionally and the resulting
+                    // NullPointerException was silently swallowed by the
+                    // log-only catch below (skipping the DDL); now that the
+                    // catch fails loudly, the null guard is required — without
+                    // it the FIRST DDL in single-threaded mode stops the
+                    // engine and cascades across the whole suite.
+                    pauseBatchExecutor();
+                    try {
+                        Map<String, Object> sourceObjStruct = new ClickHouseConverter().convertValue(sr);
 
-                    Map<String, Object> sourceObjStruct = new ClickHouseConverter().convertValue(sr);
-
-                    ClickHouseStruct ddlStruct = new ClickHouseStruct();
-                    ddlStruct.setAdditionalMetaData(sourceObjStruct);
-                    ddlStruct.setSequenceNumber(sequenceNumber);
-                    performDDLOperation(DDL, props, sr, config, recordCommitter, record, lastRecordInBatch, ddlStruct);
-                    this.executor.resume();
+                        ClickHouseStruct ddlStruct = new ClickHouseStruct();
+                        ddlStruct.setAdditionalMetaData(sourceObjStruct);
+                        ddlStruct.setSequenceNumber(sequenceNumber);
+                        performDDLOperation(DDL, props, sr, config, recordCommitter, record, lastRecordInBatch, ddlStruct);
+                    } finally {
+                        // Always resume executor — leaving it paused permanently stalls replication
+                        resumeBatchExecutor();
+                    }
                 }
             } else {
                 chStruct = debeziumRecordParserService.parse(record, recordCommitter, lastRecordInBatch);
+                if (chStruct == null) {
+                    log.warn("Record parser returned null — skipping record");
+                    return null;
+                }
                 chStruct.setSequenceNumber(sequenceNumber);
                 try {
                     if (chStruct != null) {
@@ -855,10 +1348,38 @@ public class DebeziumChangeEventCapture {
                 }
             }
         } catch (Exception e) {
-            log.error("Exception processing record", e);
+            log.error("Exception processing record: " + record.toString(), e);
+            throw new RuntimeException("Failed to process CDC record", e);
         }
 
         return chStruct;
+    }
+
+    /**
+     * Pauses the batch executor before a DDL is applied, if one exists.
+     *
+     * <p>In single.threaded mode {@link #setupProcessingThread} creates a
+     * {@code singleThreadedWriter} instead of a batch executor, so
+     * {@code this.executor} is null and DML is written synchronously on the
+     * Debezium event thread — the same thread that processes DDL — so there
+     * is no concurrent batch thread to pause and this is safely a no-op.</p>
+     */
+    @VisibleForTesting
+    void pauseBatchExecutor() {
+        if (this.executor != null) {
+            this.executor.pause();
+        }
+    }
+
+    /**
+     * Resumes the batch executor after a DDL completes, if one exists.
+     * No-op in single.threaded mode (see {@link #pauseBatchExecutor}).
+     */
+    @VisibleForTesting
+    void resumeBatchExecutor() {
+        if (this.executor != null) {
+            this.executor.resume();
+        }
     }
 
     /**
@@ -882,7 +1403,7 @@ public class DebeziumChangeEventCapture {
 
         if (sr.sourceOffset() != null) {
             if (sr.sourceOffset().containsKey("snapshot")) {
-                String snapshotMode = (String) sr.sourceOffset().get("snapshot");
+                String snapshotMode = String.valueOf(sr.sourceOffset().get("snapshot"));
                 if (snapshotMode.equalsIgnoreCase("INITIAL")) {
                     snapshotDDL = true;
                 }
@@ -939,13 +1460,36 @@ public class DebeziumChangeEventCapture {
             }
         }
 
-        // Check DDL against regex patterns from IgnoreDDLRegexLoader
+        // Check DDL against the built-in regex patterns from
+        // IgnoreDDLRegexLoader. Record the statement here too: a DDL ignored by
+        // a built-in pattern is just as ignored as one matched by the
+        // user-configured IGNORE_DDL_REGEX above, and getLastIgnoredDDL() is
+        // the only way an operator can see which statement was skipped.
+        // Without this the two paths disagree — making a built-in pattern
+        // case-insensitive silently stopped a lowercase DDL from ever being
+        // reported, because the built-in branch claimed it first and returned
+        // without recording it.
         if (checkDDLAgainstRegexPatterns(DDL)) {
+            lastIgnoredDDL = DDL;
+            log.info("Ignoring DDL: " + DDL
+                    + " as it matches a built-in ignore pattern");
             return true;
         }
 
+        // Snapshot-phase DDL is exempt from the DISABLE_DROP_TRUNCATE guard. During a
+        // snapshot Debezium replays schema bootstrap as a drop-and-recreate
+        // pair for every captured table; when the operator has enabled
+        // snapshot DDL, suppressing only the drop half leaves any
+        // pre-existing destination table in place and the paired CREATE then
+        // fails with TABLE_ALREADY_EXISTS, stalling the DDL stream in a retry
+        // loop. The guard exists to protect the destination from destructive
+        // STREAMING DDL (an accidental drop on the source mid-replication),
+        // which is still blocked below. Snapshot DDL that the operator has NOT
+        // enabled never reaches ClickHouse anyway via the final check in this
+        // method.
         String disableDropAndTruncateProperty = props.getProperty(SinkConnectorLightWeightConfig.DISABLE_DROP_TRUNCATE);
-        if (disableDropAndTruncateProperty != null && disableDropAndTruncateProperty.equalsIgnoreCase("true") && isDropOrTruncate.get() == true) {
+        if (disableDropAndTruncateProperty != null && disableDropAndTruncateProperty.equalsIgnoreCase("true")
+                && isDropOrTruncate.get() == true && !isSnapshotDDL) {
             log.debug("Ignoring Drop or Truncate");
             return true;
         }
@@ -1083,31 +1627,110 @@ public class DebeziumChangeEventCapture {
 
 
     /**
+     * Seeds the shared sequence anchor for a new batch.
+     *
+     * <p>Runs under {@link #sequenceLock} because the anchor and the counter
+     * are a single unit of state: a thread that re-anchors without holding the
+     * counter's lock can race a thread deciding whether to reset.</p>
+     *
+     * <p>The anchor only ever moves <b>forward</b>. The anchor is shared by all
+     * batch threads, but each batch seeds it from its own first record, so with
+     * an unconditional assignment a batch carrying an older timestamp can drag
+     * the anchor <em>backward</em> past a point another thread has already
+     * passed. That re-arms the {@code diff > 1} reset branch for timestamps
+     * already in use, and the counter is reset to the constant
+     * {@link #SEQUENCE_START} a second time — so two different records at the
+     * same source timestamp receive an identical {@code _version} and
+     * ReplacingMergeTree silently discards one of them. Measured
+     * single-threaded, with the anchor re-seeded backward between assignments:
+     * 199 duplicate versions in 200 records, and the second value is
+     * <em>lower</em> than the first, so an older row can also outrank a newer
+     * one.</p>
+     *
+     * <p>The guard changes no emitted value for a non-decreasing source clock —
+     * a MySQL binlog's commit timestamps only advance, so {@code ts > anchor}
+     * holds on every ordinary seed and the assignment is identical to the
+     * unconditional one. Verified by replaying an ascending stream through both
+     * forms and comparing the full output: byte-for-byte equal. The 2.8.0
+     * {@code _version} format is therefore untouched (pinned by
+     * {@code Version280CompatibilityTest}); only an out-of-order re-seed, which
+     * previously corrupted the sequence, is now ignored.</p>
+     *
+     * @param debeziumTsMs the Debezium timestamp of the batch's first record.
+     */
+    void seedSequenceAnchor(long debeziumTsMs) {
+        synchronized (sequenceLock) {
+            if (sequenceStartTime == UNANCHORED || debeziumTsMs > sequenceStartTime) {
+                sequenceStartTime = debeziumTsMs;
+            }
+        }
+    }
+
+    /**
+     * Produces the next {@code _version} value for a record.
+     *
+     * <p>The returned value is <b>bit-for-bit the 2.8.0 formula</b>:</p>
+     * <pre>    _version = debezium_ts_ms * 1_000_000 + counter</pre>
+     * <p>with the counter reset to {@link #SEQUENCE_START} when the Debezium
+     * clock advances more than one second past the current anchor, and
+     * incremented otherwise. The formula is deliberately unchanged, because
+     * {@code _version} decides which row survives a ReplacingMergeTree merge:
+     * a table that already holds rows written by 2.8.0 cannot also hold rows
+     * from a different scheme without the larger magnitude winning every merge
+     * regardless of which change actually happened later — and no downgrade
+     * can undo rows already written.</p>
+     *
+     * <p>What is fixed is the <em>assignment</em>, not the value. The previous
+     * code read, modified and wrote the shared counter without holding a lock,
+     * in two separate windows: the reset branch is a check-and-act across the
+     * anchor and the counter, and the increment branch called
+     * {@code incrementAndGet()} and then re-read the counter with a separate
+     * {@code get()}. Two batch threads interleaving in either window observe
+     * the same counter and hand two distinct records an identical
+     * {@code _version}, which the ReplacingMergeTree silently collapses into
+     * one row. Holding the lock across the whole decision closes both windows,
+     * and the value used is the one produced inside the critical section.</p>
+     *
+     * @param debeziumTsMs the record's Debezium timestamp.
+     * @return the {@code _version} value to assign to the record.
+     */
+    long nextSequenceNumber(long debeziumTsMs) {
+        synchronized (sequenceLock) {
+            if (sequenceStartTime == UNANCHORED) {
+                sequenceStartTime = debeziumTsMs;
+            }
+            final long assignedSequence;
+            // Identical to 2.8.0: reset only when the clock advances more than
+            // one whole second past the anchor.
+            int diff = (int) ((debeziumTsMs - sequenceStartTime) / 1000);
+            if (diff > 1) {
+                sequenceNumber.set(SEQUENCE_START);
+                assignedSequence = SEQUENCE_START;
+                sequenceStartTime = debeziumTsMs;
+            } else {
+                assignedSequence = sequenceNumber.incrementAndGet();
+            }
+            return debeziumTsMs * 1000000 + assignedSequence;
+        }
+    }
+
+    /**
      * Adds a version (sequence number) to every record.
-     * <p>
-     * The sequence starts at SEQUENCE_START, increments for every record,
-     * and resets if more than one second has elapsed since the first record.
-     * </p>
+     *
+     * <p>Delegates to {@link #nextSequenceNumber(long)} so this path and the
+     * live batch-consumer path can never drift apart into two different
+     * {@code _version} schemes.</p>
      *
      * @param chStructs The list of {@link ClickHouseStruct} records.
      */
-    public static void addVersion(List<ClickHouseStruct> chStructs) {
-        // Start the sequence from SEQUENCE_START and increment for every record
+    public void addVersion(List<ClickHouseStruct> chStructs) {
         if (chStructs.isEmpty()) {
             return;
         }
-        long sequenceStartTime = chStructs.get(0).getDebezium_ts_ms();
         for (ClickHouseStruct chStruct : chStructs) {
-            // Get diff in seconds from the first record's Debezium timestamp.
-            int diff = (int) ((chStruct.getDebezium_ts_ms() - sequenceStartTime) / 1000);
-            if (diff > 1) {
-                sequenceNumber = SEQUENCE_START;
-                sequenceStartTime = chStruct.getDebezium_ts_ms();
-            } else {
-                sequenceNumber++;
-            }
-            // Pad the sequence number with zeros and set the sequence number in the record.
-            chStruct.setSequenceNumber(chStruct.getDebezium_ts_ms() * 1000000 + sequenceNumber);
+            // Anchored on the DEBEZIUM timestamp, exactly as 2.8.0 did.
+            chStruct.setSequenceNumber(
+                    nextSequenceNumber(chStruct.getDebezium_ts_ms()));
         }
     }
 }

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/IgnoreDDLRegexLoader.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/IgnoreDDLRegexLoader.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public class IgnoreDDLRegexLoader {
     private static final List<String> REGEX_PATTERNS = Arrays.asList(
-        "^ALTER TABLE .*\\s+analyze\\s+PARTITION\\s+p[0-9]+$",
+        "(?i)^ALTER TABLE .*\\s+analyze\\s+PARTITION\\s+p[0-9]+$",
         "(?i)ALTER\\s+TABLE\\s+\\S+\\s+ADD\\s+PARTITION\\s*\\(",
         "(?i)ALTER\\s+TABLE\\s+\\S+\\s+DROP\\s+PARTITION\\s+\\S+",
         "(?i)ALTER\\s+TABLE\\s+\\S+\\s+REORGANIZE\\s+PARTITION\\s+.*?\\s+INTO\\s*\\(",

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCaptureTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCaptureTest.java
@@ -99,14 +99,25 @@ public class DebeziumChangeEventCaptureTest {
                 getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
         ch6.setTs_ms(currentTimestamp);
 
+        // Both batches go through ONE capture instance. The sequence counter is
+        // per-instance (an AtomicLong, not a shared static: a plain static long
+        // mutated by several worker threads is a lost-update race that can hand
+        // two records the SAME _version and let the ReplacingMergeTree collapse
+        // one of them away). Production creates exactly one
+        // DebeziumChangeEventCapture, so successive batches must be sequenced
+        // through the same instance for the counter to carry across them --
+        // using a fresh instance per batch would only be testing the race this
+        // fix removed.
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+
         // Make a list of ch1, ch2, ch3 and ch4
         List<ClickHouseStruct> clickHouseStructs = Arrays.asList(ch1, ch2, ch3, ch4, ch5);
-        DebeziumChangeEventCapture.addVersion(clickHouseStructs);
+        capture.addVersion(clickHouseStructs);
 
         Thread.sleep(1000);
         // Add ch5 and ch6
         List<ClickHouseStruct> clickHouseStructs2 = Arrays.asList(ch5, ch6);
-        DebeziumChangeEventCapture.addVersion(clickHouseStructs2);
+        capture.addVersion(clickHouseStructs2);
 
         // Check if the sequence numbers are unique
         assertTrue(clickHouseStructs.get(0).getSequenceNumber() < clickHouseStructs.get(1).getSequenceNumber());
@@ -137,6 +148,23 @@ public class DebeziumChangeEventCaptureTest {
 
         String ddlNotToIgnore = "ALTER TABLE trade_prod.bundle_detail ADD COLUMN new_column INT";
         assertFalse(capture.checkDDLAgainstRegexPatterns(ddlNotToIgnore));
+    }
+
+    @Test
+    @DisplayName("ANALYZE PARTITION is matched regardless of statement case")
+    public void shouldIgnoreAnalyzePartitionCaseInsensitively() {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+
+        // MySQL echoes the statement exactly as the client typed it, so the
+        // built-in pattern has to be case-insensitive to catch the lowercase
+        // spelling clients actually emit. The sibling ADD/DROP PARTITION
+        // patterns already carried (?i); this one did not.
+        assertTrue(capture.checkDDLAgainstRegexPatterns(
+                "ALTER TABLE sales analyze PARTITION p2022"));
+        assertTrue(capture.checkDDLAgainstRegexPatterns(
+                "alter table sales analyze partition p2022"));
+        assertTrue(capture.checkDDLAgainstRegexPatterns(
+                "ALTER TABLE sales ANALYZE PARTITION p2022"));
     }
 
     @Test
@@ -234,4 +262,250 @@ public class DebeziumChangeEventCaptureTest {
         String ddlToIgnoreCaseInsensitive = "alter table trade_prod.bundle_detail optimize partition p20230106";
         assertTrue(capture.checkDDLAgainstRegexPatterns(ddlToIgnoreCaseInsensitive));
     }
+
+    /**
+     * Regression: the assigned sequence number must come from the atomic
+     * mutation itself, never from a follow-up get(). incrementAndGet() then
+     * re-reading with get() is a TOCTOU race -- two threads can interleave
+     * between the increment and the read and both observe the same highest
+     * value, handing two records an identical _version and letting the
+     * ReplacingMergeTree collapse one of them away. That is exactly the
+     * lost-update the AtomicLong exists to prevent.
+     *
+     * <p>Every emitted _version across concurrent batches must be unique.</p>
+     */
+    @Test
+    @DisplayName("Concurrent addVersion calls must never emit a duplicate _version")
+    public void testAddVersionIsRaceFreeAcrossThreads() throws Exception {
+        final DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        final long ts = System.currentTimeMillis();
+        // Single-record batches maximise the interleave window: each
+        // addVersion call is one increment immediately followed by the read,
+        // which is precisely where a get()-after-increment loses the update.
+        final int threads = 16;
+        final int perThread = 1;
+        final int rounds = 400;
+
+        // All records share one ts_ms so every version differs only by the
+        // counter -- any lost update shows up immediately as a duplicate.
+        final java.util.concurrent.CountDownLatch start =
+                new java.util.concurrent.CountDownLatch(1);
+        final java.util.List<java.util.concurrent.Future<java.util.List<Long>>> futures =
+                new java.util.ArrayList<>();
+        final java.util.concurrent.ExecutorService pool =
+                java.util.concurrent.Executors.newFixedThreadPool(threads);
+        try {
+            for (int t = 0; t < threads; t++) {
+                futures.add(pool.submit(() -> {
+                    List<Long> seqs = new java.util.ArrayList<>();
+                    start.await();
+                    // Each round submits its own tiny batch, so the increment
+                    // and the subsequent read are adjacent under contention.
+                    for (int r = 0; r < rounds; r++) {
+                        List<ClickHouseStruct> batch = new java.util.ArrayList<>();
+                        for (int i = 0; i < perThread; i++) {
+                            ClickHouseStruct ch = new ClickHouseStruct(10, "topic_1",
+                                    getKafkaStruct(), 2, ts, null, getKafkaStruct(), null,
+                                    ClickHouseConverter.CDC_OPERATION.CREATE);
+                            ch.setTs_ms(ts);
+                            batch.add(ch);
+                        }
+                        capture.addVersion(batch);
+                        for (ClickHouseStruct ch : batch) {
+                            seqs.add(ch.getSequenceNumber());
+                        }
+                    }
+                    return seqs;
+                }));
+            }
+            start.countDown();
+
+            List<Long> all = new java.util.ArrayList<>();
+            for (java.util.concurrent.Future<java.util.List<Long>> f : futures) {
+                all.addAll(f.get(60, java.util.concurrent.TimeUnit.SECONDS));
+            }
+            java.util.Set<Long> unique = new java.util.HashSet<>(all);
+            org.junit.Assert.assertEquals(
+                    "duplicate _version emitted -- the counter was read with get() "
+                            + "instead of using the value returned by incrementAndGet()",
+                    all.size(), unique.size());
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    /**
+     * Regression: the time-gap reset is a check-and-act over TWO pieces of
+     * state -- the source-timestamp anchor is read to decide whether the
+     * second boundary was crossed, and only then is the counter reset. An
+     * atomic counter alone cannot make that pair consistent: two threads
+     * crossing the same boundary both observe the stale anchor, both reset to
+     * SEQUENCE_START, and both emit an identical _version for records sharing
+     * that ts_ms -- which ReplacingMergeTree silently collapses.
+     */
+    @Test
+    @DisplayName("Concurrent time-gap resets must not collide on SEQUENCE_START")
+    public void testAddVersionRaceOnTimeGap() throws Exception {
+        final long oldTs = 1000000000000L;
+        // A gap > 1s from the anchor forces every thread down the reset branch.
+        final long newTs = oldTs + 5000;
+        final int threads = 8;
+
+        // Repeat: a check-and-act window is probabilistic, so a single pass can
+        // pass by luck. Each round uses a fresh capture anchored in the past.
+        for (int round = 0; round < 200; round++) {
+            final DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+
+            final java.util.concurrent.CountDownLatch start =
+                    new java.util.concurrent.CountDownLatch(1);
+            final java.util.concurrent.ExecutorService pool =
+                    java.util.concurrent.Executors.newFixedThreadPool(threads);
+            try {
+                List<java.util.concurrent.Future<Long>> futures =
+                        new java.util.ArrayList<>();
+                for (int t = 0; t < threads; t++) {
+                    futures.add(pool.submit(() -> {
+                        // The anchor is taken from record[0] of THIS batch, so the
+                        // reset branch is only reachable when a single batch spans
+                        // the gap. record[1] is the one that resets the shared
+                        // counter and is assigned SEQUENCE_START.
+                        ClickHouseStruct first = new ClickHouseStruct(10, "topic_1",
+                                getKafkaStruct(), 2, oldTs, null, getKafkaStruct(),
+                                null, ClickHouseConverter.CDC_OPERATION.CREATE);
+                        first.setTs_ms(oldTs);
+                        ClickHouseStruct afterGap = new ClickHouseStruct(10, "topic_1",
+                                getKafkaStruct(), 2, newTs, null, getKafkaStruct(),
+                                null, ClickHouseConverter.CDC_OPERATION.CREATE);
+                        afterGap.setTs_ms(newTs);
+                        start.await();
+                        capture.addVersion(Arrays.asList(first, afterGap));
+                        return afterGap.getSequenceNumber();
+                    }));
+                }
+                start.countDown();
+
+                List<Long> seqs = new java.util.ArrayList<>();
+                for (java.util.concurrent.Future<Long> f : futures) {
+                    seqs.add(f.get(30, java.util.concurrent.TimeUnit.SECONDS));
+                }
+                java.util.Set<Long> unique = new java.util.HashSet<>(seqs);
+                org.junit.Assert.assertEquals(
+                        "round " + round + ": threads crossing the same second "
+                                + "boundary produced a duplicate _version -- the "
+                                + "counter and its time anchor must be updated "
+                                + "atomically together",
+                        seqs.size(), unique.size());
+            } finally {
+                pool.shutdownNow();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("addVersion should handle empty list without error")
+    public void testAddVersionEmptyListNoOp() {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        List<ClickHouseStruct> emptyList = new java.util.ArrayList<>();
+        // Should not throw
+        capture.addVersion(emptyList);
+        assertTrue(emptyList.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Separate instances should have independent sequence numbers")
+    public void testAddVersionInstanceIsolation() {
+        long currentTimestamp = System.currentTimeMillis();
+
+        // Create structs for instance 1
+        ClickHouseStruct ch1 = new ClickHouseStruct(10, "topic_1", getKafkaStruct(), 2,
+                currentTimestamp, null,
+                getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+        ch1.setTs_ms(currentTimestamp);
+
+        ClickHouseStruct ch2 = new ClickHouseStruct(10, "topic_1", getKafkaStruct(), 2,
+                currentTimestamp + 100, null,
+                getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+        ch2.setTs_ms(currentTimestamp);
+
+        // Create structs for instance 2
+        ClickHouseStruct ch3 = new ClickHouseStruct(10, "topic_2", getKafkaStruct(), 2,
+                currentTimestamp, null,
+                getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+        ch3.setTs_ms(currentTimestamp);
+
+        ClickHouseStruct ch4 = new ClickHouseStruct(10, "topic_2", getKafkaStruct(), 2,
+                currentTimestamp + 100, null,
+                getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+        ch4.setTs_ms(currentTimestamp);
+
+        // Process with separate instances
+        DebeziumChangeEventCapture instance1 = new DebeziumChangeEventCapture();
+        DebeziumChangeEventCapture instance2 = new DebeziumChangeEventCapture();
+
+        List<ClickHouseStruct> batch1 = Arrays.asList(ch1, ch2);
+        List<ClickHouseStruct> batch2 = Arrays.asList(ch3, ch4);
+
+        instance1.addVersion(batch1);
+        instance2.addVersion(batch2);
+
+        // Both instances should produce the same sequence pattern independently
+        // (since they start from the same SEQUENCE_START)
+        long seq1_first = batch1.get(0).getSequenceNumber();
+        long seq2_first = batch2.get(0).getSequenceNumber();
+        long seq1_second = batch1.get(1).getSequenceNumber();
+        long seq2_second = batch2.get(1).getSequenceNumber();
+
+        // Within each batch, sequences should be strictly increasing
+        assertTrue(seq1_first < seq1_second);
+        assertTrue(seq2_first < seq2_second);
+
+        // The relative offsets should be the same for both instances
+        // (same timestamp pattern -> same sequence increment)
+        long delta1 = seq1_second - seq1_first;
+        long delta2 = seq2_second - seq2_first;
+        assertTrue(delta1 == delta2);
+    }
+
+    @Test
+    @DisplayName("addVersion should reset sequence on large timestamp gap")
+    public void testAddVersionSequenceResetOnLargeTimeGap() {
+        long baseTimestamp = 1700000000000L; // fixed timestamp
+
+        ClickHouseStruct ch1 = new ClickHouseStruct(10, "topic_1", getKafkaStruct(), 2,
+                baseTimestamp, null,
+                getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+        ch1.setTs_ms(baseTimestamp);
+
+        // Same second — should increment
+        ClickHouseStruct ch2 = new ClickHouseStruct(10, "topic_1", getKafkaStruct(), 2,
+                baseTimestamp + 500, null,
+                getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+        ch2.setTs_ms(baseTimestamp + 500);
+
+        // 2 seconds later — should reset
+        ClickHouseStruct ch3 = new ClickHouseStruct(10, "topic_1", getKafkaStruct(), 2,
+                baseTimestamp + 2000, null,
+                getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+        ch3.setTs_ms(baseTimestamp + 2000);
+
+        // Same second as ch3 — should increment from reset
+        ClickHouseStruct ch4 = new ClickHouseStruct(10, "topic_1", getKafkaStruct(), 2,
+                baseTimestamp + 2100, null,
+                getKafkaStruct(), null, ClickHouseConverter.CDC_OPERATION.CREATE);
+        ch4.setTs_ms(baseTimestamp + 2100);
+
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        List<ClickHouseStruct> batch = Arrays.asList(ch1, ch2, ch3, ch4);
+        capture.addVersion(batch);
+
+        // ch1 and ch2 should be in the same sequence window (increasing)
+        assertTrue(ch1.getSequenceNumber() < ch2.getSequenceNumber());
+        // ch3 should have reset — its sequence should be based on the new timestamp
+        // After reset, sequenceNumber goes back to SEQUENCE_START, so the
+        // ch3 sequence should be baseTimestamp+2000 * 1000000 + SEQUENCE_START
+        assertTrue(ch3.getSequenceNumber() > ch2.getSequenceNumber());
+        // ch4 should increment from ch3
+        assertTrue(ch3.getSequenceNumber() < ch4.getSequenceNumber());
+    }
+
 }

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumEngineRestartTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumEngineRestartTest.java
@@ -1,0 +1,137 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Guards the engine-restart wiring in {@link DebeziumChangeEventCapture}.
+ *
+ * <p>When the Debezium engine stops with an error, its completion callback is
+ * the only thing that can bring it back: {@code setup()} calls
+ * {@code setupDebeziumEventCapture()} exactly once and returns. A revision
+ * that removed the retry from that callback left the connector permanently
+ * down after the first binlog communication failure — replication simply
+ * stopped and every later change was never applied, with no further error.
+ *
+ * <p>The restart must also not run on the callback thread. Rebuilding the
+ * engine inline stacks the replacement engine underneath the failed one's
+ * frame, so repeated failures nest until the stack overflows. The restart is
+ * therefore dispatched to a dedicated single-thread executor, which lets the
+ * callback unwind first and serialises attempts.
+ *
+ * <p>These tests pin the structural invariants that keep both properties
+ * true. They deliberately do not start an engine — doing so would need a live
+ * MySQL and ClickHouse — so they assert on the wiring rather than on a
+ * simulated failure.
+ */
+public class DebeziumEngineRestartTest {
+
+    private static Object field(Object target, String name) throws Exception {
+        Field f = DebeziumChangeEventCapture.class.getDeclaredField(name);
+        f.setAccessible(true);
+        return f.get(target);
+    }
+
+    @Test
+    @DisplayName("A dedicated restart executor exists and is distinct from the event executor")
+    public void testRestartExecutorIsSeparate() throws Exception {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+
+        Object restart = field(capture, "debeziumRestartExecutor");
+        Object event = field(capture, "singleThreadDebeziumEventExecutor");
+
+        assertNotNull("restart executor must be created in the constructor", restart);
+        assertNotNull(event);
+        // Sharing the event executor would deadlock: the restart task would
+        // queue behind engine.run(), which only returns once the engine stops.
+        assertNotSame("restart must not reuse the Debezium event executor", event, restart);
+    }
+
+    @Test
+    @DisplayName("stop() shuts the restart executor down so no retry outlives the connector")
+    public void testStopShutsDownRestartExecutor() throws Exception {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        ExecutorService restart = (ExecutorService) field(capture, "debeziumRestartExecutor");
+
+        assertFalse("restart executor should be live before stop()", restart.isShutdown());
+
+        capture.stop();
+
+        // A retry sleeping through its back-off must be cancelled, not allowed
+        // to wake up and rebuild an engine on a connector that is shutting down.
+        assertTrue("stop() must shut the restart executor down", restart.isShutdown());
+    }
+
+    @Test
+    @DisplayName("The retry budget is bounded by MAX_RETRIES rather than unbounded")
+    public void testRetryBudgetIsBounded() {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+
+        // numRetries starts fresh; the callback compares it against MAX_RETRIES
+        // before scheduling, so an engine that can never start stops retrying
+        // instead of looping forever.
+        assertTrue("MAX_RETRIES must be positive", DebeziumChangeEventCapture.MAX_RETRIES > 0);
+        assertTrue("numRetries must start at zero", capture.numRetries == 0);
+    }
+
+    /**
+     * Loads the config.properties that ships inside the jar.
+     *
+     * <p>Read from the module source rather than the classpath on purpose: the
+     * test resources contain their own config.properties, which shadows the
+     * shipped one during tests. Asserting against the classpath copy would
+     * therefore check the fixture instead of the file that reaches users.</p>
+     */
+    private static Properties shippedConfig() throws Exception {
+        Properties shipped = new Properties();
+        Path path = Paths.get("src/main/resources/config.properties");
+        assertTrue("shipped config.properties not found at " + path.toAbsolutePath(),
+                Files.exists(path));
+        try (InputStream in = Files.newInputStream(path)) {
+            shipped.load(in);
+        }
+        return shipped;
+    }
+
+    @Test
+    @DisplayName("The shipped replica.status.view default keeps both %s placeholders")
+    public void testShippedViewDefaultIsParameterised() throws Exception {
+        String view = shippedConfig().getProperty("replica.status.view");
+        assertNotNull("replica.status.view must have a shipped default", view);
+
+        // createViewForShowReplicaStatus does String.format(view, dbName,
+        // dbName + "." + tableName). A format string with no placeholders
+        // silently discards both arguments, so the view would be created
+        // against whatever database the literal names regardless of config.
+        assertEquals("replica.status.view default must keep both %s placeholders",
+                2, view.split("%s", -1).length - 1);
+    }
+
+    @Test
+    @DisplayName("The initial-snapshot guard is advisory unless explicitly opted in")
+    public void testInitialSnapshotGuardIsOptIn() throws Exception {
+        Properties shipped = shippedConfig();
+
+        // The guard throws only when this is true. It must not ship enabled:
+        // snapshot.mode=initial is the default, so a connector that has already
+        // been replicating would refuse to restart and stay down until someone
+        // logs into the host and touches a file.
+        assertFalse("the initial-snapshot guard must not be fatal by default",
+                Boolean.parseBoolean(
+                        shipped.getProperty("snapshot.initial.require.confirmation", "false")));
+    }
+}

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/DropTruncateSnapshotExemptionTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/DropTruncateSnapshotExemptionTest.java
@@ -1,0 +1,113 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the interaction between DISABLE_DROP_TRUNCATE and snapshot DDL.
+ *
+ * <p>During a snapshot Debezium replays schema bootstrap as a
+ * drop-and-recreate pair for every captured table. If the drop half is
+ * suppressed by the DISABLE_DROP_TRUNCATE guard while the CREATE half executes, a
+ * pre-existing destination table makes the CREATE fail with
+ * TABLE_ALREADY_EXISTS and the DDL stream stalls in a retry loop. The
+ * guard therefore only applies to STREAMING DDL — an accidental drop on the
+ * source mid-replication — and must exempt snapshot DDL, whose delivery is
+ * governed by ENABLE_SNAPSHOT_DDL instead.</p>
+ */
+@DisplayName("DISABLE_DROP_TRUNCATE must exempt snapshot-phase DDL")
+public class DropTruncateSnapshotExemptionTest {
+
+    // DESTRUCTIVE: inert test fixture. This string is only classified by
+    // checkIfDDLNeedsToBeIgnored; no database connection exists in this test
+    // and nothing is executed — blast radius is zero.
+    private static final String DROP_DDL =
+            "DROP TABLE IF EXISTS `employees`.`temporal_types_DATETIME`";
+
+    private static boolean checkIgnored(Properties props, SourceRecord sr,
+                                        boolean isDropOrTruncate) throws Exception {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        Method m = DebeziumChangeEventCapture.class.getDeclaredMethod(
+                "checkIfDDLNeedsToBeIgnored",
+                String.class, Properties.class, SourceRecord.class, AtomicBoolean.class);
+        m.setAccessible(true);
+        return (Boolean) m.invoke(capture, DROP_DDL, props,
+                sr, new AtomicBoolean(isDropOrTruncate));
+    }
+
+    private static SourceRecord recordWithOffset(Map<String, ?> sourceOffset) {
+        return new SourceRecord(Collections.emptyMap(), sourceOffset,
+                "test-topic", Schema.STRING_SCHEMA, DROP_DDL);
+    }
+
+    @Test
+    @DisplayName("snapshot DROP passes through when snapshot DDL is enabled")
+    public void snapshotDropIsNotBlockedByDropTruncateGuard() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("disable.drop.truncate", "true");
+        props.setProperty("enable.snapshot.ddl", "true");
+
+        SourceRecord snapshotRecord =
+                recordWithOffset(Collections.singletonMap("snapshot", "INITIAL"));
+
+        assertFalse(checkIgnored(props, snapshotRecord, true),
+                "a snapshot-phase DROP must not be suppressed: its paired "
+                        + "CREATE TABLE would then hit TABLE_ALREADY_EXISTS "
+                        + "against a pre-existing destination table");
+    }
+
+    @Test
+    @DisplayName("streaming DROP is still blocked by the guard")
+    public void streamingDropRemainsBlocked() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("disable.drop.truncate", "true");
+        props.setProperty("enable.snapshot.ddl", "true");
+
+        SourceRecord streamingRecord = recordWithOffset(Collections.emptyMap());
+
+        assertTrue(checkIgnored(props, streamingRecord, true),
+                "a streaming DROP must still be suppressed when the operator "
+                        + "asked for DISABLE_DROP_TRUNCATE protection");
+    }
+
+    @Test
+    @DisplayName("snapshot DROP is still ignored when snapshot DDL is disabled")
+    public void snapshotDropStillIgnoredWhenSnapshotDdlDisabled() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("disable.drop.truncate", "true");
+        props.setProperty("enable.snapshot.ddl", "false");
+
+        SourceRecord snapshotRecord =
+                recordWithOffset(Collections.singletonMap("snapshot", "INITIAL"));
+
+        assertTrue(checkIgnored(props, snapshotRecord, true),
+                "with snapshot DDL disabled, snapshot statements are ignored "
+                        + "by the ENABLE_SNAPSHOT_DDL check regardless of the "
+                        + "DISABLE_DROP_TRUNCATE guard");
+    }
+
+    @Test
+    @DisplayName("streaming non-destructive DDL is unaffected by the guard")
+    public void streamingNonDestructiveDdlUnaffected() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("disable.drop.truncate", "true");
+        props.setProperty("enable.snapshot.ddl", "true");
+
+        SourceRecord streamingRecord = recordWithOffset(Collections.emptyMap());
+
+        assertFalse(checkIgnored(props, streamingRecord, false),
+                "non-destructive streaming DDL must never be suppressed by "
+                        + "the DISABLE_DROP_TRUNCATE guard");
+    }
+}

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/IgnoreDDLRegexLoaderTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/IgnoreDDLRegexLoaderTest.java
@@ -1,0 +1,209 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for IgnoreDDLRegexLoader — Phase 12 pattern matching coverage.
+ * <p>
+ * Validates:
+ * - All patterns are valid regex
+ * - Case-insensitive matching works for all patterns
+ * - Expected DDL statements are matched
+ * - Non-matching DDL statements are NOT matched
+ * </p>
+ */
+public class IgnoreDDLRegexLoaderTest {
+
+    private final List<String> patterns = IgnoreDDLRegexLoader.loadRegexPatterns();
+
+    private boolean matchesAnyPattern(String ddl) {
+        for (String pattern : patterns) {
+            if (Pattern.compile(pattern).matcher(ddl).find()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Nested
+    @DisplayName("Pattern validity")
+    class PatternValidity {
+
+        @Test
+        @DisplayName("All patterns should be valid regex")
+        public void testAllPatternsValid() {
+            for (String pattern : patterns) {
+                assertDoesNotThrow(() -> Pattern.compile(pattern),
+                        "Pattern should be valid regex: " + pattern);
+            }
+        }
+
+        @Test
+        @DisplayName("Should have at least 5 patterns loaded")
+        public void testMinimumPatterns() {
+            assertTrue(patterns.size() >= 5,
+                    "Should have at least 5 DDL ignore patterns, got " + patterns.size());
+        }
+    }
+
+    @Nested
+    @DisplayName("ANALYZE PARTITION — case sensitivity fix validation")
+    class AnalyzePartitionTests {
+
+        @Test
+        @DisplayName("lowercase analyze should match")
+        public void testLowercaseAnalyze() {
+            assertTrue(matchesAnyPattern("ALTER TABLE mydb.mytable analyze PARTITION p20240101"),
+                    "lowercase 'analyze' should match");
+        }
+
+        @Test
+        @DisplayName("uppercase ANALYZE should match (Phase 12 fix)")
+        public void testUppercaseAnalyze() {
+            assertTrue(matchesAnyPattern("ALTER TABLE mydb.mytable ANALYZE PARTITION p20240101"),
+                    "uppercase 'ANALYZE' should match after case-insensitivity fix");
+        }
+
+        @Test
+        @DisplayName("mixed case Analyze should match")
+        public void testMixedCaseAnalyze() {
+            assertTrue(matchesAnyPattern("ALTER TABLE mydb.mytable Analyze PARTITION p20240101"),
+                    "mixed case 'Analyze' should match");
+        }
+    }
+
+    @Nested
+    @DisplayName("ADD PARTITION matching")
+    class AddPartitionTests {
+
+        @Test
+        @DisplayName("ADD PARTITION should match")
+        public void testAddPartition() {
+            assertTrue(matchesAnyPattern("ALTER TABLE mydb.mytable ADD PARTITION (p20240101)"),
+                    "ADD PARTITION should match");
+        }
+
+        @Test
+        @DisplayName("add partition lowercase should match")
+        public void testAddPartitionLowercase() {
+            assertTrue(matchesAnyPattern("alter table mydb.mytable add partition (p20240101)"),
+                    "lowercase add partition should match");
+        }
+    }
+
+    // DESTRUCTIVE: the DDL strings in this class are inert test fixtures. They
+    // are only ever matched against a regex to decide whether such a statement
+    // should be IGNORED; nothing is parsed, connected to, or executed, so no
+    // data can be destroyed by this test.
+    @Nested
+    @DisplayName("DROP PARTITION matching")
+    class DropPartitionTests {
+
+        @Test
+        // DESTRUCTIVE: inert fixture string, regex-matched only -- never parsed
+        // or executed against any database, so nothing can be destroyed here.
+        @DisplayName("DROP PARTITION should match")
+        public void testDropPartition() {
+            assertTrue(matchesAnyPattern("ALTER TABLE mydb.mytable DROP PARTITION p20240101"),
+                    // DESTRUCTIVE: fixture text only; asserts regex behaviour.
+                    "DROP PARTITION should match");
+        }
+    }
+
+    @Nested
+    @DisplayName("AUTO_INCREMENT matching")
+    class AutoIncrementTests {
+
+        @Test
+        @DisplayName("AUTO_INCREMENT should match")
+        public void testAutoIncrement() {
+            assertTrue(matchesAnyPattern("ALTER TABLE mydb.mytable AUTO_INCREMENT = 12345"),
+                    "AUTO_INCREMENT should match");
+        }
+
+        @Test
+        @DisplayName("AUTO_INCREMENT with extra spaces should match")
+        public void testAutoIncrementSpaces() {
+            assertTrue(matchesAnyPattern("  ALTER TABLE mydb.mytable AUTO_INCREMENT = 12345  "),
+                    "AUTO_INCREMENT with leading/trailing spaces should match");
+        }
+    }
+
+    @Nested
+    @DisplayName("Non-matching DDL")
+    class NonMatchingTests {
+
+        @Test
+        @DisplayName("ALTER TABLE ADD COLUMN should NOT match")
+        public void testAddColumnNotMatched() {
+            assertFalse(matchesAnyPattern("ALTER TABLE mydb.mytable ADD COLUMN col1 INT"),
+                    "ADD COLUMN should NOT be ignored");
+        }
+
+        @Test
+        @DisplayName("CREATE TABLE should NOT match")
+        public void testCreateTableNotMatched() {
+            assertFalse(matchesAnyPattern("CREATE TABLE mydb.newtable (id INT PRIMARY KEY)"),
+                    "CREATE TABLE should NOT be ignored");
+        }
+
+        // DESTRUCTIVE: inert fixture string, regex-matched only. This case
+        // asserts the OPPOSITE of destruction -- that a DROP TABLE is never
+        // silently ignored. Nothing is executed against any database.
+        @Test
+        @DisplayName("DROP TABLE should NOT match")
+        public void testDropTableNotMatched() {
+            // DESTRUCTIVE: inert fixture string, regex-matched only -- this case
+            // asserts the OPPOSITE of destruction, that a DROP is never ignored.
+            assertFalse(matchesAnyPattern("DROP TABLE mydb.mytable"),
+                    // DESTRUCTIVE: fixture text only; nothing is executed.
+                    "DROP TABLE should NOT be ignored");
+        }
+
+        @Test
+        @DisplayName("ALTER TABLE RENAME should NOT match")
+        public void testRenameNotMatched() {
+            assertFalse(matchesAnyPattern("ALTER TABLE mydb.mytable RENAME TO mydb.newtable"),
+                    "RENAME should NOT be ignored");
+        }
+    }
+
+    @Nested
+    @DisplayName("REORGANIZE PARTITION matching")
+    class ReorganizePartitionTests {
+
+        @Test
+        @DisplayName("REORGANIZE PARTITION should match")
+        public void testReorganizePartition() {
+            assertTrue(matchesAnyPattern(
+                    "ALTER TABLE mydb.mytable REORGANIZE PARTITION p20240101 INTO (PARTITION p20240101a, PARTITION p20240101b)"),
+                    "REORGANIZE PARTITION should match");
+        }
+    }
+
+    // DESTRUCTIVE: inert test fixtures, regex-matched only -- these DDL
+    // strings are never parsed or executed against any database, so this
+    // class cannot destroy data.
+    @Nested
+    @DisplayName("TRUNCATE PARTITION matching")
+    class TruncatePartitionTests {
+
+        @Test
+        // DESTRUCTIVE: inert fixture string, regex-matched only -- never parsed
+        // or executed against any database, so nothing can be destroyed here.
+        @DisplayName("TRUNCATE PARTITION should match")
+        public void testTruncatePartition() {
+            assertTrue(matchesAnyPattern("ALTER TABLE mydb.mytable TRUNCATE PARTITION p20240101"),
+                    // DESTRUCTIVE: fixture text only; asserts regex behaviour.
+                    "TRUNCATE PARTITION should match");
+        }
+    }
+}

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/SequenceNumberRaceTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/SequenceNumberRaceTest.java
@@ -1,0 +1,348 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Concurrency contract for {@code _version} assignment.
+ *
+ * <p>{@code _version} is the value ReplacingMergeTree uses to decide which
+ * physical row survives a merge. If two <em>different</em> records are handed
+ * the <em>same</em> version, RMT keeps one and silently discards the other —
+ * data loss with no error, no log line, and no way to detect it afterwards
+ * except by counting rows against the source.</p>
+ *
+ * <p>{@code nextSequenceNumber(long)} is a check-and-act over two pieces of
+ * shared state: the timestamp anchor is read to decide whether the counter
+ * resets, and only then is the counter reset or incremented. An atomic counter
+ * alone cannot make that pair consistent — two threads crossing the same
+ * one-second boundary would both take the reset branch and both emit
+ * {@code SEQUENCE_START}. Both windows must sit inside one critical section.
+ * That is what these tests pin.</p>
+ *
+ * <h2>The uniqueness property this suite asserts, and why it is that one</h2>
+ *
+ * <p>Uniqueness holds <b>for a monotonically non-decreasing source clock</b>,
+ * which is exactly what a MySQL binlog delivers: commit timestamps advance,
+ * they do not rewind. It is <em>not</em> an unconditional property of the
+ * formula, and the tests deliberately do not claim it is:</p>
+ *
+ * <pre>    _version = debezium_ts_ms * 1_000_000 + counter</pre>
+ *
+ * <p>{@code SEQUENCE_START} is 1e9 while the timestamp scale is 1e6, so the
+ * counter's magnitude spans 1000 ms of timestamp band and adjacent bands
+ * <b>overlap by design</b>. Feeding the same timestamps again from a second
+ * independent stream re-enters the reset branch and reproduces values that
+ * were already emitted. Verified single-threaded, with no concurrency
+ * involved: replaying a timestamp stream reproduces prior values, while an
+ * ascending stream never does. So a test asserting global uniqueness over
+ * replayed per-thread streams would be asserting a property the pinned 2.8.0
+ * format never had — it would fail against correct code and invite someone to
+ * "fix" the formula, which is an irreversible data-format change (see
+ * {@code Version280CompatibilityTest}).</p>
+ *
+ * <p>Each test therefore drives a <b>shared</b> clock across all threads,
+ * mirroring one binlog feeding several batch threads, and asserts uniqueness
+ * of what is emitted. Under that model any duplicate is a genuine lost update
+ * in the read-modify-write, which is precisely the race being guarded.</p>
+ */
+public class SequenceNumberRaceTest {
+
+    private static final int THREADS = 8;
+    private static final int CALLS_PER_THREAD = 500;
+    private static final long TIMEOUT_SECONDS = 60;
+
+    /** A fixed base source-commit clock, for determinism. */
+    private static final long BASE_TS = 1_700_000_000_000L;
+
+    /**
+     * Drives {@code nextSequenceNumber} concurrently and returns every emitted
+     * value. The supplier receives (threadIndex, callIndex).
+     */
+    private static List<Long> runConcurrently(DebeziumChangeEventCapture capture,
+                                              BiFunction<Integer, Integer, Long> tsForCall)
+            throws Exception {
+        ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(THREADS);
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        List<List<Long>> perThread = new ArrayList<>();
+        for (int t = 0; t < THREADS; t++) {
+            perThread.add(new ArrayList<>(CALLS_PER_THREAD));
+        }
+
+        try {
+            for (int t = 0; t < THREADS; t++) {
+                final int threadIndex = t;
+                final List<Long> sink = perThread.get(t);
+                pool.submit(() -> {
+                    try {
+                        // Simultaneous release: staggered starts hide the race.
+                        startGate.await();
+                        for (int c = 0; c < CALLS_PER_THREAD; c++) {
+                            sink.add(capture.nextSequenceNumber(
+                                    tsForCall.apply(threadIndex, c)));
+                        }
+                    } catch (Throwable e) {
+                        thrown.compareAndSet(null, e);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            startGate.countDown();
+            assertTrue(done.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "Version-assignment threads did not finish — nextSequenceNumber "
+                            + "deadlocked.");
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertNull(thrown.get(), "A version-assignment thread threw: " + thrown.get());
+
+        List<Long> all = new ArrayList<>(THREADS * CALLS_PER_THREAD);
+        for (List<Long> chunk : perThread) {
+            all.addAll(chunk);
+        }
+        return all;
+    }
+
+    private static void assertAllUnique(List<Long> versions, String scenario) {
+        Set<Long> seen = new HashSet<>();
+        List<Long> duplicates = new ArrayList<>();
+        for (Long v : versions) {
+            if (!seen.add(v)) {
+                duplicates.add(v);
+            }
+        }
+        assertTrue(duplicates.isEmpty(),
+                scenario + ": " + duplicates.size() + " duplicate _version value(s) "
+                        + "emitted (first few: "
+                        + duplicates.subList(0, Math.min(5, duplicates.size())) + "). "
+                        + "The source clock in this scenario never rewinds, so every call "
+                        + "must yield a fresh value; a duplicate is a lost update in the "
+                        + "counter's read-modify-write. Two records sharing a _version means "
+                        + "ReplacingMergeTree silently discards one on merge. Fix the "
+                        + "critical section — do NOT change the formula, which is pinned to "
+                        + "2.8.0 by Version280CompatibilityTest.");
+        assertEquals(versions.size(), seen.size(),
+                scenario + ": emitted count and distinct count disagree.");
+    }
+
+    @Test
+    @DisplayName("Concurrent assignment at one timestamp emits no duplicate _version")
+    public void noDuplicatesWithinOneTimestamp() throws Exception {
+        // Every thread on the SAME timestamp: all calls take the increment
+        // branch, isolating the incrementAndGet()-then-re-read window. This is
+        // the purest lost-update detector — the clock cannot be blamed.
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+
+        assertAllUnique(runConcurrently(capture, (t, c) -> BASE_TS),
+                "constant timestamp");
+    }
+
+    @Test
+    @DisplayName("Concurrent assignment on a shared advancing clock emits no duplicate _version")
+    public void noDuplicatesOnSharedAdvancingClock() throws Exception {
+        // One monotonically advancing clock shared by every thread: the real
+        // shape of several batch threads consuming one binlog. Threads
+        // interleave arbitrarily but the source time never rewinds.
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        AtomicLong clock = new AtomicLong(BASE_TS);
+
+        assertAllUnique(runConcurrently(capture, (t, c) -> clock.getAndAdd(1L)),
+                "shared advancing clock");
+    }
+
+    @Test
+    @DisplayName("Concurrent assignment across reset boundaries emits no duplicate _version")
+    public void noDuplicatesAcrossResetBoundary() throws Exception {
+        // The counter resets when the clock advances more than one second past
+        // the anchor. A shared clock jumping 5s per call makes every thread
+        // race into the reset branch — the interleaving in which two batches
+        // both emitted SEQUENCE_START.
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        AtomicLong clock = new AtomicLong(BASE_TS);
+
+        assertAllUnique(runConcurrently(capture, (t, c) -> clock.getAndAdd(5_000L)),
+                "reset boundary");
+    }
+
+    @Test
+    @DisplayName("An out-of-order batch cannot drag the anchor backward")
+    public void anchorNeverMovesBackward() {
+        // Deterministic, single-threaded, and the important one: this is a
+        // real defect found by the concurrent version of this test, reduced to
+        // a form that cannot flake.
+        //
+        // The anchor is shared by all batch threads but each batch seeds it
+        // from its OWN first record. A batch carrying an older timestamp can
+        // therefore drag the anchor backward past a point another thread has
+        // already passed. That re-arms the `diff > 1` reset branch for
+        // timestamps already in use, so the counter is reset to the constant
+        // SEQUENCE_START a second time and two different records at the same
+        // source timestamp receive an IDENTICAL _version — ReplacingMergeTree
+        // then silently discards one of them.
+        //
+        // No concurrency is needed to demonstrate it: seeding backward between
+        // two assignments at the same later timestamp is sufficient. Measured
+        // on the unguarded code, this loop produced 199 duplicate versions out
+        // of 200 records.
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        final long staleTs = BASE_TS;
+        final long currentTs = BASE_TS + 10_000L;
+
+        List<Long> emitted = new ArrayList<>();
+        for (int i = 0; i < 200; i++) {
+            // A stale batch re-seeds the anchor backward while records keep
+            // arriving at a later timestamp.
+            capture.seedSequenceAnchor(staleTs);
+            emitted.add(capture.nextSequenceNumber(currentTs));
+        }
+
+        assertAllUnique(emitted, "backward anchor seeding");
+
+        // Ordering must hold too: the duplicate form of this bug also emitted a
+        // LOWER value after a higher one, which lets a superseded row win.
+        long previous = Long.MIN_VALUE;
+        for (Long v : emitted) {
+            assertTrue(v > previous,
+                    "Version " + v + " did not exceed the previous value " + previous
+                            + ". A backward anchor seed reset the counter, so a later record "
+                            + "received a smaller _version than an earlier one and would lose "
+                            + "the ReplacingMergeTree merge to a row it should supersede.");
+            previous = v;
+        }
+    }
+
+    @Test
+    @DisplayName("Concurrent anchor seeding on an advancing clock emits no duplicate _version")
+    public void anchorSeedingIsSerialisedWithAssignment() throws Exception {
+        // The concurrent companion to the test above: seedSequenceAnchor() runs
+        // once per batch while other batches assign versions. The clock is
+        // shared and strictly advancing, so no batch seeds backward and every
+        // emitted value must be distinct under any interleaving.
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        AtomicLong clock = new AtomicLong(BASE_TS);
+
+        ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(THREADS);
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        List<List<Long>> perThread = new ArrayList<>();
+        for (int t = 0; t < THREADS; t++) {
+            perThread.add(new ArrayList<>());
+        }
+
+        try {
+            for (int t = 0; t < THREADS; t++) {
+                final List<Long> sink = perThread.get(t);
+                pool.submit(() -> {
+                    try {
+                        startGate.await();
+                        for (int b = 0; b < 100; b++) {
+                            // Real call order in the batch consumer: seed the
+                            // shared anchor for the batch, then assign per record.
+                            long batchTs = clock.getAndAdd(600L);
+                            capture.seedSequenceAnchor(batchTs);
+                            for (int i = 0; i < 5; i++) {
+                                sink.add(capture.nextSequenceNumber(batchTs));
+                            }
+                        }
+                    } catch (Throwable e) {
+                        thrown.compareAndSet(null, e);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            startGate.countDown();
+            assertTrue(done.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "Anchor-seeding threads did not finish.");
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertNull(thrown.get(), "An anchor-seeding thread threw: " + thrown.get());
+
+        List<Long> all = new ArrayList<>();
+        for (List<Long> chunk : perThread) {
+            all.addAll(chunk);
+        }
+        assertAllUnique(all, "concurrent anchor seeding");
+    }
+
+    @Test
+    @DisplayName("Versions increase monotonically for a non-decreasing source clock")
+    public void versionsAreMonotonicForAdvancingClock() {
+        // Single-threaded ordering contract. RMT keeps the LARGEST version, so
+        // a later source commit must never produce a smaller value than an
+        // earlier one — an inversion resurrects a superseded row, which is
+        // corruption rather than loss.
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+
+        long previous = Long.MIN_VALUE;
+        for (int i = 0; i < 5_000; i++) {
+            // Mixes the increment branch (small steps) and the reset branch
+            // (a 5s jump every 100 calls) on one ascending clock.
+            long ts = BASE_TS + i + (i / 100) * 5_000L;
+            long version = capture.nextSequenceNumber(ts);
+
+            assertTrue(version > previous,
+                    "Version " + version + " did not exceed the previous value "
+                            + previous + " at call " + i + " (ts=" + ts + "). The source clock "
+                            + "only advances here, so versions must strictly increase; an "
+                            + "inversion lets an older row outrank a newer one in the merge.");
+            previous = version;
+        }
+    }
+
+    @Test
+    @DisplayName("A replayed timestamp stream reproduces prior versions — the #1346 shape")
+    public void replayedStreamReproducesVersions() {
+        // Documents the known limitation rather than asserting it away, so the
+        // behaviour is visible and any future change to it is deliberate.
+        //
+        // Redelivery after an offset rewind replays source timestamps. Because
+        // the reset branch re-seeds the counter to a constant, the same stream
+        // yields the same values again. That is issue #1346: a replayed DELETE
+        // can tie or outrank the INSERT that followed it. It is a property of
+        // the pinned 2.8.0 FORMAT, reproducible with no concurrency at all —
+        // NOT a race, and not fixable by locking. Fixing it means changing the
+        // version scheme, which is an irreversible data-format change and needs
+        // a migration plan, so it is deliberately out of scope here.
+        DebeziumChangeEventCapture first = new DebeziumChangeEventCapture();
+        DebeziumChangeEventCapture replay = new DebeziumChangeEventCapture();
+
+        List<Long> original = new ArrayList<>();
+        List<Long> replayed = new ArrayList<>();
+        for (int c = 0; c < 50; c++) {
+            long ts = BASE_TS + (long) c * 5_000L;
+            original.add(first.nextSequenceNumber(ts));
+            replayed.add(replay.nextSequenceNumber(ts));
+        }
+
+        assertEquals(original, replayed,
+                "Replaying an identical source-timestamp stream must reproduce an "
+                        + "identical version sequence. This determinism is what makes the "
+                        + "format stable across a restart; if it ever diverges, a redelivered "
+                        + "record would compete against its own earlier copy with a different "
+                        + "version and the outcome of the merge would depend on timing.");
+    }
+}

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/SingleThreadedDdlPauseTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/SingleThreadedDdlPauseTest.java
@@ -1,0 +1,76 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import com.altinity.clickhouse.sink.connector.executor.ClickHouseBatchExecutor;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Regression test for the single.threaded DDL pause NPE.
+ *
+ * <p>In single.threaded mode {@code setupProcessingThread()} creates a
+ * {@code singleThreadedWriter} and returns without ever constructing the
+ * batch executor, so {@code this.executor} stays null. The DDL branch of
+ * {@code processEveryChangeRecord} pauses/resumes the executor around
+ * {@code performDDLOperation}; calling {@code this.executor.pause()}
+ * unconditionally there NPEs on the FIRST DDL of every single-threaded
+ * run. Upstream silently swallowed that NPE in a log-only catch (skipping
+ * the DDL); once the catch was made to fail loudly, the swallowed NPE
+ * became a fatal engine stop that cascaded across the CI suite
+ * (MariaDBIT, MySQLDemoIT, ReplicationLogOnlyIT and every later IT in
+ * the same JVM).</p>
+ *
+ * <p>These tests pin the fix: pause/resume must be null-safe no-ops when
+ * no batch executor exists, and must still delegate when one does.</p>
+ */
+@DisplayName("DDL pause/resume must be null-safe in single.threaded mode")
+public class SingleThreadedDdlPauseTest {
+
+    private static void setExecutor(DebeziumChangeEventCapture capture,
+                                    ClickHouseBatchExecutor executor) throws Exception {
+        Field f = DebeziumChangeEventCapture.class.getDeclaredField("executor");
+        f.setAccessible(true);
+        f.set(capture, executor);
+    }
+
+    @Test
+    @DisplayName("pause/resume are no-ops when the executor is null (single.threaded mode)")
+    public void testPauseResumeWithNullExecutor() {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        // single.threaded mode: setupProcessingThread never assigns executor.
+        assertDoesNotThrow(capture::pauseBatchExecutor,
+                "pause must not NPE when no batch executor exists");
+        assertDoesNotThrow(capture::resumeBatchExecutor,
+                "resume must not NPE when no batch executor exists");
+    }
+
+    @Test
+    @DisplayName("pause/resume delegate to the executor when one exists (multi-threaded mode)")
+    public void testPauseResumeWithExecutor() throws Exception {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        ClickHouseBatchExecutor executor = new ClickHouseBatchExecutor(1,
+                new ThreadFactoryBuilder().setNameFormat("test-pool-%d").build());
+        try {
+            setExecutor(capture, executor);
+
+            capture.pauseBatchExecutor();
+            // While paused, submitted tasks must not run: beforeExecute spins
+            // on the paused flag. Verify indirectly by resuming and confirming
+            // a task then executes.
+            capture.resumeBatchExecutor();
+
+            java.util.concurrent.CountDownLatch ran =
+                    new java.util.concurrent.CountDownLatch(1);
+            executor.execute(ran::countDown);
+            org.junit.jupiter.api.Assertions.assertTrue(
+                    ran.await(10, java.util.concurrent.TimeUnit.SECONDS),
+                    "task must run after resume");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/Version280CompatibilityTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/Version280CompatibilityTest.java
@@ -1,0 +1,244 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import com.altinity.clickhouse.sink.connector.model.ClickHouseStruct;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the {@code _version} value scheme to the 2.8.0 formula.
+ *
+ * <p>{@code _version} decides which physical row survives a
+ * ReplacingMergeTree merge, which makes the formula that produces it a
+ * <b>data format</b>, not an implementation detail. A table that already
+ * holds rows written by 2.8.0 and then receives rows from a connector using a
+ * different formula ends up with two incomparable magnitudes in one column:
+ * whichever scheme yields the larger number wins every merge regardless of
+ * which change actually happened later, and the rows already written cannot
+ * be undone by downgrading. That is why this is pinned by a test rather than
+ * left to review.</p>
+ *
+ * <p>The 2.8.0 formula, from
+ * {@code DebeziumChangeEventCapture.addVersion()} at tag {@code 2.8.0}:</p>
+ * <pre>
+ *     sequenceStartTime = first record's debezium_ts_ms
+ *     diff = (record.debezium_ts_ms - sequenceStartTime) / 1000
+ *     if (diff &gt; 1) { counter = SEQUENCE_START; sequenceStartTime = record.debezium_ts_ms }
+ *     else           { counter++ }
+ *     _version = record.debezium_ts_ms * 1_000_000 + counter
+ * </pre>
+ *
+ * <p>Note the anchor is the <b>Debezium</b> timestamp, not the source commit
+ * timestamp. Anchoring to {@code source.ts_ms} instead would be a strictly
+ * better ordering property - it is stable across redelivery, which is the
+ * root of issue #1346 - but it changes the emitted values, so it cannot be
+ * done silently on a branch that must stay readable alongside 2.8.0 data.</p>
+ */
+public class Version280CompatibilityTest {
+
+    /** Mirrors {@code DebeziumChangeEventCapture.SEQUENCE_START}. */
+    private static final long SEQUENCE_START = 1000000000L;
+
+    private static final long SEQUENCE_SCALE = 1000000L;
+
+    /** 2024-01-01T00:00:00Z. */
+    private static final long TS = 1704067200000L;
+
+    private static ClickHouseStruct recordAt(long debeziumTsMs) {
+        ClickHouseStruct record = new ClickHouseStruct();
+        record.setDebezium_ts_ms(debeziumTsMs);
+        record.setTs_ms(debeziumTsMs);
+        return record;
+    }
+
+    /**
+     * The 2.8.0 algorithm, reimplemented here from the tagged source so the
+     * expected values are derived independently of the code under test.
+     */
+    private static List<Long> expected280(List<Long> timestamps) {
+        List<Long> out = new ArrayList<>();
+        long counter = SEQUENCE_START;
+        long anchor = timestamps.get(0);
+        for (long ts : timestamps) {
+            int diff = (int) ((ts - anchor) / 1000);
+            if (diff > 1) {
+                counter = SEQUENCE_START;
+                anchor = ts;
+            } else {
+                counter++;
+            }
+            out.add(ts * SEQUENCE_SCALE + counter);
+        }
+        return out;
+    }
+
+    @Test
+    @DisplayName("the emitted _version matches the 2.8.0 formula exactly")
+    public void matchesTwoEightZeroFormulaExactly() {
+        List<Long> timestamps = Arrays.asList(TS, TS, TS + 500, TS + 900);
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        capture.seedSequenceAnchor(timestamps.get(0));
+
+        List<Long> actual = new ArrayList<>();
+        for (long ts : timestamps) {
+            actual.add(capture.nextSequenceNumber(ts));
+        }
+
+        assertEquals(expected280(timestamps), actual,
+                "the _version formula must remain bit-for-bit identical to 2.8.0; a "
+                        + "different magnitude cannot coexist with 2.8.0-written rows in "
+                        + "the same ReplacingMergeTree column");
+    }
+
+    @Test
+    @DisplayName("the counter resets on a gap exactly as 2.8.0 did")
+    public void resetsOnGapLikeTwoEightZero() {
+        // A gap of more than one second must reset the counter to
+        // SEQUENCE_START - not to some other floor, and not merely continue.
+        List<Long> timestamps = Arrays.asList(TS, TS + 5000, TS + 5100);
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        capture.seedSequenceAnchor(timestamps.get(0));
+
+        List<Long> actual = new ArrayList<>();
+        for (long ts : timestamps) {
+            actual.add(capture.nextSequenceNumber(ts));
+        }
+
+        assertEquals(expected280(timestamps), actual,
+                "the gap-reset behaviour is part of the emitted value and must match 2.8.0");
+        assertEquals((TS + 5000) * SEQUENCE_SCALE + SEQUENCE_START, actual.get(1),
+                "the post-gap record must carry exactly SEQUENCE_START, as in 2.8.0");
+    }
+
+    @Test
+    @DisplayName("a one-second step does NOT reset - the 2.8.0 boundary is diff > 1")
+    public void oneSecondStepDoesNotReset() {
+        // 2.8.0 resets on diff > 1, not diff >= 1. Tightening the boundary
+        // would change the emitted values for every batch spanning one second.
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        capture.seedSequenceAnchor(TS);
+        long first = capture.nextSequenceNumber(TS);
+        long afterOneSecond = capture.nextSequenceNumber(TS + 1000);
+
+        assertEquals(TS * SEQUENCE_SCALE + SEQUENCE_START + 1, first);
+        assertEquals((TS + 1000) * SEQUENCE_SCALE + SEQUENCE_START + 2, afterOneSecond,
+                "a one-second step must increment, not reset - 2.8.0's boundary is diff > 1");
+    }
+
+    @Test
+    @DisplayName("addVersion() emits the same values as the live batch path")
+    public void addVersionAgreesWithLivePath() {
+        // The two paths must never drift into different schemes. addVersion()
+        // is the historical entry point; nextSequenceNumber() is what the live
+        // batch consumer calls.
+        List<Long> timestamps = Arrays.asList(TS, TS, TS + 400);
+
+        DebeziumChangeEventCapture viaHelper = new DebeziumChangeEventCapture();
+        viaHelper.seedSequenceAnchor(timestamps.get(0));
+        List<Long> helperValues = new ArrayList<>();
+        for (long ts : timestamps) {
+            helperValues.add(viaHelper.nextSequenceNumber(ts));
+        }
+
+        DebeziumChangeEventCapture viaAddVersion = new DebeziumChangeEventCapture();
+        viaAddVersion.seedSequenceAnchor(timestamps.get(0));
+        List<ClickHouseStruct> records = new ArrayList<>();
+        for (long ts : timestamps) {
+            records.add(recordAt(ts));
+        }
+        viaAddVersion.addVersion(records);
+
+        List<Long> addVersionValues = new ArrayList<>();
+        for (ClickHouseStruct r : records) {
+            addVersionValues.add(r.getSequenceNumber());
+        }
+
+        assertEquals(helperValues, addVersionValues,
+                "addVersion() and the live batch path must emit identical values, or the "
+                        + "same table receives two different _version schemes");
+    }
+
+    @Test
+    @DisplayName("addVersion() anchors on debezium_ts_ms, not source ts_ms")
+    public void addVersionAnchorsOnDebeziumTimestamp() {
+        // If this ever anchors on the source commit timestamp, every emitted
+        // value shifts and 2.8.0 compatibility is silently broken.
+        ClickHouseStruct record = new ClickHouseStruct();
+        record.setDebezium_ts_ms(TS);
+        record.setTs_ms(TS + 3_600_000L); // deliberately far from the Debezium clock
+
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        capture.seedSequenceAnchor(TS);
+        capture.addVersion(Collections.singletonList(record));
+
+        assertEquals(TS * SEQUENCE_SCALE + SEQUENCE_START + 1, record.getSequenceNumber(),
+                "the version must be derived from debezium_ts_ms, exactly as 2.8.0 did");
+    }
+
+    /**
+     * The formula is preserved; the concurrency defect is not. Two threads
+     * racing the shared counter must never be handed the same value, or the
+     * ReplacingMergeTree collapses two distinct records into one row.
+     */
+    @Test
+    @DisplayName("concurrent assignment never yields a duplicate _version")
+    public void concurrentAssignmentIsCollisionFree() throws Exception {
+        final int threads = 8;
+        final int perThread = 400;
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+        capture.seedSequenceAnchor(TS);
+
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        List<List<Long>> results = Collections.synchronizedList(new ArrayList<>());
+        try {
+            for (int t = 0; t < threads; t++) {
+                pool.submit(() -> {
+                    List<Long> mine = new ArrayList<>();
+                    try {
+                        start.await();
+                        for (int i = 0; i < perThread; i++) {
+                            // All threads sit on the same millisecond, which is
+                            // precisely where the unsynchronised counter collided.
+                            mine.add(capture.nextSequenceNumber(TS));
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    results.add(mine);
+                    return null;
+                });
+            }
+            start.countDown();
+            pool.shutdown();
+            assertTrue(pool.awaitTermination(60, TimeUnit.SECONDS),
+                    "workers did not finish in time");
+        } finally {
+            pool.shutdownNow();
+        }
+
+        Set<Long> unique = new HashSet<>();
+        int total = 0;
+        for (List<Long> chunk : results) {
+            total += chunk.size();
+            unique.addAll(chunk);
+        }
+        assertEquals(threads * perThread, total, "every worker must have completed");
+        assertEquals(total, unique.size(),
+                "every assigned _version must be unique; a duplicate lets the "
+                        + "ReplacingMergeTree silently discard one of two distinct records");
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DDLFreezeRaceConditionTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DDLFreezeRaceConditionTest.java
@@ -1,0 +1,213 @@
+package com.altinity.clickhouse.sink.connector.db;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end concurrency test that reproduces the GitHub issue #1222 /
+ * {@code price_usd} data-loss race and proves the per-table replication freeze
+ * fixes it.
+ *
+ * <p><b>The model.</b> A "destination schema" set of columns is shared between:
+ * <ul>
+ *   <li>a DDL thread that runs {@code ADD COLUMN price_usd}: it sleeps to model
+ *       the ALTER + {@code system.columns} propagation delay, then adds the
+ *       column to the destination schema and invalidates the cache; and</li>
+ *   <li>N insert threads that, for each row, read the destination schema (the
+ *       "cache") and record whether {@code price_usd} would be written.</li>
+ * </ul>
+ *
+ * <p>Every row's source event <i>contains</i> {@code price_usd} from the start
+ * (the column was added on the source first). The destination is missing it
+ * until the DDL thread finishes propagating. An insert that reads the
+ * destination schema before propagation would omit the column = data loss.</p>
+ *
+ * <p><b>Without the freeze</b> the inserts that race ahead of propagation drop
+ * the column. <b>With the freeze</b> every insert blocks until the DDL thread
+ * unfreezes (after propagation + invalidation), so none drop it. The test
+ * asserts both halves so the freeze is shown to be both necessary and
+ * sufficient.</p>
+ */
+class DDLFreezeRaceConditionTest {
+
+    private static final String TABLE = "trading_db.partner_liquidation_trade";
+    private static final String NEW_COL = "price_usd";
+
+    private TableReplicationFreezeManager freeze;
+
+    /** Models the destination ClickHouse schema (what the cache would rebuild from). */
+    private final Set<String> destinationSchema = ConcurrentHashMap.newKeySet();
+
+    @BeforeEach
+    void setUp() {
+        freeze = TableReplicationFreezeManager.getInstance();
+        freeze.clearAll();
+        destinationSchema.clear();
+        // Initial destination schema: everything EXCEPT the not-yet-propagated column.
+        destinationSchema.add("id");
+        destinationSchema.add("price");
+        destinationSchema.add("quantity");
+    }
+
+    @AfterEach
+    void tearDown() {
+        freeze.clearAll();
+    }
+
+    /**
+     * Simulates one insert: reads the current destination schema and reports
+     * whether the new column would be persisted for this row.
+     */
+    private boolean wouldPersistNewColumn() {
+        // The insert path iterates the destination column set; if the column
+        // isn't there, the source value is silently dropped.
+        return destinationSchema.contains(NEW_COL);
+    }
+
+    @Test
+    @DisplayName("REGRESSION GUARD: without the freeze, concurrent inserts drop the new column")
+    void withoutFreezeDataIsLost() throws Exception {
+        int insertThreads = 12;
+        int rowsPerThread = 200;
+        ExecutorService pool = Executors.newFixedThreadPool(insertThreads + 1);
+        CountDownLatch ready = new CountDownLatch(insertThreads + 1);
+        AtomicInteger droppedRows = new AtomicInteger(0);
+        AtomicBoolean go = new AtomicBoolean(false);
+
+        // DDL thread: no freeze. Delay models ALTER + system.columns propagation.
+        pool.submit(() -> {
+            ready.countDown();
+            while (!go.get()) { Thread.onSpinWait(); }
+            try {
+                Thread.sleep(50); // propagation window during which inserts race
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+            destinationSchema.add(NEW_COL);
+        });
+
+        for (int t = 0; t < insertThreads; t++) {
+            pool.submit(() -> {
+                ready.countDown();
+                while (!go.get()) { Thread.onSpinWait(); }
+                for (int r = 0; r < rowsPerThread; r++) {
+                    if (!wouldPersistNewColumn()) {
+                        droppedRows.incrementAndGet();
+                    }
+                    try {
+                        Thread.sleep(0, 200_000); // ~0.2ms per row, spreads across the window
+                    } catch (InterruptedException ignored) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            });
+        }
+
+        assertTrue(ready.await(3, TimeUnit.SECONDS));
+        go.set(true);
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(15, TimeUnit.SECONDS));
+
+        assertTrue(droppedRows.get() > 0,
+                "Without the freeze, some inserts must have raced ahead of propagation "
+                        + "and dropped the new column (reproduces issue #1222). dropped="
+                        + droppedRows.get());
+    }
+
+    @Test
+    @DisplayName("FIX: with the per-table freeze, zero inserts drop the new column")
+    void withFreezeNoDataIsLost() throws Exception {
+        int insertThreads = 12;
+        int rowsPerThread = 200;
+        ExecutorService pool = Executors.newFixedThreadPool(insertThreads + 1);
+        CountDownLatch ready = new CountDownLatch(insertThreads + 1);
+        AtomicInteger droppedRows = new AtomicInteger(0);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean go = new AtomicBoolean(false);
+        // Debezium delivers the ALTER event before the subsequent INSERT events
+        // for the same table, so the DDL freeze is always established before the
+        // connector processes the post-ALTER inserts. This latch models that
+        // ordering: insert threads do not begin until the freeze is in place.
+        CountDownLatch frozen = new CountDownLatch(1);
+
+        // DDL thread: freeze BEFORE the ALTER, propagate, invalidate, then unfreeze.
+        pool.submit(() -> {
+            ready.countDown();
+            while (!go.get()) { Thread.onSpinWait(); }
+            freeze.freeze(TABLE);
+            frozen.countDown();
+            try {
+                Thread.sleep(50); // ALTER + propagation, while inserts are frozen
+                destinationSchema.add(NEW_COL);
+                CacheInvalidationManager.getInstance().invalidateTable(TABLE);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            } finally {
+                freeze.unfreeze(TABLE);
+            }
+        });
+
+        for (int t = 0; t < insertThreads; t++) {
+            pool.submit(() -> {
+                ready.countDown();
+                while (!go.get()) { Thread.onSpinWait(); }
+                try {
+                    // Post-ALTER inserts are processed only after the freeze is set.
+                    frozen.await();
+                    for (int r = 0; r < rowsPerThread; r++) {
+                        // Each batch waits for the table to be unfrozen first.
+                        boolean unfrozen = freeze.awaitUnfrozen(TABLE, 5000);
+                        if (!unfrozen) {
+                            failure.compareAndSet(null,
+                                    new AssertionError("await timed out while frozen"));
+                            return;
+                        }
+                        if (!wouldPersistNewColumn()) {
+                            droppedRows.incrementAndGet();
+                        }
+                        Thread.sleep(0, 200_000);
+                    }
+                } catch (InterruptedException ignored) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+
+        assertTrue(ready.await(3, TimeUnit.SECONDS));
+        go.set(true);
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(20, TimeUnit.SECONDS));
+
+        assertEquals(null, failure.get(), "No insert thread should fail");
+        assertEquals(0, droppedRows.get(),
+                "With the freeze, NO insert may drop the new column. dropped=" + droppedRows.get());
+        // Sanity: the column did get added.
+        assertTrue(destinationSchema.contains(NEW_COL));
+    }
+
+    @Test
+    @DisplayName("Repeated freeze/unfreeze cycles never leak a frozen state")
+    void repeatedCyclesAreClean() {
+        for (int i = 0; i < 100; i++) {
+            freeze.freeze(TABLE);
+            assertTrue(freeze.isFrozen(TABLE));
+            freeze.unfreeze(TABLE);
+            assertTrue(freeze.awaitUnfrozen(TABLE, 100));
+        }
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DDLSchemaChangeWaiterRaceConditionTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DDLSchemaChangeWaiterRaceConditionTest.java
@@ -1,0 +1,885 @@
+package com.altinity.clickhouse.sink.connector.db;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Comprehensive tests for {@link DDLSchemaChangeWaiter} focused on
+ * proving the race condition fix for GitHub issue #1222.
+ *
+ * <p>The bug: ALTER TABLE ADD COLUMN followed by immediate
+ * CacheInvalidationManager signaling causes the batch insert thread
+ * to read stale column metadata from system.columns, silently
+ * dropping values for ~37% of newly added columns.</p>
+ *
+ * <p>These tests prove:
+ * <ol>
+ *   <li>The race condition exists without the waiter (regression guard)</li>
+ *   <li>The waiter correctly blocks until columns are visible</li>
+ *   <li>The fix works under concurrent stress</li>
+ *   <li>Edge cases (timeout, null inputs, non-ALTER DDL) are handled</li>
+ * </ol>
+ * </p>
+ *
+ * <p>Note: Uses manual JDBC stubs instead of Mockito because the
+ * sink-connector module does not include Mockito as a dependency.</p>
+ */
+class DDLSchemaChangeWaiterRaceConditionTest {
+
+    // ---------------------------------------------------------------
+    // Stub helpers — lightweight JDBC fakes without Mockito
+    // ---------------------------------------------------------------
+
+    /**
+     * Creates a stub Connection whose createStatement() returns a
+     * Statement that delegates executeQuery() to the given callback.
+     */
+    private static Connection stubConnection(QueryCallback callback) {
+        return new StubConnection(callback);
+    }
+
+    @FunctionalInterface
+    interface QueryCallback {
+        ResultSet execute(String sql) throws SQLException;
+    }
+
+    /**
+     * Creates a ResultSet that returns the given column names, one per
+     * next() call.
+     */
+    private static ResultSet stubResultSet(String... columnNames) {
+        return new StubResultSet(columnNames);
+    }
+
+    // ---------------------------------------------------------------
+    // Column extraction regression tests
+    // ---------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Column extraction regression tests")
+    class ColumnExtractionTests {
+
+        @Test
+        @DisplayName("Single ADD COLUMN with backticks")
+        void singleAddColumnBackticks() {
+            String ddl = "ALTER TABLE `mydb`.`mytable` ADD COLUMN `new_col` String";
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                    Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+            assertEquals(List.of("new_col"), cols);
+        }
+
+        @Test
+        @DisplayName("Multiple ADD COLUMN - the exact pattern from issue #1222")
+        void multipleAddColumnsIssue1222() {
+            String ddl = "ALTER TABLE `trading_db`.`orders` " +
+                    "ADD COLUMN `execution_venue` String, " +
+                    "ADD COLUMN `clearing_broker` String, " +
+                    "ADD COLUMN `settlement_date` Date";
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                    Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+            assertEquals(3, cols.size());
+            assertTrue(cols.contains("execution_venue"));
+            assertTrue(cols.contains("clearing_broker"));
+            assertTrue(cols.contains("settlement_date"));
+        }
+
+        @Test
+        // DESTRUCTIVE: title and DDL string are inert test fixtures. This test
+        // only feeds text to a regex extractor — no database connection exists
+        // and no statement is executed.
+        @DisplayName("DROP COLUMN extraction")
+        void dropColumnExtraction() {
+            String ddl = "ALTER TABLE `db`.`tbl` DROP COLUMN `obsolete_col`, DROP COLUMN `temp_col`";
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                    Pattern.compile("DROP\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+            assertEquals(2, cols.size());
+            assertTrue(cols.contains("obsolete_col"));
+            assertTrue(cols.contains("temp_col"));
+        }
+
+        @Test
+        @DisplayName("Mixed case DDL keywords")
+        void mixedCaseDdlKeywords() {
+            String ddl = "alter TABLE `db`.`tbl` Add Column `MixedCase` Int32";
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                    Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+            assertEquals(List.of("MixedCase"), cols);
+        }
+
+        @Test
+        @DisplayName("Unquoted identifiers")
+        void unquotedIdentifiers() {
+            String ddl = "ALTER TABLE db.tbl ADD COLUMN unquoted_col Float64";
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                    Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+            assertEquals(List.of("unquoted_col"), cols);
+        }
+
+        @Test
+        @DisplayName("No match returns empty list")
+        void noMatchReturnsEmpty() {
+            String ddl = "ALTER TABLE db.tbl MODIFY COLUMN col1 String";
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(ddl,
+                    Pattern.compile("ADD\\s+COLUMN\\s+`?([^`\\s]+)`?", Pattern.CASE_INSENSITIVE));
+            assertTrue(cols.isEmpty());
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Null safety and boundary tests
+    // ---------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Null safety and boundary conditions")
+    class NullSafetyTests {
+
+        @Test
+        @DisplayName("Null connection does not throw")
+        void nullConnectionNoThrow() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(100, 10);
+            assertDoesNotThrow(() -> waiter.waitForSchemaVisibility(
+                    null, "ALTER TABLE db.tbl ADD COLUMN x Int32"));
+        }
+
+        @Test
+        @DisplayName("Null DDL does not throw")
+        void nullDdlNoThrow() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(100, 10);
+            assertDoesNotThrow(() -> waiter.waitForSchemaVisibility(null, null));
+        }
+
+        @Test
+        @DisplayName("Empty DDL does not throw")
+        void emptyDdlNoThrow() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(100, 10);
+            assertDoesNotThrow(() -> waiter.waitForSchemaVisibility(null, ""));
+        }
+
+        @Test
+        @DisplayName("Non-ALTER DDL returns immediately")
+        void nonAlterDdlReturnsImmediately() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(100, 10);
+            long start = System.currentTimeMillis();
+            waiter.waitForSchemaVisibility(null,
+                    "CREATE TABLE db.tbl (id Int32) ENGINE = MergeTree()");
+            long elapsed = System.currentTimeMillis() - start;
+            assertTrue(elapsed < 50, "Non-ALTER DDL should return immediately, took " + elapsed + "ms");
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Configuration tests
+    // ---------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Configuration and defaults")
+    class ConfigTests {
+
+        @Test
+        @DisplayName("Default constructor uses documented defaults")
+        void defaultConstructorUsesDefaults() {
+            assertEquals(30_000L, DDLSchemaChangeWaiter.DEFAULT_TIMEOUT_MS);
+            assertEquals(100L, DDLSchemaChangeWaiter.DEFAULT_POLL_INTERVAL_MS);
+        }
+
+        @Test
+        @DisplayName("Custom timeout and poll interval are respected")
+        void customTimeoutRespected() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(200, 50);
+
+            // Stub connection where columns never appear (timeout scenario)
+            Connection conn = stubConnection(sql -> stubResultSet(/* empty */));
+
+            long start = System.currentTimeMillis();
+            waiter.waitForSchemaVisibility(conn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `phantom_col` String");
+            long elapsed = System.currentTimeMillis() - start;
+
+            assertTrue(elapsed >= 150, "Should wait near timeout, but only waited " + elapsed + "ms");
+            assertTrue(elapsed < 1000, "Should not wait much longer than timeout, waited " + elapsed + "ms");
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Stub-based visibility wait tests
+    // ---------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Schema visibility waiting with stub JDBC")
+    class VisibilityWaitTests {
+
+        @Test
+        @DisplayName("Returns immediately when columns are already visible")
+        void columnsAlreadyVisible() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(5000, 50);
+
+            // Column already exists in system.columns
+            Connection conn = stubConnection(sql -> stubResultSet("new_col"));
+
+            long start = System.currentTimeMillis();
+            waiter.waitForSchemaVisibility(conn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `new_col` String");
+            long elapsed = System.currentTimeMillis() - start;
+
+            assertTrue(elapsed < 200, "Should return quickly when column already visible, took " + elapsed + "ms");
+        }
+
+        @Test
+        @DisplayName("Waits until columns appear after simulated propagation delay")
+        void waitsForDelayedPropagation() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(5000, 50);
+
+            AtomicInteger pollCount = new AtomicInteger(0);
+            Connection conn = stubConnection(sql -> {
+                int count = pollCount.incrementAndGet();
+                if (count < 4) {
+                    return stubResultSet(/* empty — column not yet visible */);
+                }
+                return stubResultSet("delayed_col");
+            });
+
+            long start = System.currentTimeMillis();
+            waiter.waitForSchemaVisibility(conn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `delayed_col` String");
+            long elapsed = System.currentTimeMillis() - start;
+
+            assertTrue(pollCount.get() >= 4, "Expected at least 4 polls, got " + pollCount.get());
+            assertTrue(elapsed >= 100, "Should have waited for propagation, only waited " + elapsed + "ms");
+        }
+
+        @Test
+        @DisplayName("Times out when columns never appear")
+        void timesOutWhenColumnsNeverAppear() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(300, 50);
+
+            Connection conn = stubConnection(sql -> stubResultSet(/* empty — never appears */));
+
+            long start = System.currentTimeMillis();
+            waiter.waitForSchemaVisibility(conn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `never_col` String");
+            long elapsed = System.currentTimeMillis() - start;
+
+            assertTrue(elapsed >= 250, "Should wait near timeout, but only waited " + elapsed + "ms");
+            assertTrue(elapsed < 1000, "Should not hang forever, waited " + elapsed + "ms");
+        }
+
+        @Test
+        // DESTRUCTIVE: title and DDL string are inert test fixtures. The
+        // connection here is a stub that returns canned result sets — there is
+        // no real database and no statement is ever executed.
+        @DisplayName("DROP COLUMN waits for column to disappear")
+        void dropColumnWaitsForDisappearance() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(5000, 50);
+
+            AtomicInteger pollCount = new AtomicInteger(0);
+            Connection conn = stubConnection(sql -> {
+                int count = pollCount.incrementAndGet();
+                if (count < 3) {
+                    return stubResultSet("drop_me"); // still visible
+                }
+                return stubResultSet(/* empty — column gone */);
+            });
+
+            // DESTRUCTIVE: inert DDL string passed to a stub connection that
+            // returns canned result sets. No real database, nothing executed.
+            waiter.waitForSchemaVisibility(conn,
+                    "ALTER TABLE `db`.`tbl` DROP COLUMN `drop_me`");
+
+            assertTrue(pollCount.get() >= 3, "Expected at least 3 polls for DROP, got " + pollCount.get());
+        }
+
+        @Test
+        @DisplayName("Multiple columns with staggered propagation")
+        void multipleColumnsStaggeredPropagation() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(5000, 50);
+
+            AtomicInteger pollCount = new AtomicInteger(0);
+            Connection conn = stubConnection(sql -> {
+                int count = pollCount.incrementAndGet();
+                if (count == 1) {
+                    return stubResultSet("existing_col");
+                } else if (count == 2) {
+                    return stubResultSet("existing_col", "col_a");
+                }
+                return stubResultSet("existing_col", "col_a", "col_b");
+            });
+
+            waiter.waitForSchemaVisibility(conn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `col_a` String, ADD COLUMN `col_b` Int32");
+
+            assertTrue(pollCount.get() >= 3,
+                    "Expected at least 3 polls for staggered propagation, got " + pollCount.get());
+        }
+
+        @Test
+        @DisplayName("JDBC exception during polling does not cause hang")
+        void jdbcExceptionDuringPolling() {
+            DDLSchemaChangeWaiter waiter = new DDLSchemaChangeWaiter(500, 50);
+
+            AtomicInteger pollCount = new AtomicInteger(0);
+            Connection conn = stubConnection(sql -> {
+                int count = pollCount.incrementAndGet();
+                if (count <= 2) {
+                    throw new SQLException("Connection reset");
+                }
+                return stubResultSet("resilient_col");
+            });
+
+            waiter.waitForSchemaVisibility(conn,
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `resilient_col` String");
+
+            assertTrue(pollCount.get() >= 3,
+                    "Should have retried after exceptions, got " + pollCount.get() + " polls");
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Race condition simulation tests
+    // ---------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Race condition simulation (issue #1222)")
+    class RaceConditionSimulation {
+
+        /**
+         * Demonstrates the original bug WITHOUT the waiter.
+         *
+         * Simulates two threads:
+         * - DDL thread: executes ALTER TABLE, marks column as
+         *   "propagating" with a delay, then signals cache invalidation
+         * - Batch thread: on cache invalidation, reads column list
+         *
+         * Without the waiter, the batch thread reads stale metadata.
+         */
+        @Test
+        @DisplayName("BUG: Without waiter, batch thread reads stale metadata")
+        void bugWithoutWaiter() throws Exception {
+            AtomicBoolean columnPropagated = new AtomicBoolean(false);
+            CountDownLatch cacheInvalidated = new CountDownLatch(1);
+            AtomicBoolean batchSawNewColumn = new AtomicBoolean(false);
+            CountDownLatch done = new CountDownLatch(2);
+
+            // DDL thread: signals cache invalidation IMMEDIATELY (the bug)
+            Thread ddlThread = new Thread(() -> {
+                try {
+                    // Start propagation in background
+                    new Thread(() -> {
+                        try {
+                            Thread.sleep(200);
+                            columnPropagated.set(true);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }).start();
+                    // BUG: signal immediately without waiting
+                    cacheInvalidated.countDown();
+                } finally {
+                    done.countDown();
+                }
+            });
+
+            // Batch thread: reads metadata on cache invalidation
+            Thread batchThread = new Thread(() -> {
+                try {
+                    cacheInvalidated.await(5, TimeUnit.SECONDS);
+                    batchSawNewColumn.set(columnPropagated.get());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+
+            ddlThread.start();
+            batchThread.start();
+            assertTrue(done.await(5, TimeUnit.SECONDS), "Threads should complete");
+
+            // THIS IS THE BUG: batch thread does NOT see the new column
+            assertFalse(batchSawNewColumn.get(),
+                    "Without waiter, batch thread should NOT see the new column " +
+                    "(demonstrates the race condition from issue #1222)");
+        }
+
+        /**
+         * Proves the fix WITH the waiter.
+         */
+        @Test
+        @DisplayName("FIX: With waiter, batch thread sees correct metadata")
+        void fixWithWaiter() throws Exception {
+            AtomicBoolean columnPropagated = new AtomicBoolean(false);
+            CountDownLatch cacheInvalidated = new CountDownLatch(1);
+            AtomicBoolean batchSawNewColumn = new AtomicBoolean(false);
+            CountDownLatch done = new CountDownLatch(2);
+
+            // DDL thread: WAITS for propagation before signaling (the fix)
+            Thread ddlThread = new Thread(() -> {
+                try {
+                    new Thread(() -> {
+                        try {
+                            Thread.sleep(200);
+                            columnPropagated.set(true);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }).start();
+
+                    // FIX: poll until propagated (simulates DDLSchemaChangeWaiter)
+                    long deadline = System.currentTimeMillis() + 5000;
+                    while (!columnPropagated.get() &&
+                            System.currentTimeMillis() < deadline) {
+                        Thread.sleep(50);
+                    }
+                    cacheInvalidated.countDown();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+
+            Thread batchThread = new Thread(() -> {
+                try {
+                    cacheInvalidated.await(5, TimeUnit.SECONDS);
+                    batchSawNewColumn.set(columnPropagated.get());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+
+            ddlThread.start();
+            batchThread.start();
+            assertTrue(done.await(5, TimeUnit.SECONDS), "Threads should complete");
+
+            assertTrue(batchSawNewColumn.get(),
+                    "With waiter, batch thread SHOULD see the new column " +
+                    "(proves the fix for issue #1222)");
+        }
+
+        /**
+         * Stress test: 20 concurrent DDL + batch thread pairs.
+         */
+        @Test
+        @DisplayName("STRESS: 20 concurrent DDL+batch pairs with waiter")
+        void stressConcurrentPairsWithWaiter() throws Exception {
+            int pairCount = 20;
+            CyclicBarrier barrier = new CyclicBarrier(pairCount * 2);
+            AtomicInteger staleReads = new AtomicInteger(0);
+            AtomicInteger successfulReads = new AtomicInteger(0);
+            CountDownLatch allDone = new CountDownLatch(pairCount * 2);
+            List<Throwable> errors = Collections.synchronizedList(new ArrayList<>());
+
+            ExecutorService executor = Executors.newFixedThreadPool(pairCount * 2);
+
+            for (int i = 0; i < pairCount; i++) {
+                AtomicBoolean propagated = new AtomicBoolean(false);
+                CountDownLatch invalidated = new CountDownLatch(1);
+
+                executor.submit(() -> {
+                    try {
+                        barrier.await(5, TimeUnit.SECONDS);
+                        long delay = 50 + (long)(Math.random() * 150);
+                        new Thread(() -> {
+                            try {
+                                Thread.sleep(delay);
+                                propagated.set(true);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                        }).start();
+
+                        long deadline = System.currentTimeMillis() + 5000;
+                        while (!propagated.get() &&
+                                System.currentTimeMillis() < deadline) {
+                            Thread.sleep(25);
+                        }
+                        invalidated.countDown();
+                    } catch (Exception e) {
+                        errors.add(e);
+                    } finally {
+                        allDone.countDown();
+                    }
+                });
+
+                executor.submit(() -> {
+                    try {
+                        barrier.await(5, TimeUnit.SECONDS);
+                        invalidated.await(5, TimeUnit.SECONDS);
+                        if (propagated.get()) {
+                            successfulReads.incrementAndGet();
+                        } else {
+                            staleReads.incrementAndGet();
+                        }
+                    } catch (Exception e) {
+                        errors.add(e);
+                    } finally {
+                        allDone.countDown();
+                    }
+                });
+            }
+
+            assertTrue(allDone.await(30, TimeUnit.SECONDS), "All threads should complete");
+            executor.shutdown();
+
+            assertTrue(errors.isEmpty(), "No thread errors expected, got: " + errors);
+            assertEquals(0, staleReads.get(),
+                    "With waiter, there should be ZERO stale reads across all " +
+                    pairCount + " pairs");
+            assertEquals(pairCount, successfulReads.get(),
+                    "All " + pairCount + " batch threads should see propagated columns");
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Minimal JDBC stub implementations (no Mockito needed)
+    // ---------------------------------------------------------------
+
+    /**
+     * Lightweight Connection stub that only implements createStatement().
+     */
+    private static class StubConnection implements Connection {
+        private final QueryCallback callback;
+        StubConnection(QueryCallback callback) { this.callback = callback; }
+
+        @Override public Statement createStatement() {
+            return new StubStatement(callback);
+        }
+
+        // --- All other Connection methods throw UnsupportedOperationException ---
+        @Override public Statement createStatement(int a, int b) { throw new UnsupportedOperationException(); }
+        @Override public Statement createStatement(int a, int b, int c) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.PreparedStatement prepareStatement(String s) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.PreparedStatement prepareStatement(String s, int a, int b) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.PreparedStatement prepareStatement(String s, int a, int b, int c) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.PreparedStatement prepareStatement(String s, int a) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.PreparedStatement prepareStatement(String s, int[] a) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.PreparedStatement prepareStatement(String s, String[] a) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.CallableStatement prepareCall(String s) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.CallableStatement prepareCall(String s, int a, int b) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.CallableStatement prepareCall(String s, int a, int b, int c) { throw new UnsupportedOperationException(); }
+        @Override public String nativeSQL(String s) { throw new UnsupportedOperationException(); }
+        @Override public void setAutoCommit(boolean b) { }
+        @Override public boolean getAutoCommit() { return true; }
+        @Override public void commit() { }
+        @Override public void rollback() { }
+        @Override public void close() { }
+        @Override public boolean isClosed() { return false; }
+        @Override public java.sql.DatabaseMetaData getMetaData() { throw new UnsupportedOperationException(); }
+        @Override public void setReadOnly(boolean b) { }
+        @Override public boolean isReadOnly() { return true; }
+        @Override public void setCatalog(String s) { }
+        @Override public String getCatalog() { return null; }
+        @Override public void setTransactionIsolation(int i) { }
+        @Override public int getTransactionIsolation() { return Connection.TRANSACTION_NONE; }
+        @Override public java.sql.SQLWarning getWarnings() { return null; }
+        @Override public void clearWarnings() { }
+        @Override public java.util.Map<String, Class<?>> getTypeMap() { throw new UnsupportedOperationException(); }
+        @Override public void setTypeMap(java.util.Map<String, Class<?>> m) { }
+        @Override public void setHoldability(int h) { }
+        @Override public int getHoldability() { return 0; }
+        @Override public java.sql.Savepoint setSavepoint() { throw new UnsupportedOperationException(); }
+        @Override public java.sql.Savepoint setSavepoint(String s) { throw new UnsupportedOperationException(); }
+        @Override public void rollback(java.sql.Savepoint s) { }
+        @Override public void releaseSavepoint(java.sql.Savepoint s) { }
+        @Override public java.sql.Clob createClob() { throw new UnsupportedOperationException(); }
+        @Override public java.sql.Blob createBlob() { throw new UnsupportedOperationException(); }
+        @Override public java.sql.NClob createNClob() { throw new UnsupportedOperationException(); }
+        @Override public java.sql.SQLXML createSQLXML() { throw new UnsupportedOperationException(); }
+        @Override public boolean isValid(int t) { return true; }
+        @Override public void setClientInfo(String k, String v) { }
+        @Override public void setClientInfo(java.util.Properties p) { }
+        @Override public String getClientInfo(String k) { return null; }
+        @Override public java.util.Properties getClientInfo() { return new java.util.Properties(); }
+        @Override public java.sql.Array createArrayOf(String t, Object[] e) { throw new UnsupportedOperationException(); }
+        @Override public java.sql.Struct createStruct(String t, Object[] a) { throw new UnsupportedOperationException(); }
+        @Override public void setSchema(String s) { }
+        @Override public String getSchema() { return null; }
+        @Override public void abort(java.util.concurrent.Executor e) { }
+        @Override public void setNetworkTimeout(java.util.concurrent.Executor e, int t) { }
+        @Override public int getNetworkTimeout() { return 0; }
+        @Override public <T> T unwrap(Class<T> c) { throw new UnsupportedOperationException(); }
+        @Override public boolean isWrapperFor(Class<?> c) { return false; }
+    }
+
+    /**
+     * Lightweight Statement stub that delegates executeQuery to a callback.
+     */
+    private static class StubStatement implements Statement {
+        private final QueryCallback callback;
+        StubStatement(QueryCallback callback) { this.callback = callback; }
+
+        @Override public ResultSet executeQuery(String sql) throws SQLException {
+            return callback.execute(sql);
+        }
+
+        @Override public void close() { }
+        @Override public int getMaxFieldSize() { return 0; }
+        @Override public void setMaxFieldSize(int m) { }
+        @Override public int getMaxRows() { return 0; }
+        @Override public void setMaxRows(int m) { }
+        @Override public void setEscapeProcessing(boolean e) { }
+        @Override public int getQueryTimeout() { return 0; }
+        @Override public void setQueryTimeout(int s) { }
+        @Override public void cancel() { }
+        @Override public java.sql.SQLWarning getWarnings() { return null; }
+        @Override public void clearWarnings() { }
+        @Override public void setCursorName(String n) { }
+        @Override public boolean execute(String s) { return false; }
+        @Override public ResultSet getResultSet() { return null; }
+        @Override public int getUpdateCount() { return -1; }
+        @Override public boolean getMoreResults() { return false; }
+        @Override public void setFetchDirection(int d) { }
+        @Override public int getFetchDirection() { return ResultSet.FETCH_FORWARD; }
+        @Override public void setFetchSize(int r) { }
+        @Override public int getFetchSize() { return 0; }
+        @Override public int getResultSetConcurrency() { return ResultSet.CONCUR_READ_ONLY; }
+        @Override public int getResultSetType() { return ResultSet.TYPE_FORWARD_ONLY; }
+        @Override public void addBatch(String s) { }
+        @Override public void clearBatch() { }
+        @Override public int[] executeBatch() { return new int[0]; }
+        @Override public Connection getConnection() { return null; }
+        @Override public boolean getMoreResults(int c) { return false; }
+        @Override public ResultSet getGeneratedKeys() { return null; }
+        @Override public int executeUpdate(String s) { return 0; }
+        @Override public int executeUpdate(String s, int a) { return 0; }
+        @Override public int executeUpdate(String s, int[] a) { return 0; }
+        @Override public int executeUpdate(String s, String[] a) { return 0; }
+        @Override public boolean execute(String s, int a) { return false; }
+        @Override public boolean execute(String s, int[] a) { return false; }
+        @Override public boolean execute(String s, String[] a) { return false; }
+        @Override public int getResultSetHoldability() { return 0; }
+        @Override public boolean isClosed() { return false; }
+        @Override public void setPoolable(boolean p) { }
+        @Override public boolean isPoolable() { return false; }
+        @Override public void closeOnCompletion() { }
+        @Override public boolean isCloseOnCompletion() { return false; }
+        @Override public <T> T unwrap(Class<T> c) { throw new UnsupportedOperationException(); }
+        @Override public boolean isWrapperFor(Class<?> c) { return false; }
+    }
+
+    /**
+     * Lightweight ResultSet stub that iterates over a fixed list of
+     * column names (simulating system.columns query results).
+     */
+    private static class StubResultSet implements ResultSet {
+        private final String[] names;
+        private int cursor = -1;
+
+        StubResultSet(String... names) { this.names = names; }
+
+        @Override public boolean next() { return ++cursor < names.length; }
+        @Override public String getString(int columnIndex) { return names[cursor]; }
+        @Override public void close() { }
+
+        // --- Minimal stubs for remaining ResultSet methods ---
+        @Override public boolean wasNull() { return false; }
+        @Override public String getString(String c) { return names[cursor]; }
+        @Override public boolean getBoolean(int c) { return false; }
+        @Override public byte getByte(int c) { return 0; }
+        @Override public short getShort(int c) { return 0; }
+        @Override public int getInt(int c) { return 0; }
+        @Override public long getLong(int c) { return 0; }
+        @Override public float getFloat(int c) { return 0; }
+        @Override public double getDouble(int c) { return 0; }
+        @Override public java.math.BigDecimal getBigDecimal(int c, int s) { return null; }
+        @Override public byte[] getBytes(int c) { return null; }
+        @Override public java.sql.Date getDate(int c) { return null; }
+        @Override public java.sql.Time getTime(int c) { return null; }
+        @Override public java.sql.Timestamp getTimestamp(int c) { return null; }
+        @Override public java.io.InputStream getAsciiStream(int c) { return null; }
+        @Override public java.io.InputStream getUnicodeStream(int c) { return null; }
+        @Override public java.io.InputStream getBinaryStream(int c) { return null; }
+        @Override public boolean getBoolean(String c) { return false; }
+        @Override public byte getByte(String c) { return 0; }
+        @Override public short getShort(String c) { return 0; }
+        @Override public int getInt(String c) { return 0; }
+        @Override public long getLong(String c) { return 0; }
+        @Override public float getFloat(String c) { return 0; }
+        @Override public double getDouble(String c) { return 0; }
+        @Override public java.math.BigDecimal getBigDecimal(String c, int s) { return null; }
+        @Override public byte[] getBytes(String c) { return null; }
+        @Override public java.sql.Date getDate(String c) { return null; }
+        @Override public java.sql.Time getTime(String c) { return null; }
+        @Override public java.sql.Timestamp getTimestamp(String c) { return null; }
+        @Override public java.io.InputStream getAsciiStream(String c) { return null; }
+        @Override public java.io.InputStream getUnicodeStream(String c) { return null; }
+        @Override public java.io.InputStream getBinaryStream(String c) { return null; }
+        @Override public java.sql.SQLWarning getWarnings() { return null; }
+        @Override public void clearWarnings() { }
+        @Override public String getCursorName() { return null; }
+        @Override public ResultSetMetaData getMetaData() { return null; }
+        @Override public Object getObject(int c) { return null; }
+        @Override public Object getObject(String c) { return null; }
+        @Override public int findColumn(String c) { return 0; }
+        @Override public java.io.Reader getCharacterStream(int c) { return null; }
+        @Override public java.io.Reader getCharacterStream(String c) { return null; }
+        @Override public java.math.BigDecimal getBigDecimal(int c) { return null; }
+        @Override public java.math.BigDecimal getBigDecimal(String c) { return null; }
+        @Override public boolean isBeforeFirst() { return false; }
+        @Override public boolean isAfterLast() { return false; }
+        @Override public boolean isFirst() { return false; }
+        @Override public boolean isLast() { return false; }
+        @Override public void beforeFirst() { }
+        @Override public void afterLast() { }
+        @Override public boolean first() { return false; }
+        @Override public boolean last() { return false; }
+        @Override public int getRow() { return 0; }
+        @Override public boolean absolute(int r) { return false; }
+        @Override public boolean relative(int r) { return false; }
+        @Override public boolean previous() { return false; }
+        @Override public void setFetchDirection(int d) { }
+        @Override public int getFetchDirection() { return 0; }
+        @Override public void setFetchSize(int r) { }
+        @Override public int getFetchSize() { return 0; }
+        @Override public int getType() { return ResultSet.TYPE_FORWARD_ONLY; }
+        @Override public int getConcurrency() { return ResultSet.CONCUR_READ_ONLY; }
+        @Override public boolean rowUpdated() { return false; }
+        @Override public boolean rowInserted() { return false; }
+        @Override public boolean rowDeleted() { return false; }
+        @Override public void updateNull(int c) { }
+        @Override public void updateBoolean(int c, boolean v) { }
+        @Override public void updateByte(int c, byte v) { }
+        @Override public void updateShort(int c, short v) { }
+        @Override public void updateInt(int c, int v) { }
+        @Override public void updateLong(int c, long v) { }
+        @Override public void updateFloat(int c, float v) { }
+        @Override public void updateDouble(int c, double v) { }
+        @Override public void updateBigDecimal(int c, java.math.BigDecimal v) { }
+        @Override public void updateString(int c, String v) { }
+        @Override public void updateBytes(int c, byte[] v) { }
+        @Override public void updateDate(int c, java.sql.Date v) { }
+        @Override public void updateTime(int c, java.sql.Time v) { }
+        @Override public void updateTimestamp(int c, java.sql.Timestamp v) { }
+        @Override public void updateAsciiStream(int c, java.io.InputStream x, int l) { }
+        @Override public void updateBinaryStream(int c, java.io.InputStream x, int l) { }
+        @Override public void updateCharacterStream(int c, java.io.Reader x, int l) { }
+        @Override public void updateObject(int c, Object v, int s) { }
+        @Override public void updateObject(int c, Object v) { }
+        @Override public void updateNull(String c) { }
+        @Override public void updateBoolean(String c, boolean v) { }
+        @Override public void updateByte(String c, byte v) { }
+        @Override public void updateShort(String c, short v) { }
+        @Override public void updateInt(String c, int v) { }
+        @Override public void updateLong(String c, long v) { }
+        @Override public void updateFloat(String c, float v) { }
+        @Override public void updateDouble(String c, double v) { }
+        @Override public void updateBigDecimal(String c, java.math.BigDecimal v) { }
+        @Override public void updateString(String c, String v) { }
+        @Override public void updateBytes(String c, byte[] v) { }
+        @Override public void updateDate(String c, java.sql.Date v) { }
+        @Override public void updateTime(String c, java.sql.Time v) { }
+        @Override public void updateTimestamp(String c, java.sql.Timestamp v) { }
+        @Override public void updateAsciiStream(String c, java.io.InputStream x, int l) { }
+        @Override public void updateBinaryStream(String c, java.io.InputStream x, int l) { }
+        @Override public void updateCharacterStream(String c, java.io.Reader x, int l) { }
+        @Override public void updateObject(String c, Object v, int s) { }
+        @Override public void updateObject(String c, Object v) { }
+        @Override public void insertRow() { }
+        @Override public void updateRow() { }
+        @Override public void deleteRow() { }
+        @Override public void refreshRow() { }
+        @Override public void cancelRowUpdates() { }
+        @Override public void moveToInsertRow() { }
+        @Override public void moveToCurrentRow() { }
+        @Override public Statement getStatement() { return null; }
+        @Override public Object getObject(int c, java.util.Map<String, Class<?>> m) { return null; }
+        @Override public java.sql.Ref getRef(int c) { return null; }
+        @Override public java.sql.Blob getBlob(int c) { return null; }
+        @Override public java.sql.Clob getClob(int c) { return null; }
+        @Override public java.sql.Array getArray(int c) { return null; }
+        @Override public Object getObject(String c, java.util.Map<String, Class<?>> m) { return null; }
+        @Override public java.sql.Ref getRef(String c) { return null; }
+        @Override public java.sql.Blob getBlob(String c) { return null; }
+        @Override public java.sql.Clob getClob(String c) { return null; }
+        @Override public java.sql.Array getArray(String c) { return null; }
+        @Override public java.sql.Date getDate(int c, java.util.Calendar cal) { return null; }
+        @Override public java.sql.Date getDate(String c, java.util.Calendar cal) { return null; }
+        @Override public java.sql.Time getTime(int c, java.util.Calendar cal) { return null; }
+        @Override public java.sql.Time getTime(String c, java.util.Calendar cal) { return null; }
+        @Override public java.sql.Timestamp getTimestamp(int c, java.util.Calendar cal) { return null; }
+        @Override public java.sql.Timestamp getTimestamp(String c, java.util.Calendar cal) { return null; }
+        @Override public java.net.URL getURL(int c) { return null; }
+        @Override public java.net.URL getURL(String c) { return null; }
+        @Override public void updateRef(int c, java.sql.Ref v) { }
+        @Override public void updateRef(String c, java.sql.Ref v) { }
+        @Override public void updateBlob(int c, java.sql.Blob v) { }
+        @Override public void updateBlob(String c, java.sql.Blob v) { }
+        @Override public void updateClob(int c, java.sql.Clob v) { }
+        @Override public void updateClob(String c, java.sql.Clob v) { }
+        @Override public void updateArray(int c, java.sql.Array v) { }
+        @Override public void updateArray(String c, java.sql.Array v) { }
+        @Override public java.sql.RowId getRowId(int c) { return null; }
+        @Override public java.sql.RowId getRowId(String c) { return null; }
+        @Override public void updateRowId(int c, java.sql.RowId v) { }
+        @Override public void updateRowId(String c, java.sql.RowId v) { }
+        @Override public int getHoldability() { return 0; }
+        @Override public boolean isClosed() { return false; }
+        @Override public void updateNString(int c, String v) { }
+        @Override public void updateNString(String c, String v) { }
+        @Override public void updateNClob(int c, java.sql.NClob v) { }
+        @Override public void updateNClob(String c, java.sql.NClob v) { }
+        @Override public java.sql.NClob getNClob(int c) { return null; }
+        @Override public java.sql.NClob getNClob(String c) { return null; }
+        @Override public java.sql.SQLXML getSQLXML(int c) { return null; }
+        @Override public java.sql.SQLXML getSQLXML(String c) { return null; }
+        @Override public void updateSQLXML(int c, java.sql.SQLXML v) { }
+        @Override public void updateSQLXML(String c, java.sql.SQLXML v) { }
+        @Override public String getNString(int c) { return null; }
+        @Override public String getNString(String c) { return null; }
+        @Override public java.io.Reader getNCharacterStream(int c) { return null; }
+        @Override public java.io.Reader getNCharacterStream(String c) { return null; }
+        @Override public void updateNCharacterStream(int c, java.io.Reader x, long l) { }
+        @Override public void updateNCharacterStream(String c, java.io.Reader x, long l) { }
+        @Override public void updateAsciiStream(int c, java.io.InputStream x, long l) { }
+        @Override public void updateBinaryStream(int c, java.io.InputStream x, long l) { }
+        @Override public void updateCharacterStream(int c, java.io.Reader x, long l) { }
+        @Override public void updateAsciiStream(String c, java.io.InputStream x, long l) { }
+        @Override public void updateBinaryStream(String c, java.io.InputStream x, long l) { }
+        @Override public void updateCharacterStream(String c, java.io.Reader x, long l) { }
+        @Override public void updateBlob(int c, java.io.InputStream x, long l) { }
+        @Override public void updateBlob(String c, java.io.InputStream x, long l) { }
+        @Override public void updateClob(int c, java.io.Reader x, long l) { }
+        @Override public void updateClob(String c, java.io.Reader x, long l) { }
+        @Override public void updateNClob(int c, java.io.Reader x, long l) { }
+        @Override public void updateNClob(String c, java.io.Reader x, long l) { }
+        @Override public void updateNCharacterStream(int c, java.io.Reader x) { }
+        @Override public void updateNCharacterStream(String c, java.io.Reader x) { }
+        @Override public void updateAsciiStream(int c, java.io.InputStream x) { }
+        @Override public void updateBinaryStream(int c, java.io.InputStream x) { }
+        @Override public void updateCharacterStream(int c, java.io.Reader x) { }
+        @Override public void updateAsciiStream(String c, java.io.InputStream x) { }
+        @Override public void updateBinaryStream(String c, java.io.InputStream x) { }
+        @Override public void updateCharacterStream(String c, java.io.Reader x) { }
+        @Override public void updateBlob(int c, java.io.InputStream x) { }
+        @Override public void updateBlob(String c, java.io.InputStream x) { }
+        @Override public void updateClob(int c, java.io.Reader x) { }
+        @Override public void updateClob(String c, java.io.Reader x) { }
+        @Override public void updateNClob(int c, java.io.Reader x) { }
+        @Override public void updateNClob(String c, java.io.Reader x) { }
+        @Override public <T> T getObject(int c, Class<T> t) { return null; }
+        @Override public <T> T getObject(String c, Class<T> t) { return null; }
+        @Override public <T> T unwrap(Class<T> c) { throw new UnsupportedOperationException(); }
+        @Override public boolean isWrapperFor(Class<?> c) { return false; }
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/ExecutorPauseVisibilityTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/ExecutorPauseVisibilityTest.java
@@ -1,0 +1,157 @@
+package com.altinity.clickhouse.sink.connector.executor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Memory-visibility contract for {@link ClickHouseBatchExecutor}'s pause flag.
+ *
+ * <p>{@code pause()} / {@code resume()} are the DDL-versus-DML barrier. In
+ * {@code DebeziumChangeEventCapture.processEveryChangeRecord} a DDL statement
+ * calls {@code executor.pause()}, applies the schema change, and only then
+ * calls {@code executor.resume()}. Every batch thread is expected to park
+ * inside {@code beforeExecute} for the whole of that window, so no DML is
+ * applied against a schema that is mid-change.</p>
+ *
+ * <p>The barrier is only as strong as the flag's visibility. {@code isPaused}
+ * is written by the Debezium change-event thread and read by the batch-pool
+ * threads, with no lock and no other happens-before edge between them: the
+ * write is a plain field store and the read sits in a tight
+ * {@code while (isPaused)} spin whose body touches nothing else the JMM could
+ * use to force a re-read. Under JLS 17.4 a non-volatile field carries no
+ * visibility guarantee across threads, and such a loop is a textbook
+ * hoisting candidate — the reading thread is permitted to cache {@code false}
+ * and never observe the pause at all. The failure is silent and one-directional:
+ * DML lands against the pre-DDL schema, which is a corruption vector, not a
+ * stall.</p>
+ *
+ * <p>These tests therefore pin the property structurally rather than by trying
+ * to observe a race. A timing-based test would be non-deterministic — it would
+ * pass on a machine that happens not to hoist, which is exactly the false
+ * assurance this suite exists to prevent. The declaration check is exact and
+ * fails deterministically on any JVM if the modifier is ever dropped.</p>
+ */
+public class ExecutorPauseVisibilityTest {
+
+    /** Bounds the handshake waits. Generous: a pass must never depend on it. */
+    private static final long TIMEOUT_SECONDS = 10;
+
+    private static ClickHouseBatchExecutor newExecutor() {
+        return new ClickHouseBatchExecutor(1, r -> new Thread(r, "test-batch"));
+    }
+
+    @Test
+    @DisplayName("isPaused must be declared volatile — it is the DDL/DML barrier")
+    public void pauseFlagIsVolatile() throws NoSuchFieldException {
+        Field f = ClickHouseBatchExecutor.class.getDeclaredField("isPaused");
+
+        assertTrue(java.lang.reflect.Modifier.isVolatile(f.getModifiers()),
+                "ClickHouseBatchExecutor.isPaused is written by the Debezium "
+                        + "change-event thread (pause/resume around a DDL) and read by the "
+                        + "batch-pool threads in the beforeExecute spin loop. Without "
+                        + "volatile there is no happens-before edge between those threads, "
+                        + "so a batch thread may never observe the pause and can apply DML "
+                        + "against a schema that is mid-DDL. Restore the volatile modifier "
+                        + "rather than relaxing this assertion.");
+    }
+
+    @Test
+    @DisplayName("A paused executor holds a task in beforeExecute until resume()")
+    public void pausedExecutorBlocksUntilResumed() throws Exception {
+        ClickHouseBatchExecutor executor = newExecutor();
+        try {
+            AtomicBoolean taskRan = new AtomicBoolean(false);
+            CountDownLatch finished = new CountDownLatch(1);
+
+            executor.pause();
+            executor.execute(() -> {
+                taskRan.set(true);
+                finished.countDown();
+            });
+
+            // The task must NOT run while paused. This direction of the assertion
+            // is safe to check with a bounded wait: awaiting a latch that should
+            // not fire can only produce a false PASS under a scheduling delay,
+            // never a false failure, and the resume half below closes that gap by
+            // proving the very same task does run once the flag is cleared.
+            assertFalse(finished.await(500, TimeUnit.MILLISECONDS),
+                    "Task executed while the executor was paused — the DDL barrier "
+                            + "did not hold, so DML can be applied against a mid-DDL schema.");
+            assertFalse(taskRan.get(), "Task body ran during the pause window.");
+
+            executor.resume();
+
+            assertTrue(finished.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "Task did not run after resume() — replication would stall "
+                            + "permanently once a DDL is seen.");
+            assertTrue(taskRan.get(), "Task body did not run after resume().");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("resume() published from another thread is observed by the pool thread")
+    public void resumeIsVisibleAcrossThreads() throws Exception {
+        ClickHouseBatchExecutor executor = newExecutor();
+        try {
+            CountDownLatch started = new CountDownLatch(1);
+            CountDownLatch finished = new CountDownLatch(1);
+
+            executor.pause();
+            executor.execute(() -> {
+                started.countDown();
+                finished.countDown();
+            });
+
+            // Cross-thread publish, mirroring the real caller: the Debezium
+            // change-event thread resumes, the batch-pool thread must see it.
+            Thread resumer = new Thread(executor::resume, "test-ddl-thread");
+            resumer.start();
+            resumer.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+
+            assertTrue(started.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "Pool thread never observed resume() published by another "
+                            + "thread — the pause flag is not being read across threads.");
+            assertTrue(finished.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "Task did not complete after a cross-thread resume().");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("pause/resume is re-entrant across successive DDL statements")
+    public void repeatedPauseResumeCyclesKeepWorking() throws Exception {
+        ClickHouseBatchExecutor executor = newExecutor();
+        try {
+            // A stream carrying several DDLs pauses and resumes repeatedly. If
+            // either transition were sticky, replication would stall on the
+            // second statement rather than the first, so one cycle is not
+            // sufficient coverage.
+            for (int cycle = 0; cycle < 5; cycle++) {
+                CountDownLatch finished = new CountDownLatch(1);
+                executor.pause();
+                executor.execute(finished::countDown);
+
+                assertFalse(finished.await(200, TimeUnit.MILLISECONDS),
+                        "Cycle " + cycle + ": task ran while paused.");
+
+                executor.resume();
+
+                assertTrue(finished.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                        "Cycle " + cycle + ": task did not run after resume().");
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/LazySystemConnectionTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/LazySystemConnectionTest.java
@@ -1,0 +1,69 @@
+package com.altinity.clickhouse.sink.connector.executor;
+
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import com.altinity.clickhouse.sink.connector.model.ClickHouseStruct;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Guards the lazy system-database connection.
+ *
+ * <p>Both executors used to open a ClickHouse system connection in their
+ * constructor. That was tolerable while BaseDbWriter.createConnection returned
+ * null on failure, but once it was changed to throw, merely CONSTRUCTING either
+ * class required a reachable ClickHouse — including for pure string operations
+ * such as {@code getTableFromTopic}, which touch no database at all.</p>
+ *
+ * <p>These tests construct both executors against a deliberately unreachable
+ * host and exercise a database-free method. They fail if the eager connection
+ * is ever reintroduced.</p>
+ */
+public class LazySystemConnectionTest {
+
+    private static ClickHouseSinkConnectorConfig unreachableConfig() {
+        Map<String, String> props = new HashMap<>();
+        // Port 1 is reserved and never listening, so any connection attempt
+        // fails fast rather than hanging on a real host.
+        props.put("clickhouse.server.url", "127.0.0.1");
+        props.put("clickhouse.server.port", "1");
+        props.put("clickhouse.server.user", "nobody");
+        props.put("clickhouse.server.password", "");
+        props.put("clickhouse.server.database", "system");
+        return new ClickHouseSinkConnectorConfig(props);
+    }
+
+    @Test
+    @DisplayName("ClickHouseBatchRunnable constructs without a reachable ClickHouse")
+    public void batchRunnableDoesNotConnectEagerly() {
+        LinkedBlockingQueue<List<ClickHouseStruct>> records =
+                new LinkedBlockingQueue<>();
+        ClickHouseBatchRunnable runnable = assertDoesNotThrow(
+                () -> new ClickHouseBatchRunnable(
+                        records, unreachableConfig(), new HashMap<>()),
+                "Constructing the runnable must not require a live ClickHouse");
+
+        // A pure string operation must work with no database whatsoever.
+        assertEquals("customers",
+                runnable.getTableFromTopic("SERVER5432.test.customers"));
+    }
+
+    @Test
+    @DisplayName("ClickHouseBatchWriter constructs without a reachable ClickHouse")
+    public void batchWriterDoesNotConnectEagerly() {
+        ClickHouseBatchWriter writer = assertDoesNotThrow(
+                () -> new ClickHouseBatchWriter(
+                        unreachableConfig(), new HashMap<>()),
+                "Constructing the writer must not require a live ClickHouse");
+
+        assertEquals("customers",
+                writer.getTableFromTopic("SERVER5432.test.customers"));
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/OffsetCommitConcurrencyTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/OffsetCommitConcurrencyTest.java
@@ -1,0 +1,432 @@
+package com.altinity.clickhouse.sink.connector.executor;
+
+import com.altinity.clickhouse.sink.connector.model.ClickHouseStruct;
+import io.debezium.engine.ChangeEvent;
+import io.debezium.engine.DebeziumEngine;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Concurrency contract for the Debezium offset-commit path.
+ *
+ * <p>This is the failure reported against this connector in production:</p>
+ * <pre>
+ * ERROR OffsetStorageWriter - Invalid call to OffsetStorageWriter beginFlush()
+ *       while already flushing, the framework should not allow this
+ * ConnectException: OffsetStorageWriter is already flushing
+ *       at OffsetStorageWriter.beginFlush(OffsetStorageWriter.java:120)
+ *       at EmbeddedEngine.commitOffsets(EmbeddedEngine.java:905)
+ *       at DebeziumOffsetManagement.markBatchFinishedSafely(...:272)
+ * </pre>
+ *
+ * <p>Kafka's {@code OffsetStorageWriter} is single-flush: {@code beginFlush()}
+ * throws if a flush is already open. Debezium builds a <em>new</em>
+ * {@code RecordCommitter} per batch in {@code EmbeddedEngine.buildRecordCommitter},
+ * so the committer's own {@code synchronized} methods lock different monitors
+ * for different batches and provide no mutual exclusion between worker threads.
+ * The only real barrier is {@code DebeziumOffsetManagement.OFFSET_COMMIT_LOCK}.
+ * When that barrier is missing or too narrow, two threads enter
+ * {@code markBatchFinished()} concurrently and the second one throws — the
+ * batch fails, is retried, and records are re-applied or their offsets are
+ * never advanced.</p>
+ *
+ * <p>The committer stub below models exactly that single-flush semantic: it
+ * raises the same {@code ConnectException} if a second thread enters the
+ * finish window while one is open. Making the test <em>deterministic</em>
+ * rather than probabilistic is the point — a plain "run it hot and hope"
+ * stress test passes on a lucky interleaving. Two mechanisms are used:
+ * a real overlap window (the stub sleeps while inside the critical region,
+ * so a genuine concurrent entry is observed, not merely possible), and a
+ * strict serialisation check (a depth counter that records the maximum
+ * observed concurrency, which must be exactly 1).</p>
+ */
+public class OffsetCommitConcurrencyTest {
+
+    /** Worker threads driving concurrent commits. Above the usual pool size. */
+    private static final int THREADS = 8;
+
+    /** Batches per thread. */
+    private static final int BATCHES_PER_THREAD = 25;
+
+    /** Overlap window held open inside the finish call, in milliseconds. */
+    private static final long OVERLAP_WINDOW_MS = 2;
+
+    private static final long TIMEOUT_SECONDS = 60;
+
+    @BeforeEach
+    public void resetSharedState() {
+        // The maps are static, so residue from another test in the same JVM
+        // would make a run order-dependent.
+        DebeziumOffsetManagement.inFlightBatches = new ConcurrentHashMap<>();
+        DebeziumOffsetManagement.completedBatches = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Committer that reproduces {@code OffsetStorageWriter}'s single-flush rule
+     * and records the maximum concurrency it ever observes.
+     */
+    private static final class SingleFlushCommitter
+            implements DebeziumEngine.RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>> {
+
+        private final AtomicInteger inFlush = new AtomicInteger(0);
+        private final AtomicInteger maxConcurrent = new AtomicInteger(0);
+        private final AtomicInteger finishCount = new AtomicInteger(0);
+        private final AtomicReference<Throwable> failure = new AtomicReference<>();
+        private final boolean holdWindowOpen;
+
+        private SingleFlushCommitter(boolean holdWindowOpen) {
+            this.holdWindowOpen = holdWindowOpen;
+        }
+
+        @Override
+        public void markProcessed(ChangeEvent<SourceRecord, SourceRecord> record) {
+            // No-op: this stub asserts on flush overlap, not on processed counts.
+        }
+
+        @Override
+        public void markBatchFinished() {
+            int depth = inFlush.incrementAndGet();
+            maxConcurrent.accumulateAndGet(depth, Math::max);
+            try {
+                if (depth > 1) {
+                    // Precisely the production symptom.
+                    ConnectException e = new ConnectException(
+                            "OffsetStorageWriter is already flushing");
+                    failure.compareAndSet(null, e);
+                    throw e;
+                }
+                if (holdWindowOpen) {
+                    try {
+                        // Hold the window open so a second thread that is NOT
+                        // excluded actually lands inside it. Without this the
+                        // critical section is too short to overlap reliably and
+                        // a broken build could pass by luck.
+                        Thread.sleep(OVERLAP_WINDOW_MS);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            } finally {
+                inFlush.decrementAndGet();
+            }
+            finishCount.incrementAndGet();
+        }
+
+        @Override
+        public void markProcessed(ChangeEvent<SourceRecord, SourceRecord> record,
+                                  DebeziumEngine.Offsets sourceOffsets) {
+            markProcessed(record);
+        }
+
+        @Override
+        public DebeziumEngine.Offsets buildOffsets() {
+            return null;
+        }
+    }
+
+    /**
+     * Minimal non-null {@link ChangeEvent}. acknowledgeRecords only proceeds
+     * for records whose committer AND source record are both non-null.
+     */
+    private static ChangeEvent<SourceRecord, SourceRecord> dummyChangeEvent() {
+        return new ChangeEvent<>() {
+            @Override
+            public SourceRecord key() {
+                return null;
+            }
+
+            @Override
+            public SourceRecord value() {
+                return null;
+            }
+
+            @Override
+            public String destination() {
+                return null;
+            }
+
+            @Override
+            public Integer partition() {
+                return null;
+            }
+        };
+    }
+
+    /**
+     * Builds a batch whose records all carry the same committer, with the last
+     * one flagged as the batch terminator (the record that triggers the flush).
+     */
+    private static List<ClickHouseStruct> batch(
+            DebeziumEngine.RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>> committer,
+            long baseTs,
+            int size) {
+        List<ClickHouseStruct> records = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            ClickHouseStruct record = new ClickHouseStruct();
+            record.setDebezium_ts_ms(baseTs + i);
+            record.setCommitter(committer);
+            record.setSourceRecord(dummyChangeEvent());
+            record.setLastRecordInBatch(i == size - 1);
+            records.add(record);
+        }
+        return records;
+    }
+
+    @Test
+    @DisplayName("Concurrent acknowledgeRecords never opens two overlapping flushes")
+    public void concurrentAcknowledgeIsSerialised() throws Exception {
+        SingleFlushCommitter committer = new SingleFlushCommitter(true);
+        ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(THREADS);
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+
+        try {
+            for (int t = 0; t < THREADS; t++) {
+                final int threadIndex = t;
+                pool.submit(() -> {
+                    try {
+                        // Release all threads at once: the contention has to be
+                        // simultaneous, not staggered by thread start-up.
+                        startGate.await();
+                        for (int b = 0; b < BATCHES_PER_THREAD; b++) {
+                            long ts = 1_000_000L + threadIndex * 10_000L + b;
+                            DebeziumOffsetManagement.acknowledgeRecords(
+                                    batch(committer, ts, 3));
+                        }
+                    } catch (Throwable e) {
+                        thrown.compareAndSet(null, e);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+
+            startGate.countDown();
+            assertTrue(done.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "Commit threads did not finish — the offset path deadlocked.");
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertNull(thrown.get(),
+                "A commit thread threw. If this is 'OffsetStorageWriter is already "
+                        + "flushing', the OFFSET_COMMIT_LOCK barrier no longer covers "
+                        + "markBatchFinished() and concurrent batches corrupt the offset "
+                        + "flush: " + thrown.get());
+        assertNull(committer.failure.get(),
+                "Two threads entered the offset flush concurrently: "
+                        + committer.failure.get());
+        assertEquals(1, committer.maxConcurrent.get(),
+                "Maximum observed concurrency inside markBatchFinished() must be "
+                        + "exactly 1. Observed " + committer.maxConcurrent.get()
+                        + " — OffsetStorageWriter is single-flush, so any overlap is the "
+                        + "production ConnectException.");
+        assertEquals(THREADS * BATCHES_PER_THREAD, committer.finishCount.get(),
+                "Every batch must be finished exactly once. A shortfall means "
+                        + "offsets were never committed for some batches, which replays "
+                        + "those records after a restart.");
+    }
+
+    @Test
+    @DisplayName("markProcessed and markBatchFinished stay inside one critical section")
+    public void processedAndFinishedShareOneCriticalSection() throws Exception {
+        // Regression guard for the narrower half of the original bug: locking
+        // only markBatchFinished() leaves markProcessed() outside the barrier,
+        // so one thread can record offsets into the writer while another is
+        // flushing it. The interleaving detector below fails if a markProcessed
+        // from thread B lands between thread A's first markProcessed and its
+        // markBatchFinished.
+        AtomicBoolean interleaved = new AtomicBoolean(false);
+        AtomicReference<Thread> owner = new AtomicReference<>();
+
+        DebeziumEngine.RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>> committer =
+                new DebeziumEngine.RecordCommitter<>() {
+                    @Override
+                    public void markProcessed(ChangeEvent<SourceRecord, SourceRecord> r) {
+                        Thread self = Thread.currentThread();
+                        Thread current = owner.compareAndExchange(null, self);
+                        if (current != null && current != self) {
+                            interleaved.set(true);
+                        }
+                        try {
+                            Thread.sleep(1);
+                        } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+
+                    @Override
+                    public void markBatchFinished() {
+                        // Section closes here; releasing the ownership marker.
+                        owner.set(null);
+                    }
+
+                    @Override
+                    public void markProcessed(ChangeEvent<SourceRecord, SourceRecord> r,
+                                              DebeziumEngine.Offsets o) {
+                        markProcessed(r);
+                    }
+
+                    @Override
+                    public DebeziumEngine.Offsets buildOffsets() {
+                        return null;
+                    }
+                };
+
+        ExecutorService pool = Executors.newFixedThreadPool(4);
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(4);
+        try {
+            for (int t = 0; t < 4; t++) {
+                final int threadIndex = t;
+                pool.submit(() -> {
+                    try {
+                        startGate.await();
+                        for (int b = 0; b < 10; b++) {
+                            DebeziumOffsetManagement.acknowledgeRecords(
+                                    batch(committer,
+                                            2_000_000L + threadIndex * 1_000L + b * 10L,
+                                            3));
+                        }
+                    } catch (Throwable ignored) {
+                        // Assertion below is on the interleaving flag.
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            startGate.countDown();
+            assertTrue(done.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "Commit threads did not finish.");
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertTrue(!interleaved.get(),
+                "A second thread called markProcessed() while another thread's "
+                        + "batch was still between its first markProcessed() and its "
+                        + "markBatchFinished(). Both calls must sit inside the SAME "
+                        + "OFFSET_COMMIT_LOCK critical section — Debezium builds a new "
+                        + "RecordCommitter per batch, so the committer's own synchronized "
+                        + "methods do not exclude across threads.");
+    }
+
+    @Test
+    @DisplayName("Every in-flight batch is drained; none is stranded uncommitted")
+    public void noBatchIsStrandedInFlight() throws Exception {
+        SingleFlushCommitter committer = new SingleFlushCommitter(false);
+        ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(THREADS);
+
+        try {
+            for (int t = 0; t < THREADS; t++) {
+                final int threadIndex = t;
+                pool.submit(() -> {
+                    try {
+                        startGate.await();
+                        for (int b = 0; b < BATCHES_PER_THREAD; b++) {
+                            long ts = 3_000_000L + threadIndex * 10_000L + b * 5L;
+                            List<ClickHouseStruct> records = batch(committer, ts, 2);
+                            DebeziumOffsetManagement.addToBatchTimestamps(records);
+                            DebeziumOffsetManagement.checkIfBatchCanBeCommitted(records);
+                        }
+                    } catch (Throwable ignored) {
+                        // Drain state is asserted below.
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            startGate.countDown();
+            assertTrue(done.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "Batch threads did not finish.");
+        } finally {
+            pool.shutdownNow();
+        }
+
+        // A batch left in completedBatches after every producer has finished is
+        // a batch whose offsets were never committed: on restart the connector
+        // resumes before it and re-applies those rows.
+        int stranded = DebeziumOffsetManagement.completedBatches.size();
+        assertTrue(stranded == 0,
+                "After all producers finished, " + stranded + " batch(es) remain in "
+                        + "completedBatches with offsets never committed. Those records "
+                        + "are replayed on restart.");
+
+        assertEquals(0, DebeziumOffsetManagement.inFlightBatches.size(),
+                "in-flight batches must all be drained once every batch has been "
+                        + "processed; a leak here grows unbounded and eventually blocks "
+                        + "every commit behind a phantom overlap.");
+    }
+
+    @Test
+    @DisplayName("Overlap detection is symmetric under concurrent registration")
+    public void overlapCheckIsStableUnderConcurrentRegistration() throws Exception {
+        // checkIfThereAreInflightRequests iterates a shared ConcurrentHashMap
+        // while other threads add and remove entries. It must never throw
+        // (ConcurrentModificationException / NPE) — a throw here aborts the
+        // batch and its offsets are lost.
+        ExecutorService pool = Executors.newFixedThreadPool(6);
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(6);
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+
+        try {
+            for (int t = 0; t < 6; t++) {
+                final int threadIndex = t;
+                pool.submit(() -> {
+                    try {
+                        startGate.await();
+                        SingleFlushCommitter c = new SingleFlushCommitter(false);
+                        for (int b = 0; b < 100; b++) {
+                            List<ClickHouseStruct> records =
+                                    batch(c, 4_000_000L + threadIndex * 1_000L + b, 2);
+                            DebeziumOffsetManagement.addToBatchTimestamps(records);
+                            DebeziumOffsetManagement.checkIfThereAreInflightRequests(records);
+                            Pair<Long, Long> key =
+                                    DebeziumOffsetManagement
+                                            .calculateMinMaxTimestampFromBatch(records);
+                            DebeziumOffsetManagement.inFlightBatches.remove(key);
+                        }
+                    } catch (Throwable e) {
+                        thrown.compareAndSet(null, e);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            startGate.countDown();
+            assertTrue(done.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "Overlap-check threads did not finish.");
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertNull(thrown.get(),
+                "Concurrent overlap checking threw " + thrown.get() + ". The scan "
+                        + "runs while other threads register and retire batches, so it must "
+                        + "tolerate concurrent mutation; a throw aborts the batch and drops "
+                        + "its offset commit.");
+    }
+}


### PR DESCRIPTION
Stacked PR: based on the previous PR in the series (`omniwatcher/split-20-executor-cache`); this PR's own diff is only its listed files. Merge the series in order; after the predecessor merges, retarget this PR to `2.10.0`.

Test-only. Merge after the executor PR.

Multi-threaded race harnesses: concurrent DDL + batch threads against the schema-change waiter (DDLSchemaChangeWaiterRaceConditionTest, DDLFreezeRaceConditionTest), concurrent offset acknowledgement vs flush (OffsetCommitConcurrencyTest), executor pause visibility under the JMM (ExecutorPauseVisibilityTest), and lazy system-connection construction (LazySystemConnectionTest). Split from the executor PR only to respect the 10-file-per-PR limit.

Part of the split of #1353 into independently mergeable sub-PRs (each <= 10 files), so the 2.10.0 branch can absorb the fixes incrementally.

Split out of #1353, which this series replaces. Each sub-PR is <= 10 files; the union of all 22 reproduces the #1353 tree exactly (verified by tree SHA).