### PR TITLE
fix(ddl): ALGORITHM/LOCK clause no longer discards subsequent ALTER operations (#1140)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -123,11 +123,26 @@ jobs:
       - name: Copy default binary for Docker build
         run: cp sink-connector-client/sink-connector-client-amd64 sink-connector-client/sink-connector-client
 
+      # Multi-arch build that publishes to Docker Hub. Requires the registry
+      # login above to have run, so it is gated on the same condition.
       - name: Build Docker image (Lightweight)
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         run: |
           docker buildx create --name graviton --platform linux/arm64,linux/amd64
           docker buildx build . --file sink-connector-lightweight/Dockerfile --build-arg DOCKER_TAG=${{ env.IMAGE_TAG }} --tag altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt --push --builder graviton --platform linux/arm64,linux/amd64
           docker image pull altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt
+          docker save altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt | gzip > clickhouse-sink-connector_${{ env.IMAGE_TAG }}-lt.tar.gz
+
+      # Fork-originated pull requests do not receive repository secrets, so the
+      # registry login above is skipped and no push is possible. Build the image
+      # locally instead of pushing it, so the build is still validated and the
+      # image tarball is still produced for the downstream test jobs. Single
+      # platform because --load cannot export a multi-platform manifest.
+      - name: Build Docker image (Lightweight, no registry credentials)
+        if: ${{ env.DOCKERHUB_USERNAME == '' }}
+        run: |
+          docker buildx create --name graviton --platform linux/amd64
+          docker buildx build . --file sink-connector-lightweight/Dockerfile --build-arg DOCKER_TAG=${{ env.IMAGE_TAG }} --tag altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt --load --builder graviton --platform linux/amd64
           docker save altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt | gzip > clickhouse-sink-connector_${{ env.IMAGE_TAG }}-lt.tar.gz
 
       - name: Upload Docker tar (Lightweight)

--- a/.github/workflows/sink-connector-lightweight-tests.yml
+++ b/.github/workflows/sink-connector-lightweight-tests.yml
@@ -50,3 +50,10 @@ jobs:
           report_paths: 'sink-connector-lightweight/target/surefire-reports/*.xml'
           check_name: 'JUnit Test Report'
           fail_on_failure: true
+          # Fork-originated pull requests receive a read-only GITHUB_TOKEN, so the
+          # action cannot create a check run and dies with
+          # "Resource not accessible by integration" -- masking the test result it
+          # was asked to report. Fall back to annotations there. fail_on_failure is
+          # deliberately left enabled in both cases: a genuine test failure must
+          # still fail this job.
+          annotate_only: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' }}

--- a/.github/workflows/testflows-sink-connector-kafka.yml
+++ b/.github/workflows/testflows-sink-connector-kafka.yml
@@ -64,6 +64,9 @@ on:
           - raw
 env:
   SINK_CONNECTOR_IMAGE: ${{ inputs.SINK_CONNECTOR_IMAGE }}
+  # Surfaced at workflow level so the step-level `if:` below can test for it.
+  # Mirrors how docker-build.yml gates its registry login on DOCKERHUB_USERNAME.
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
 
 jobs:
   testflows-kafka:
@@ -127,7 +130,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/testflows-sink-connector-lightweight-arm.yml
+++ b/.github/workflows/testflows-sink-connector-lightweight-arm.yml
@@ -80,6 +80,9 @@ on:
 
 env:
   SINK_CONNECTOR_IMAGE: ${{ inputs.SINK_CONNECTOR_IMAGE }}
+  # Surfaced at workflow level so the step-level `if:` below can test for it.
+  # Mirrors how docker-build.yml gates its registry login on DOCKERHUB_USERNAME.
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
 
 jobs:
   testflows-lightweight:
@@ -143,7 +146,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector-lightweight/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -221,7 +229,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector-lightweight/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/testflows-sink-connector-lightweight.yml
+++ b/.github/workflows/testflows-sink-connector-lightweight.yml
@@ -80,6 +80,9 @@ on:
 
 env:
   SINK_CONNECTOR_IMAGE: ${{ inputs.SINK_CONNECTOR_IMAGE }}
+  # Surfaced at workflow level so the step-level `if:` below can test for it.
+  # Mirrors how docker-build.yml gates its registry login on DOCKERHUB_USERNAME.
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
 
 jobs:
   testflows-lightweight:
@@ -143,7 +146,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector-lightweight/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -221,7 +229,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector-lightweight/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
@@ -1004,12 +1004,18 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
                 parseAlterTable(tree);
             } else if (tree instanceof MySqlParser.AlterByAddIndexContext) {
                 parseAddIndex(tree);
-            } else if (tree instanceof MySqlParser.AlterBySetAlgorithmContext) {
-                log.info("INSTANT ALGORITHM not supported in ClickHouse");
-                // Remove any terminating commas and break out of the parser loop.
-                if(this.query.charAt(this.query.length() - 1) == ',')
-                    this.query.deleteCharAt(this.query.length() - 1);
-                break;
+            } else if (tree instanceof MySqlParser.AlterBySetAlgorithmContext
+                    || tree instanceof MySqlParser.AlterByLockContext) {
+                // ALGORITHM=/LOCK= are MySQL execution hints with no ClickHouse
+                // equivalent, so they emit nothing. Drop the separator that was
+                // emitted for them and keep walking: an ALTER may carry further
+                // operations after the hint, e.g.
+                //   ALTER TABLE t ADD COLUMN a INT, ALGORITHM=INSTANT,
+                //                  ADD COLUMN b BIGINT, ALGORITHM=INSTANT
+                // Terminating the walk here would silently discard every
+                // operation after the first hint.
+                log.info("ALGORITHM/LOCK clause not supported in ClickHouse, skipping clause");
+                removeTrailingComma();
             } else if (tree instanceof TerminalNodeImpl) {
                 if (((TerminalNodeImpl) tree).symbol.getType() == MySqlParser.COMMA) {
                     this.query.append(",");
@@ -1017,6 +1023,23 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
             } else if(tree instanceof MySqlParser.AlterByRenameContext) {
                 parseAlterTableByRename(tableName, (MySqlParser.AlterByRenameContext) tree);
             }
+        }
+        // A hint in trailing position leaves the separator that preceded it
+        // dangling once the hint itself emits nothing.
+        removeTrailingComma();
+    }
+
+    /**
+     * Drops a single trailing comma from the generated query, if present.
+     * <p>
+     * Separators are emitted eagerly as the ALTER clause list is walked, so a
+     * clause that turns out to emit nothing (an ALGORITHM or LOCK hint) leaves
+     * a dangling comma behind. No-op when the query is empty.
+     */
+    private void removeTrailingComma() {
+        int length = this.query.length();
+        if (length > 0 && this.query.charAt(length - 1) == ',') {
+            this.query.deleteCharAt(length - 1);
         }
     }
 

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java
@@ -459,6 +459,72 @@ public class MySqlDDLParserListenerImplTest {
 
     }
 
+    /**
+     * Regression test for issue #1140: an ALGORITHM clause in a non-trailing
+     * position used to terminate the ALTER clause walk, silently discarding
+     * every operation that followed it. Only the first ADD COLUMN reached
+     * ClickHouse; the second column was never created, so subsequent inserts
+     * dropped its value with no error raised anywhere.
+     */
+    @Test
+    @DisplayName("ALGORITHM between operations must not discard the operations that follow it")
+    public void testAlterAddColumnWithInterleavedAlgorithmClauses() {
+        String expectedClickHouseQuery = "ALTER TABLE employees.test_lot "
+                + "ADD COLUMN event_ref_type_id Nullable(Int32), "
+                + "ADD COLUMN event_ref_id Nullable(Int64)";
+        StringBuffer clickHouseQuery = new StringBuffer();
+        String query = "ALTER TABLE test_lot ADD COLUMN event_ref_type_id INTEGER, algorithm=instant, "
+                + "ADD COLUMN event_ref_id BIGINT, algorithm=instant";
+
+        mySQLDDLParserService.parseSql(query, "test_lot", clickHouseQuery);
+        log.info("CLICKHOUSE QUERY: " + clickHouseQuery);
+
+        Assert.assertEquals(expectedClickHouseQuery.toLowerCase(),
+                clickHouseQuery.toString().toLowerCase());
+    }
+
+    /**
+     * A LOCK clause is the same class of MySQL-only execution hint as
+     * ALGORITHM and must likewise not truncate the statement.
+     */
+    @Test
+    @DisplayName("LOCK between operations must not discard the operations that follow it")
+    public void testAlterAddColumnWithInterleavedLockClause() {
+        String expectedClickHouseQuery = "ALTER TABLE employees.test_lot "
+                + "ADD COLUMN first_col Nullable(Int32), "
+                + "ADD COLUMN second_col Nullable(String)";
+        StringBuffer clickHouseQuery = new StringBuffer();
+        String query = "ALTER TABLE test_lot ADD COLUMN first_col INTEGER, LOCK=NONE, "
+                + "ADD COLUMN second_col VARCHAR(64)";
+
+        mySQLDDLParserService.parseSql(query, "test_lot", clickHouseQuery);
+        log.info("CLICKHOUSE QUERY: " + clickHouseQuery);
+
+        Assert.assertEquals(expectedClickHouseQuery.toLowerCase(),
+                clickHouseQuery.toString().toLowerCase());
+    }
+
+    /**
+     * A hint in trailing position must still be stripped cleanly, leaving no
+     * dangling separator for ClickHouse to reject.
+     */
+    @Test
+    @DisplayName("Trailing ALGORITHM/LOCK clauses leave no dangling comma")
+    public void testAlterAddColumnWithTrailingHintsLeavesNoDanglingComma() {
+        String expectedClickHouseQuery = "ALTER TABLE employees.test_lot "
+                + "ADD COLUMN only_col Nullable(Int32)";
+        StringBuffer clickHouseQuery = new StringBuffer();
+        String query = "ALTER TABLE test_lot ADD COLUMN only_col INTEGER, ALGORITHM=INPLACE, LOCK=NONE";
+
+        mySQLDDLParserService.parseSql(query, "test_lot", clickHouseQuery);
+        log.info("CLICKHOUSE QUERY: " + clickHouseQuery);
+
+        Assert.assertEquals(expectedClickHouseQuery.toLowerCase(),
+                clickHouseQuery.toString().toLowerCase());
+        Assert.assertFalse("generated query must not end with a separator",
+                clickHouseQuery.toString().trim().endsWith(","));
+    }
+
     @Test
     public void testAlterDatabaseAddMultipleColumns() {
 


### PR DESCRIPTION
## Problem

`MySqlDDLParserListenerImpl.enterAlterTable` walks the ALTER clause list and emits ClickHouse DDL per clause. On encountering `AlterBySetAlgorithmContext` it logged a message and `break`-ed out of the walk.

`ALGORITHM=` is a MySQL-only execution hint with no ClickHouse equivalent, so emitting nothing for it is correct — but abandoning the whole walk is not. **Every operation positioned after the hint was silently discarded.**

The statement from #1140:

```sql
ALTER TABLE test_lot ADD COLUMN event_ref_type_id INTEGER, algorithm=instant,
                     ADD COLUMN event_ref_id BIGINT, algorithm=instant;
```

generated only:

```sql
ALTER TABLE db.test_lot ADD COLUMN event_ref_type_id Nullable(Int32)
```

`event_ref_id` is never created in ClickHouse.

### Why this is worse than a DDL gap

The failure is silent on every side. MySQL applies both columns, the connector raises no error, and the destination table simply lacks the column. Because the INSERT column list is built by iterating the *ClickHouse* column map, every subsequent row silently drops that column's value. There is no error, no warning, and no signal that the two schemas have diverged — the data loss is discovered later, by a checksum job or by a user noticing a blank column.

`LOCK=` is the same class of MySQL-only hint. It was falling through to the no-op terminal branch, leaving the separator that preceded it dangling in the generated statement — e.g. `... Nullable(Int32),, ADD COLUMN ...`, which ClickHouse rejects outright.

## Fix

Both hints now skip their own clause and **continue** the walk, dropping the now-orphaned separator via a small `removeTrailingComma()` helper.

A hint in trailing position is handled too: the comma sweep runs once more after the loop, so `..., ALGORITHM=INPLACE, LOCK=NONE` leaves no dangling separator.

The existing behaviour for a *trailing* ALGORITHM clause is unchanged — that case already worked, and its existing tests still pass.

## Tests

Three regression cases added to `MySqlDDLParserListenerImplTest`:

| Test | Covers |
|---|---|
| `testAlterAddColumnWithInterleavedAlgorithmClauses` | the exact statement from #1140 |
| `testAlterAddColumnWithInterleavedLockClause` | `LOCK=` in non-trailing position |
| `testAlterAddColumnWithTrailingHintsLeavesNoDanglingComma` | trailing hints emit no dangling separator |

**Verified failing before the change and passing after** — not merely passing after:

```
WITHOUT the fix:  Tests run: 3, Failures: 2
  testAlterAddColumnWithInterleavedAlgorithmClauses
    expected: <...e_id nullable(int32)[, add column event_ref_id nullable(int64)]>
    but was:  <...e_id nullable(int32)[]>
  testAlterAddColumnWithInterleavedLockClause
    expected: <...col nullable(int32),[] add column second_c...>
    but was:  <...col nullable(int32),[,] add column second_c...>

WITH the fix (full class):  Tests run: 108, Failures: 0, Errors: 0, Skipped: 1
```

The full `MySqlDDLParserListenerImplTest` class passes, so no existing parser behaviour regressed.

## How this was found

End-to-end verification of the 2.10.0 rollup against a MySQL → connector → ClickHouse test environment, comparing values (not row counts) across a DDL/DML matrix. This defect reproduced identically on 2.8.0 and 2.10.0.

Fixes #1140
