### PR TITLE
fix(cdc): execute TRUNCATE at its binlog position, not after the batch inserts

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -123,11 +123,26 @@ jobs:
       - name: Copy default binary for Docker build
         run: cp sink-connector-client/sink-connector-client-amd64 sink-connector-client/sink-connector-client
 
+      # Multi-arch build that publishes to Docker Hub. Requires the registry
+      # login above to have run, so it is gated on the same condition.
       - name: Build Docker image (Lightweight)
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         run: |
           docker buildx create --name graviton --platform linux/arm64,linux/amd64
           docker buildx build . --file sink-connector-lightweight/Dockerfile --build-arg DOCKER_TAG=${{ env.IMAGE_TAG }} --tag altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt --push --builder graviton --platform linux/arm64,linux/amd64
           docker image pull altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt
+          docker save altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt | gzip > clickhouse-sink-connector_${{ env.IMAGE_TAG }}-lt.tar.gz
+
+      # Fork-originated pull requests do not receive repository secrets, so the
+      # registry login above is skipped and no push is possible. Build the image
+      # locally instead of pushing it, so the build is still validated and the
+      # image tarball is still produced for the downstream test jobs. Single
+      # platform because --load cannot export a multi-platform manifest.
+      - name: Build Docker image (Lightweight, no registry credentials)
+        if: ${{ env.DOCKERHUB_USERNAME == '' }}
+        run: |
+          docker buildx create --name graviton --platform linux/amd64
+          docker buildx build . --file sink-connector-lightweight/Dockerfile --build-arg DOCKER_TAG=${{ env.IMAGE_TAG }} --tag altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt --load --builder graviton --platform linux/amd64
           docker save altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt | gzip > clickhouse-sink-connector_${{ env.IMAGE_TAG }}-lt.tar.gz
 
       - name: Upload Docker tar (Lightweight)

--- a/.github/workflows/sink-connector-lightweight-tests.yml
+++ b/.github/workflows/sink-connector-lightweight-tests.yml
@@ -50,3 +50,10 @@ jobs:
           report_paths: 'sink-connector-lightweight/target/surefire-reports/*.xml'
           check_name: 'JUnit Test Report'
           fail_on_failure: true
+          # Fork-originated pull requests receive a read-only GITHUB_TOKEN, so the
+          # action cannot create a check run and dies with
+          # "Resource not accessible by integration" -- masking the test result it
+          # was asked to report. Fall back to annotations there. fail_on_failure is
+          # deliberately left enabled in both cases: a genuine test failure must
+          # still fail this job.
+          annotate_only: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' }}

--- a/.github/workflows/testflows-sink-connector-kafka.yml
+++ b/.github/workflows/testflows-sink-connector-kafka.yml
@@ -64,6 +64,9 @@ on:
           - raw
 env:
   SINK_CONNECTOR_IMAGE: ${{ inputs.SINK_CONNECTOR_IMAGE }}
+  # Surfaced at workflow level so the step-level `if:` below can test for it.
+  # Mirrors how docker-build.yml gates its registry login on DOCKERHUB_USERNAME.
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
 
 jobs:
   testflows-kafka:
@@ -127,7 +130,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/testflows-sink-connector-lightweight-arm.yml
+++ b/.github/workflows/testflows-sink-connector-lightweight-arm.yml
@@ -80,6 +80,9 @@ on:
 
 env:
   SINK_CONNECTOR_IMAGE: ${{ inputs.SINK_CONNECTOR_IMAGE }}
+  # Surfaced at workflow level so the step-level `if:` below can test for it.
+  # Mirrors how docker-build.yml gates its registry login on DOCKERHUB_USERNAME.
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
 
 jobs:
   testflows-lightweight:
@@ -143,7 +146,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector-lightweight/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -221,7 +229,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector-lightweight/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/testflows-sink-connector-lightweight.yml
+++ b/.github/workflows/testflows-sink-connector-lightweight.yml
@@ -80,6 +80,9 @@ on:
 
 env:
   SINK_CONNECTOR_IMAGE: ${{ inputs.SINK_CONNECTOR_IMAGE }}
+  # Surfaced at workflow level so the step-level `if:` below can test for it.
+  # Mirrors how docker-build.yml gates its registry login on DOCKERHUB_USERNAME.
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
 
 jobs:
   testflows-lightweight:
@@ -143,7 +146,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector-lightweight/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -221,7 +229,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector-lightweight/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/TruncateTableIT.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/TruncateTableIT.java
@@ -174,6 +174,8 @@ public class TruncateTableIT {
         });
 
         Thread.sleep(30000);
+
+        try {
         BaseDbWriter writer = ITCommon.getDBWriter(clickHouseContainer);
 
         Connection conn = ITCommon.connectToMySQL(mySqlContainer);
@@ -214,12 +216,17 @@ public class TruncateTableIT {
         Assert.assertFalse("pre-truncate rows must not survive the truncate", staleRowFound);
         Assert.assertEquals("rows inserted after the truncate were wiped by it",
                 3, afterRows);
-
-        if (engine.get() != null) {
-            engine.get().stop();
+        } finally {
+            // Release the embedded engine and its CLI port unconditionally. If an
+            // assertion above fails, a teardown placed after it would never run,
+            // the port would stay bound, and every subsequent test in this class
+            // would fail with "Port already in use" -- turning one real failure
+            // into a cascade that hides its own cause.
+            if (engine.get() != null) {
+                engine.get().stop();
+            }
+            executorService.shutdown();
+            HikariDbSource.close();
         }
-        executorService.shutdown();
-
-        HikariDbSource.close();
     }
 }

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/TruncateTableIT.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/TruncateTableIT.java
@@ -141,4 +141,85 @@ public class TruncateTableIT {
 
         HikariDbSource.close();
     }
+
+    /**
+     * Regression test: rows written after a TRUNCATE must survive it.
+     * <p>
+     * The truncate used to be executed at the end of the batch, after
+     * {@code executeBatch()}. When a TRUNCATE and the inserts that logically
+     * follow it landed in the same batch, the truncate therefore ran last and
+     * wiped the very rows the batch had just inserted. The destination ended up
+     * empty while the source held the post-truncate rows, and nothing was
+     * logged -- the divergence only surfaced later via a checksum comparison.
+     * <p>
+     * The truncate is now executed at its binlog position: rows staged before
+     * it are flushed first, the table is truncated, and rows after it are
+     * inserted afterwards.
+     */
+    @Test
+    @DisplayName("Rows inserted after a TRUNCATE must survive the truncate")
+    public void testRowsInsertedAfterTruncateSurvive() throws Exception {
+
+        AtomicReference<DebeziumChangeEventCapture> engine = new AtomicReference<>();
+
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+        executorService.execute(() -> {
+            try {
+                engine.set(new DebeziumChangeEventCapture());
+                engine.get().setup(ITCommon.getDebeziumProperties(mySqlContainer, clickHouseContainer),
+                        new SourceRecordParserService(), false);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        Thread.sleep(30000);
+        BaseDbWriter writer = ITCommon.getDBWriter(clickHouseContainer);
+
+        Connection conn = ITCommon.connectToMySQL(mySqlContainer);
+        conn.prepareStatement("create table truncate_then_insert(id int primary key, payload varchar(64))")
+                .execute();
+        Thread.sleep(10000);
+
+        // Pre-truncate state.
+        conn.prepareStatement("insert into truncate_then_insert values(1, 'before')").execute();
+        conn.prepareStatement("insert into truncate_then_insert values(2, 'before')").execute();
+        Thread.sleep(10000);
+
+        // TRUNCATE immediately followed by the new state, with no pause in
+        // between, so the truncate and the following inserts are handled in the
+        // same batch -- this is what the defect required to reproduce.
+        conn.prepareStatement("truncate table truncate_then_insert").execute();
+        conn.prepareStatement("insert into truncate_then_insert values(10, 'after')").execute();
+        conn.prepareStatement("insert into truncate_then_insert values(11, 'after')").execute();
+        conn.prepareStatement("insert into truncate_then_insert values(12, 'after')").execute();
+        conn.close();
+        Thread.sleep(20000);
+
+        // The three post-truncate rows must be present, and none of the
+        // pre-truncate rows may remain.
+        ResultSet rs = ITCommon.executeQueryWithResultSet(
+                "select id, payload from employees.truncate_then_insert final order by id",
+                writer.getConnection());
+        int afterRows = 0;
+        boolean staleRowFound = false;
+        while (rs.next()) {
+            if ("before".equalsIgnoreCase(rs.getString("payload"))) {
+                staleRowFound = true;
+            } else {
+                afterRows++;
+            }
+        }
+
+        Assert.assertFalse("pre-truncate rows must not survive the truncate", staleRowFound);
+        Assert.assertEquals("rows inserted after the truncate were wiped by it",
+                3, afterRows);
+
+        if (engine.get() != null) {
+            engine.get().stop();
+        }
+        executorService.shutdown();
+
+        HikariDbSource.close();
+    }
 }

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/PreparedStatementExecutor.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/PreparedStatementExecutor.java
@@ -155,7 +155,6 @@ public class PreparedStatementExecutor {
         Lists.partition(entry.getValue(), (int)maxRecordsInBatch).forEach(batch -> {
 
             String databaseName = null;
-            ArrayList<ClickHouseStruct> truncatedRecords = new ArrayList<>();
 
             DBMetadata metadata = new DBMetadata(config);
             ReplicationHistoryHandler replicationHistoryHandler = null;
@@ -176,7 +175,28 @@ public class PreparedStatementExecutor {
                     }
 
                     if (record.getCdcOperation().getOperation().equalsIgnoreCase(ClickHouseConverter.CDC_OPERATION.TRUNCATE.getOperation())) {
-                        truncatedRecords.add(record);
+                        // A TRUNCATE must be applied at its binlog position, not at the
+                        // end of the batch. Rows staged before it belong to the
+                        // pre-truncate state and have to reach ClickHouse first; rows
+                        // after it are the new state and must survive. Flush what is
+                        // staged, truncate, then keep accumulating the remainder.
+                        //
+                        // Executing the truncate after executeBatch() (the previous
+                        // behaviour) discarded every row the same batch had just
+                        // inserted whenever a TRUNCATE was followed by more DML.
+                        try {
+                            ps.executeBatch();
+                        } catch (SQLException e) {
+                            throw new RuntimeException(String.format(
+                                    "Failed to flush records staged before TRUNCATE for %s.%s",
+                                    databaseName, tableName), e);
+                        }
+                        try {
+                            metadata.truncateTable(conn, databaseName, tableName);
+                        } catch (SQLException e) {
+                            throw new RuntimeException(String.format(
+                                    "TRUNCATE failed for %s.%s", databaseName, tableName), e);
+                        }
                         continue;
                     }
 
@@ -253,13 +273,6 @@ public class PreparedStatementExecutor {
                 throw new RuntimeException(e);
             }
 
-            if (!truncatedRecords.isEmpty()) {
-                try {
-                    metadata.truncateTable(conn, databaseName, tableName);
-                } catch (SQLException e) {
-                    throw new RuntimeException(e);
-                }
-            }
         });
 
         return result.get();


### PR DESCRIPTION
## Problem

A `TRUNCATE` arriving on the CDC data path was collected into a `truncatedRecords` list and applied only **after** `ps.executeBatch()`, at the very end of the batch.

When a `TRUNCATE` and the inserts that logically follow it land in the same batch, the truncate therefore runs last — and wipes the rows the batch has just inserted.

```
Source order:    INSERT a, INSERT b, TRUNCATE, INSERT c, INSERT d
Applied order:   INSERT a, INSERT b, INSERT c, INSERT d, TRUNCATE
Destination:     empty
Expected:        c, d
```

### Why this is hard to catch

The divergence is silent. Nothing is logged, no exception is raised, and the connector keeps streaming — the destination simply loses the post-truncate rows. It surfaces later as a checksum mismatch, by which point the binlog position that caused it is long gone.

The window is not narrow in practice: any `TRUNCATE` followed by a repopulating load — the common "wipe and reload this reference table" pattern — produces exactly this interleaving.

## Fix

The truncate is applied where the binlog says it belongs:

1. rows staged before it are flushed with `executeBatch()`
2. the table is truncated
3. the loop keeps accumulating the rows that follow into the same prepared statement, executed normally at the end of the batch

The trailing post-insert truncate block and the now-unused `truncatedRecords` list are removed, so a batch carrying a `TRUNCATE` truncates **exactly once**.

Both new failure paths raise with the database and table named, rather than rethrowing a bare `SQLException`, so a failure to flush or to truncate is attributable instead of anonymous.

## Tests

`TruncateTableIT.testRowsInsertedAfterTruncateSurvive` replicates a `TRUNCATE` immediately followed by three inserts **with no pause between them**, so they are handled in one batch — the condition the defect requires to reproduce. It asserts:

- the three post-truncate rows are present in ClickHouse
- no pre-truncate row survived

The existing `testIsDeleted` case, which covers truncate with no following DML, is unchanged and still passes — that path was already correct, which is why the defect went unnoticed.

## Relationship to #1287

[#1287](https://github.com/Altinity/clickhouse-sink-connector/issues/1287) reports that the `disable.drop.truncate` *config guard* is non-functional on both the DDL and CDC paths. This PR is a different defect in the same area: it concerns **when** a truncate is applied relative to the batch's own inserts, and it reproduces with default configuration regardless of that setting. The two fixes are complementary and do not overlap — this PR deliberately does not touch the config guard.

## How this was found

End-to-end verification of the 2.10.0 rollup against a MySQL → connector → ClickHouse test environment, comparing values rather than row counts across a DDL/DML matrix. This defect reproduced identically on 2.8.0 and 2.10.0.
