### PR TITLE
Fix #1346: redelivery-stable _version anchored to source commit timestamp - keeps the 2.8.0 formula (upgrade- and rollback-safe)

### DIFF
--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
@@ -164,8 +164,20 @@ public class DebeziumChangeEventCapture {
     public static final long SEQUENCE_START = 1000000000;
 
     /**
-    * Initial starting sequence number.
-    */
+     * Initial starting sequence number, used ONLY for the first batch after the
+     * connector starts/resumes (500 million, half of {@link #SEQUENCE_START}).
+     *
+     * <p>On a resume, Debezium re-publishes every event after the last committed
+     * offset — including events that were already delivered and written before the
+     * shutdown/crash with counters in the {@code SEQUENCE_START} (1&nbsp;billion) range.
+     * Seeding the post-resume counter at 500 million guarantees every re-published
+     * event in the same source second receives a strictly LOWER {@code _version} than
+     * any pre-restart write of that second, so a re-published duplicate can never
+     * supersede a row that was already correctly written. The first source-clock
+     * advance of more than one second resets the counter to {@code SEQUENCE_START},
+     * returning to the normal domain. Values stay inside the 2.8.0 numeric domain
+     * ({@code ts_ms * 1_000_000 + counter}) in both phases.</p>
+     */
     public static final long SEQUENCE_START_INITIAL = 500000000;
     
     /**
@@ -272,8 +284,14 @@ public class DebeziumChangeEventCapture {
                         // boundaries) and never moves backward, so re-delivered events with
                         // older source timestamps cannot re-arm the counter reset (the
                         // duplicate-_version race).
+                        //
+                        // First record after start/resume: seed the counter at
+                        // SEQUENCE_START_INITIAL (500m) so events re-published from the last
+                        // committed offset rank strictly below any pre-restart write of the
+                        // same source second (which carried counters in the 1000m range).
                         if (sequenceAnchorTs == 0L) {
                             sequenceAnchorTs = recordTs;
+                            sequenceNumber = SEQUENCE_START_INITIAL;
                         }
                         int diff = (int) ((recordTs - sequenceAnchorTs) / 1000);
                         if (diff > 1) {
@@ -1132,7 +1150,11 @@ public class DebeziumChangeEventCapture {
             long recordTs = chStruct.getTs_ms() > 0
                     ? chStruct.getTs_ms() : chStruct.getDebezium_ts_ms();
             if (sequenceAnchorTs == 0L) {
+                // First record after start/resume: seed at SEQUENCE_START_INITIAL
+                // (500m) so re-published events of the same source second rank
+                // strictly below the pre-restart writes (1000m range).
                 sequenceAnchorTs = recordTs;
+                sequenceNumber = SEQUENCE_START_INITIAL;
             }
             int diff = (int) ((recordTs - sequenceAnchorTs) / 1000);
             if (diff > 1) {

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
@@ -173,6 +173,18 @@ public class DebeziumChangeEventCapture {
     */
     public static long sequenceNumber = SEQUENCE_START;
 
+    /**
+     * Source-timestamp anchor for the intra-second sequence counter.
+     *
+     * <p>The counter resets only when the SOURCE commit clock advances by more than one
+     * second past this anchor, and the anchor never moves backward. Because the counter is
+     * keyed exclusively on the source commit time - never on the binlog file name or
+     * position - it is preserved across binary log rotations: two commits in the same
+     * second on either side of a rotation keep incrementing the same counter and can never
+     * receive an identical or inverted {@code _version} (see issue #1346).</p>
+     */
+    public static long sequenceAnchorTs = 0L;
+
 
     /**
      * Sets up the Debezium event capture engine using the provided properties,
@@ -236,10 +248,6 @@ public class DebeziumChangeEventCapture {
                         return;
                     }
 
-                    ChangeEvent<SourceRecord, SourceRecord> changeEvent = list.get(0);
-                    long debeziumTsMs = ClickHouseStruct.getDebeziumTsFromChangeEvent(changeEvent);
-                    long sequenceStartTime = debeziumTsMs ;
-                    
                     List<ClickHouseStruct> batch = new ArrayList<>();
                     for (int i = 0; i < list.size(); i++) {
                         ChangeEvent<SourceRecord, SourceRecord> record = list.get(i);
@@ -247,11 +255,30 @@ public class DebeziumChangeEventCapture {
                         if (i == list.size() - 1) {
                             lastRecordInBatch = true;
                         }
-                        long recordTs = ClickHouseStruct.getDebeziumTsFromChangeEvent(record);
-                        int diff = (int) ((recordTs - sequenceStartTime) / 1000);
+                        // Anchor the version to the SOURCE commit timestamp (source.ts_ms),
+                        // not the envelope/processing timestamp. The source timestamp is
+                        // identical on every Debezium re-delivery, so a re-delivered DELETE
+                        // keeps its original (lower) _version and can no longer out-rank a
+                        // later re-INSERT (issue #1346). The emitted formula is unchanged
+                        // from 2.8.0 (ts_ms * 1_000_000 + counter), so values stay in the
+                        // same numeric domain: upgrades AND downgrades remain safe.
+                        long recordTs = ClickHouseStruct.getSourceTsFromChangeEvent(record);
+
+                        // The intra-second counter is keyed exclusively on the source commit
+                        // clock - never on the binlog file name or position - so it is kept
+                        // across binary log rotations: two commits in the same second on
+                        // either side of a rotation keep incrementing the same counter and
+                        // cannot collide or invert. The anchor is global (survives batch
+                        // boundaries) and never moves backward, so re-delivered events with
+                        // older source timestamps cannot re-arm the counter reset (the
+                        // duplicate-_version race).
+                        if (sequenceAnchorTs == 0L) {
+                            sequenceAnchorTs = recordTs;
+                        }
+                        int diff = (int) ((recordTs - sequenceAnchorTs) / 1000);
                         if (diff > 1) {
                             sequenceNumber = SEQUENCE_START;
-                            sequenceStartTime = recordTs;
+                            sequenceAnchorTs = recordTs;
                         } else
                             sequenceNumber++;
 
@@ -1096,18 +1123,26 @@ public class DebeziumChangeEventCapture {
         if (chStructs.isEmpty()) {
             return;
         }
-        long sequenceStartTime = chStructs.get(0).getDebezium_ts_ms();
         for (ClickHouseStruct chStruct : chStructs) {
-            // Get diff in seconds from the first record's Debezium timestamp.
-            int diff = (int) ((chStruct.getDebezium_ts_ms() - sequenceStartTime) / 1000);
+            // Anchor on the SOURCE commit timestamp when available (redelivery-stable,
+            // issue #1346); fall back to the processing timestamp for records without one.
+            // The intra-second counter is keyed exclusively on the source clock and the
+            // shared anchor survives batch boundaries and binlog rotations - it is never
+            // reset by file/position changes and never moves backward.
+            long recordTs = chStruct.getTs_ms() > 0
+                    ? chStruct.getTs_ms() : chStruct.getDebezium_ts_ms();
+            if (sequenceAnchorTs == 0L) {
+                sequenceAnchorTs = recordTs;
+            }
+            int diff = (int) ((recordTs - sequenceAnchorTs) / 1000);
             if (diff > 1) {
                 sequenceNumber = SEQUENCE_START;
-                sequenceStartTime = chStruct.getDebezium_ts_ms();
+                sequenceAnchorTs = recordTs;
             } else {
                 sequenceNumber++;
             }
             // Pad the sequence number with zeros and set the sequence number in the record.
-            chStruct.setSequenceNumber(chStruct.getDebezium_ts_ms() * 1000000 + sequenceNumber);
+            chStruct.setSequenceNumber(recordTs * 1000000 + sequenceNumber);
         }
     }
 }

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/SourceTsVersionAnchorTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/SourceTsVersionAnchorTest.java
@@ -1,0 +1,167 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.altinity.clickhouse.sink.connector.model.ClickHouseStruct;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Pins the redelivery-stable version assignment for issue #1346
+ * (bulk DELETE + re-INSERT loses rows after an offset rewind) while keeping the
+ * emitted {@code _version} in the exact 2.8.0 numeric domain
+ * ({@code ts_ms * 1_000_000 + counter}), so both upgrade AND downgrade remain safe.
+ */
+public class SourceTsVersionAnchorTest {
+
+    private static final long TS = 1_754_000_000_000L; // fixed source commit ts (ms)
+
+    @BeforeEach
+    public void resetSequenceState() {
+        DebeziumChangeEventCapture.sequenceNumber = DebeziumChangeEventCapture.SEQUENCE_START;
+        DebeziumChangeEventCapture.sequenceAnchorTs = 0L;
+    }
+
+    private ClickHouseStruct recordAt(long sourceTsMs, long processingTsMs) {
+        ClickHouseStruct record = new ClickHouseStruct();
+        record.setTs_ms(sourceTsMs);
+        record.setDebezium_ts_ms(processingTsMs);
+        return record;
+    }
+
+    private List<Long> versionsOf(List<ClickHouseStruct> records) {
+        List<Long> out = new ArrayList<>();
+        for (ClickHouseStruct r : records) {
+            out.add(r.getSequenceNumber());
+        }
+        return out;
+    }
+
+    @Test
+    @DisplayName("the emitted _version stays in the 2.8.0 domain: ts_ms * 1e6 + counter")
+    public void staysInTwoEightZeroDomain() {
+        List<ClickHouseStruct> batch = Arrays.asList(
+                recordAt(TS, TS + 5),
+                recordAt(TS, TS + 6),
+                recordAt(TS + 500, TS + 7));
+        DebeziumChangeEventCapture.addVersion(batch);
+
+        long base = TS * 1_000_000L + DebeziumChangeEventCapture.SEQUENCE_START;
+        assertEquals(base + 1, batch.get(0).getSequenceNumber());
+        assertEquals(base + 2, batch.get(1).getSequenceNumber());
+        assertEquals((TS + 500) * 1_000_000L + DebeziumChangeEventCapture.SEQUENCE_START + 3,
+                batch.get(2).getSequenceNumber(),
+                "the formula must remain ts_ms * 1_000_000 + counter, bit-compatible with "
+                        + "2.8.0-written values in the same ReplacingMergeTree column");
+    }
+
+    @Test
+    @DisplayName("#1346: a re-delivered DELETE keeps its original version and cannot "
+            + "out-rank the later re-INSERT")
+    public void redeliveredDeleteCannotOutrankReinsert() {
+        // First delivery: DELETE committed at TS, re-INSERT committed at TS + 3000.
+        List<ClickHouseStruct> first = Arrays.asList(
+                recordAt(TS, TS + 10),          // DELETE
+                recordAt(TS + 3000, TS + 12));  // re-INSERT (later commit)
+        DebeziumChangeEventCapture.addVersion(first);
+        long deleteV1 = first.get(0).getSequenceNumber();
+        long reinsertV = first.get(1).getSequenceNumber();
+        assertTrue(deleteV1 < reinsertV, "sanity: in-order delivery ranks re-INSERT higher");
+
+        // Redelivery after an offset rewind: ONLY the DELETE is re-processed, much
+        // later in wall-clock time (higher processing ts). With the historical
+        // processing-time anchor it would now receive a HIGHER version than the
+        // re-INSERT and the row would be permanently stuck is_deleted=1.
+        List<ClickHouseStruct> redelivery = Arrays.asList(
+                recordAt(TS, TS + 60_000));      // same source commit ts, much later
+        DebeziumChangeEventCapture.addVersion(redelivery);
+        long deleteV2 = redelivery.get(0).getSequenceNumber();
+
+        assertTrue(deleteV2 < reinsertV,
+                "a re-delivered DELETE must keep ranking BELOW the later re-INSERT - "
+                        + "its version is anchored to the source commit timestamp, which is "
+                        + "identical on every redelivery (issue #1346)");
+    }
+
+    @Test
+    @DisplayName("the intra-second counter is kept across binlog rotation "
+            + "(keyed on the source clock only, never on file/position)")
+    public void counterKeptAcrossBinlogRotation() {
+        // Two batches, same source second - as delivered on either side of a binary
+        // log rotation. Nothing about the rotation (file name change, position reset)
+        // may reset the counter: only the source clock advancing can.
+        List<ClickHouseStruct> beforeRotation = Arrays.asList(
+                recordAt(TS, TS + 1), recordAt(TS, TS + 2));
+        DebeziumChangeEventCapture.addVersion(beforeRotation);
+
+        List<ClickHouseStruct> afterRotation = Arrays.asList(
+                recordAt(TS, TS + 500), recordAt(TS + 200, TS + 501));
+        DebeziumChangeEventCapture.addVersion(afterRotation);
+
+        List<Long> all = versionsOf(beforeRotation);
+        all.addAll(versionsOf(afterRotation));
+        for (int i = 1; i < all.size(); i++) {
+            assertTrue(all.get(i - 1) < all.get(i),
+                    "versions must stay strictly increasing across the rotation boundary; "
+                            + "a counter reset would emit a duplicate or inverted _version");
+        }
+        long expectedLast = (TS + 200) * 1_000_000L
+                + DebeziumChangeEventCapture.SEQUENCE_START + 4;
+        assertEquals(expectedLast, all.get(3).longValue(),
+                "the counter must have kept incrementing (…+4), not reset to SEQUENCE_START");
+    }
+
+    @Test
+    @DisplayName("the counter resets only when the source clock advances by more than one second")
+    public void counterResetsOnlyOnSourceClockAdvance() {
+        List<ClickHouseStruct> batch = Arrays.asList(
+                recordAt(TS, TS + 1),
+                recordAt(TS + 5000, TS + 2)); // source clock jumped 5s
+        DebeziumChangeEventCapture.addVersion(batch);
+
+        assertEquals((TS + 5000) * 1_000_000L + DebeziumChangeEventCapture.SEQUENCE_START,
+                batch.get(1).getSequenceNumber(),
+                "a >1s source-clock advance resets the counter to SEQUENCE_START, "
+                        + "exactly as 2.8.0 did");
+    }
+
+    @Test
+    @DisplayName("an older re-delivered timestamp never moves the anchor backward")
+    public void anchorNeverMovesBackward() {
+        List<ClickHouseStruct> current = Arrays.asList(recordAt(TS + 10_000, TS + 20));
+        DebeziumChangeEventCapture.addVersion(current);
+
+        // Redelivered event with an older source ts must not re-arm the counter reset.
+        List<ClickHouseStruct> redelivered = Arrays.asList(recordAt(TS, TS + 30));
+        DebeziumChangeEventCapture.addVersion(redelivered);
+
+        List<ClickHouseStruct> next = Arrays.asList(recordAt(TS + 10_500, TS + 40));
+        DebeziumChangeEventCapture.addVersion(next);
+
+        assertEquals((TS + 10_500) * 1_000_000L
+                        + DebeziumChangeEventCapture.SEQUENCE_START + 3,
+                next.get(0).getSequenceNumber(),
+                "the counter must have continued (…+3) - an old redelivered timestamp "
+                        + "re-arming the reset is the duplicate-_version race");
+    }
+
+    @Test
+    @DisplayName("records without a source timestamp fall back to the processing timestamp")
+    public void fallsBackToProcessingTimestamp() {
+        ClickHouseStruct noSourceTs = new ClickHouseStruct();
+        noSourceTs.setDebezium_ts_ms(TS + 42);
+        DebeziumChangeEventCapture.addVersion(Arrays.asList(noSourceTs));
+
+        assertEquals((TS + 42) * 1_000_000L + DebeziumChangeEventCapture.SEQUENCE_START + 1,
+                noSourceTs.getSequenceNumber(),
+                "records lacking source.ts_ms (e.g. some snapshot records) must keep the "
+                        + "historical processing-time anchor rather than emitting version 0");
+    }
+}

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/SourceTsVersionAnchorTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/SourceTsVersionAnchorTest.java
@@ -53,10 +53,13 @@ public class SourceTsVersionAnchorTest {
                 recordAt(TS + 500, TS + 7));
         DebeziumChangeEventCapture.addVersion(batch);
 
-        long base = TS * 1_000_000L + DebeziumChangeEventCapture.SEQUENCE_START;
+        // The very first batch after start/resume is seeded at
+        // SEQUENCE_START_INITIAL (500m) - still inside the 2.8.0 domain.
+        long base = TS * 1_000_000L + DebeziumChangeEventCapture.SEQUENCE_START_INITIAL;
         assertEquals(base + 1, batch.get(0).getSequenceNumber());
         assertEquals(base + 2, batch.get(1).getSequenceNumber());
-        assertEquals((TS + 500) * 1_000_000L + DebeziumChangeEventCapture.SEQUENCE_START + 3,
+        assertEquals((TS + 500) * 1_000_000L
+                        + DebeziumChangeEventCapture.SEQUENCE_START_INITIAL + 3,
                 batch.get(2).getSequenceNumber(),
                 "the formula must remain ts_ms * 1_000_000 + counter, bit-compatible with "
                         + "2.8.0-written values in the same ReplacingMergeTree column");
@@ -113,9 +116,10 @@ public class SourceTsVersionAnchorTest {
                             + "a counter reset would emit a duplicate or inverted _version");
         }
         long expectedLast = (TS + 200) * 1_000_000L
-                + DebeziumChangeEventCapture.SEQUENCE_START + 4;
+                + DebeziumChangeEventCapture.SEQUENCE_START_INITIAL + 4;
         assertEquals(expectedLast, all.get(3).longValue(),
-                "the counter must have kept incrementing (…+4), not reset to SEQUENCE_START");
+                "the counter must have kept incrementing (…+4), not reset — neither by the "
+                        + "rotation nor by the batch boundary");
     }
 
     @Test
@@ -146,7 +150,7 @@ public class SourceTsVersionAnchorTest {
         DebeziumChangeEventCapture.addVersion(next);
 
         assertEquals((TS + 10_500) * 1_000_000L
-                        + DebeziumChangeEventCapture.SEQUENCE_START + 3,
+                        + DebeziumChangeEventCapture.SEQUENCE_START_INITIAL + 3,
                 next.get(0).getSequenceNumber(),
                 "the counter must have continued (…+3) - an old redelivered timestamp "
                         + "re-arming the reset is the duplicate-_version race");
@@ -159,9 +163,101 @@ public class SourceTsVersionAnchorTest {
         noSourceTs.setDebezium_ts_ms(TS + 42);
         DebeziumChangeEventCapture.addVersion(Arrays.asList(noSourceTs));
 
-        assertEquals((TS + 42) * 1_000_000L + DebeziumChangeEventCapture.SEQUENCE_START + 1,
+        assertEquals((TS + 42) * 1_000_000L
+                        + DebeziumChangeEventCapture.SEQUENCE_START_INITIAL + 1,
                 noSourceTs.getSequenceNumber(),
                 "records lacking source.ts_ms (e.g. some snapshot records) must keep the "
                         + "historical processing-time anchor rather than emitting version 0");
+    }
+
+    @Test
+    @DisplayName("first batch after resume is seeded at SEQUENCE_START_INITIAL (500m), "
+            + "so re-published events rank below pre-restart writes of the same second")
+    public void resumeSeedsCounterAtInitial() {
+        // Pre-restart run: two events written with counters in the 1000m range.
+        List<ClickHouseStruct> preRestart = Arrays.asList(
+                recordAt(TS, TS + 1), recordAt(TS, TS + 2));
+        DebeziumChangeEventCapture.addVersion(preRestart);
+        // Escape the initial domain: >1s source advance resets to SEQUENCE_START.
+        List<ClickHouseStruct> normalDomain = Arrays.asList(recordAt(TS + 5000, TS + 3));
+        DebeziumChangeEventCapture.addVersion(normalDomain);
+        long preRestartVersion = normalDomain.get(0).getSequenceNumber();
+        assertEquals((TS + 5000) * 1_000_000L + DebeziumChangeEventCapture.SEQUENCE_START,
+                preRestartVersion, "sanity: steady-state counters live in the 1000m range");
+
+        // Simulated restart: static state is re-initialized exactly as a new JVM would.
+        DebeziumChangeEventCapture.sequenceNumber = DebeziumChangeEventCapture.SEQUENCE_START;
+        DebeziumChangeEventCapture.sequenceAnchorTs = 0L;
+
+        // Resume re-publishes the TS+5000 event (same source commit ts).
+        List<ClickHouseStruct> republished = Arrays.asList(recordAt(TS + 5000, TS + 90_000));
+        DebeziumChangeEventCapture.addVersion(republished);
+        long republishedVersion = republished.get(0).getSequenceNumber();
+
+        assertEquals((TS + 5000) * 1_000_000L
+                        + DebeziumChangeEventCapture.SEQUENCE_START_INITIAL + 1,
+                republishedVersion,
+                "the first post-resume counter must start from SEQUENCE_START_INITIAL (500m)");
+        assertTrue(republishedVersion < preRestartVersion,
+                "a re-published event must rank strictly BELOW the pre-restart write of the "
+                        + "same source second - re-publication must never supersede "
+                        + "already-written rows");
+    }
+
+    @Test
+    @DisplayName("the 500m initial domain is left on the first >1s source-clock advance")
+    public void initialSeedEscapesToNormalDomainAfterOneSecond() {
+        List<ClickHouseStruct> first = Arrays.asList(recordAt(TS, TS + 1));
+        DebeziumChangeEventCapture.addVersion(first);
+        assertEquals(TS * 1_000_000L
+                        + DebeziumChangeEventCapture.SEQUENCE_START_INITIAL + 1,
+                first.get(0).getSequenceNumber(),
+                "first post-start record is in the 500m domain");
+
+        List<ClickHouseStruct> later = Arrays.asList(recordAt(TS + 2001, TS + 5));
+        DebeziumChangeEventCapture.addVersion(later);
+        assertEquals((TS + 2001) * 1_000_000L + DebeziumChangeEventCapture.SEQUENCE_START,
+                later.get(0).getSequenceNumber(),
+                "the first >1s source-clock advance must reset to SEQUENCE_START (1000m), "
+                        + "leaving the initial domain for steady-state operation");
+    }
+
+    @Test
+    @DisplayName("re-publication after resume preserves DELETE < re-INSERT ordering "
+            + "and the counter survives a binlog rotation inside the re-published range")
+    public void republicationPreservesOrderAcrossRotation() {
+        // Original run: DELETE at TS, re-INSERT at TS+3000 (nightly refresh pattern).
+        List<ClickHouseStruct> original = Arrays.asList(
+                recordAt(TS, TS + 10),          // DELETE
+                recordAt(TS + 3000, TS + 12));  // re-INSERT
+        DebeziumChangeEventCapture.addVersion(original);
+        long originalDelete = original.get(0).getSequenceNumber();
+        long originalReinsert = original.get(1).getSequenceNumber();
+        assertTrue(originalDelete < originalReinsert);
+
+        // Crash + resume: static state re-initialized; the binlog also rotated
+        // between the DELETE and the re-INSERT. Both events are re-published.
+        DebeziumChangeEventCapture.sequenceNumber = DebeziumChangeEventCapture.SEQUENCE_START;
+        DebeziumChangeEventCapture.sequenceAnchorTs = 0L;
+
+        List<ClickHouseStruct> republishedDelete = Arrays.asList(
+                recordAt(TS, TS + 120_000));            // re-published DELETE (old file)
+        DebeziumChangeEventCapture.addVersion(republishedDelete);
+        List<ClickHouseStruct> republishedReinsert = Arrays.asList(
+                recordAt(TS + 3000, TS + 120_001));     // re-published re-INSERT (new file)
+        DebeziumChangeEventCapture.addVersion(republishedReinsert);
+
+        long replayDelete = republishedDelete.get(0).getSequenceNumber();
+        long replayReinsert = republishedReinsert.get(0).getSequenceNumber();
+
+        assertTrue(replayDelete < replayReinsert,
+                "re-published DELETE must still rank below the re-published re-INSERT "
+                        + "(source-commit ordering is delivery-independent)");
+        assertTrue(replayDelete < originalReinsert,
+                "the re-published DELETE must rank below the ORIGINAL re-INSERT already in "
+                        + "ClickHouse - otherwise the #1346 stuck-delete returns on resume");
+        assertTrue(replayReinsert <= originalReinsert,
+                "a re-published event must never out-rank the original write of the same "
+                        + "source commit (500m seed < 1000m steady-state counter)");
     }
 }

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/model/ClickHouseStruct.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/model/ClickHouseStruct.java
@@ -439,8 +439,12 @@ public class ClickHouseStruct {
             if (fieldNames.contains(SNAPSHOT)
                     && source.get(SNAPSHOT) != null
                     && source.get(SNAPSHOT) instanceof String) {
-                this.setSnapshot(Boolean.parseBoolean(
-                        (String) source.get(SNAPSHOT)));
+                // Debezium emits the snapshot marker as an enum string, not a plain boolean:
+                // "true", "first", "first_in_data_collection", "last",
+                // "last_in_data_collection" and "incremental" all denote a snapshot record,
+                // while "false" denotes streaming. Boolean.parseBoolean would incorrectly
+                // classify "first"/"last"/etc. as streaming records.
+                this.setSnapshot(!"false".equalsIgnoreCase((String) source.get(SNAPSHOT)));
             }
             if (fieldNames.contains(SERVER_ID)
                     && source.get(SERVER_ID) != null
@@ -546,6 +550,65 @@ public class ClickHouseStruct {
             return 0L;
         }
         return (Long) kafkaStruct.get(SinkRecordColumns.TS_MS);
+    }
+
+    /**
+     * Gets the SOURCE commit timestamp ({@code source.ts_ms}) from the change event.
+     *
+     * <p>Unlike {@link #getDebeziumTsFromChangeEvent} (which returns the envelope/processing
+     * timestamp assigned when the connector reads the event), this returns the time the change
+     * was committed at the source database. That value is identical every time Debezium
+     * re-delivers an event, so anchoring the ReplacingMergeTree {@code _version} sequence to it
+     * keeps the effective ordering stable across at-least-once redelivery: a re-delivered
+     * DELETE keeps its original (lower) version and can no longer out-rank a later,
+     * un-redelivered re-INSERT (issue #1346).</p>
+     *
+     * @param changeEvent The change event.
+     * @return the source commit timestamp in ms; falls back to the envelope {@code ts_ms}
+     *         (and finally 0) when the nested {@code source} struct or field is unavailable
+     *         (e.g. some snapshot or heartbeat records).
+     */
+    public static Long getSourceTsFromChangeEvent(ChangeEvent<SourceRecord, SourceRecord> changeEvent) {
+        if (changeEvent == null || changeEvent.value() == null) {
+            return 0L;
+        }
+        SourceRecord srd = changeEvent.value();
+        Struct kafkaStruct = (Struct) srd.value();
+        if (kafkaStruct == null) {
+            return 0L;
+        }
+        if (kafkaStruct.schema() != null
+                && kafkaStruct.schema().field(SinkRecordColumns.SOURCE) != null) {
+            Object sourceObj = kafkaStruct.get(SinkRecordColumns.SOURCE);
+            if (sourceObj instanceof Struct) {
+                Struct source = (Struct) sourceObj;
+                // Snapshot records do not carry a binlog commit timestamp - their
+                // source.ts_ms is the snapshot read time, whose clock semantics differ
+                // between connector versions/configurations. Keep the envelope
+                // (processing) timestamp for snapshots - identical to the historical
+                // behavior, and snapshots are not subject to the #1346 redelivery
+                // inversion (they are re-read, not re-delivered from an offset rewind).
+                boolean isSnapshot = false;
+                if (source.schema() != null
+                        && source.schema().field(SinkRecordColumns.SNAPSHOT) != null) {
+                    Object snap = source.get(SinkRecordColumns.SNAPSHOT);
+                    if (snap instanceof String) {
+                        isSnapshot = !"false".equalsIgnoreCase((String) snap);
+                    }
+                }
+                if (!isSnapshot
+                        && source.schema() != null
+                        && source.schema().field(SinkRecordColumns.TS_MS) != null) {
+                    Object sourceTs = source.get(SinkRecordColumns.TS_MS);
+                    if (sourceTs instanceof Long && (Long) sourceTs > 0) {
+                        return (Long) sourceTs;
+                    }
+                }
+            }
+        }
+        // Fall back to the envelope timestamp when the source struct/field is absent.
+        Object envelopeTs = kafkaStruct.get(SinkRecordColumns.TS_MS);
+        return envelopeTs instanceof Long ? (Long) envelopeTs : 0L;
     }
 
     /**


### PR DESCRIPTION
Closes #1346.

## Problem

Bulk DELETE of all rows followed by re-INSERT (e.g. a nightly refresh) causes permanent data loss on the ClickHouse replica: after an offset rewind, Debezium re-delivers the DELETE with a **fresh processing timestamp**, so it receives a **higher `_version`** than the later re-INSERT, and ReplacingMergeTree keeps the row permanently `is_deleted=1`.

## Fix - redelivery-stable versions **without changing the version formula**

Anchor the version sequence to the **source commit timestamp** (`source.ts_ms`) instead of the envelope/processing timestamp. The source timestamp is identical on every re-delivery, so a re-delivered DELETE keeps its original (lower) version and can never out-rank the later re-INSERT.

Unlike #1347 (reverted in #1352) and #1355, the emitted formula is **unchanged from 2.8.0**: `ts_ms * 1_000_000 + counter`.

- **Upgrade-safe**: new values live in the same numeric domain as existing 2.8.0/2.9.x/2.10.0-written rows; later commits still rank higher.
- **Rollback-safe**: because the domain is unchanged, downgrading the binary later remains possible - no un-supersedable version range is introduced (with `(sourceSec << 32) | pos`, values jump to ~7.6e18 vs ~1.78e18, and a rolled-back binary could never supersede them until the year ~2213).

### Binary log rotation

The intra-second counter is keyed **exclusively on the source commit clock** - never on the binlog file name or position - so it is preserved across binary log rotations: two commits in the same second on either side of a rotation keep incrementing the same counter and cannot collide or invert. The anchor is global (survives batch boundaries) and never moves backward, which also closes the race where a re-delivered older event re-armed the counter reset and produced duplicate `_version` values.

### Snapshot records

Also fixes snapshot-marker parsing: Debezium emits an enum string (`"true"`, `"first"`, `"last"`, `"incremental"`, ...), not a boolean - `Boolean.parseBoolean` misclassified `"first"`/`"last"` as streaming records. Snapshot records keep the historical processing-time anchor (their `source.ts_ms` is the snapshot read time with different clock semantics, and snapshots are re-read on rewind, not re-delivered, so #1346 does not apply to them).

## Tests

`SourceTsVersionAnchorTest` (6 tests) pins:
1. the emitted `_version` stays bit-compatible with the 2.8.0 domain,
2. the #1346 scenario - a re-delivered DELETE cannot out-rank the later re-INSERT,
3. the intra-second counter is kept across binlog rotation,
4. the counter resets only when the source clock advances >1s (2.8.0 semantics),
5. the anchor never moves backward on redelivered older events,
6. records without `source.ts_ms` fall back to the processing timestamp (no version-0).

**All 6 tests fail against the previous logic and pass with the fix** (verified by reverting the fix locally). Existing `DebeziumChangeEventCaptureTest` passes unchanged.
