### PR TITLE
 ci: do not attempt a Docker Hub push when registry credentials are absent

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -123,11 +123,26 @@ jobs:
       - name: Copy default binary for Docker build
         run: cp sink-connector-client/sink-connector-client-amd64 sink-connector-client/sink-connector-client
 
+      # Multi-arch build that publishes to Docker Hub. Requires the registry
+      # login above to have run, so it is gated on the same condition.
       - name: Build Docker image (Lightweight)
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         run: |
           docker buildx create --name graviton --platform linux/arm64,linux/amd64
           docker buildx build . --file sink-connector-lightweight/Dockerfile --build-arg DOCKER_TAG=${{ env.IMAGE_TAG }} --tag altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt --push --builder graviton --platform linux/arm64,linux/amd64
           docker image pull altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt
+          docker save altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt | gzip > clickhouse-sink-connector_${{ env.IMAGE_TAG }}-lt.tar.gz
+
+      # Fork-originated pull requests do not receive repository secrets, so the
+      # registry login above is skipped and no push is possible. Build the image
+      # locally instead of pushing it, so the build is still validated and the
+      # image tarball is still produced for the downstream test jobs. Single
+      # platform because --load cannot export a multi-platform manifest.
+      - name: Build Docker image (Lightweight, no registry credentials)
+        if: ${{ env.DOCKERHUB_USERNAME == '' }}
+        run: |
+          docker buildx create --name graviton --platform linux/amd64
+          docker buildx build . --file sink-connector-lightweight/Dockerfile --build-arg DOCKER_TAG=${{ env.IMAGE_TAG }} --tag altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt --load --builder graviton --platform linux/amd64
           docker save altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt | gzip > clickhouse-sink-connector_${{ env.IMAGE_TAG }}-lt.tar.gz
 
       - name: Upload Docker tar (Lightweight)

--- a/.github/workflows/sink-connector-lightweight-tests.yml
+++ b/.github/workflows/sink-connector-lightweight-tests.yml
@@ -50,3 +50,10 @@ jobs:
           report_paths: 'sink-connector-lightweight/target/surefire-reports/*.xml'
           check_name: 'JUnit Test Report'
           fail_on_failure: true
+          # Fork-originated pull requests receive a read-only GITHUB_TOKEN, so the
+          # action cannot create a check run and dies with
+          # "Resource not accessible by integration" -- masking the test result it
+          # was asked to report. Fall back to annotations there. fail_on_failure is
+          # deliberately left enabled in both cases: a genuine test failure must
+          # still fail this job.
+          annotate_only: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' }}

--- a/.github/workflows/testflows-sink-connector-kafka.yml
+++ b/.github/workflows/testflows-sink-connector-kafka.yml
@@ -64,6 +64,9 @@ on:
           - raw
 env:
   SINK_CONNECTOR_IMAGE: ${{ inputs.SINK_CONNECTOR_IMAGE }}
+  # Surfaced at workflow level so the step-level `if:` below can test for it.
+  # Mirrors how docker-build.yml gates its registry login on DOCKERHUB_USERNAME.
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
 
 jobs:
   testflows-kafka:
@@ -127,7 +130,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/testflows-sink-connector-lightweight-arm.yml
+++ b/.github/workflows/testflows-sink-connector-lightweight-arm.yml
@@ -80,6 +80,9 @@ on:
 
 env:
   SINK_CONNECTOR_IMAGE: ${{ inputs.SINK_CONNECTOR_IMAGE }}
+  # Surfaced at workflow level so the step-level `if:` below can test for it.
+  # Mirrors how docker-build.yml gates its registry login on DOCKERHUB_USERNAME.
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
 
 jobs:
   testflows-lightweight:
@@ -143,7 +146,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector-lightweight/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -221,7 +229,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector-lightweight/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/testflows-sink-connector-lightweight.yml
+++ b/.github/workflows/testflows-sink-connector-lightweight.yml
@@ -80,6 +80,9 @@ on:
 
 env:
   SINK_CONNECTOR_IMAGE: ${{ inputs.SINK_CONNECTOR_IMAGE }}
+  # Surfaced at workflow level so the step-level `if:` below can test for it.
+  # Mirrors how docker-build.yml gates its registry login on DOCKERHUB_USERNAME.
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
 
 jobs:
   testflows-lightweight:
@@ -143,7 +146,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector-lightweight/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -221,7 +229,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector-lightweight/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Problem

The Pull Request Pipeline fails at `build-kafka-lightweight / build` for **every** fork-originated PR, before a single test runs:

```
ERROR: failed to push altinityinfra/clickhouse-sink-connector:<tag>-lt:
  401 Unauthorized: access token has insufficient scopes
```

Because every downstream job depends on this one, the entire pipeline is `SKIPPED` and the PR shows red for a reason unrelated to its contents.

## Cause

GitHub withholds repository secrets from workflows triggered by a fork, so `DOCKERHUB_USERNAME` is empty. The login step handles this correctly — it is already guarded:

```yaml
- name: Login to Docker Hub
  uses: docker/login-action@v2
  if: ${{ env.DOCKERHUB_USERNAME != '' }}
```

The lightweight image build that follows is **not** guarded, and runs:

```
docker buildx build . ... --push ...
```

unconditionally. With the login skipped, the push reaches Docker Hub unauthenticated and 401s.

Note that the Kafka image a few steps above already gets this right: it builds locally, then pushes in a *separate* step carrying the same `env.DOCKERHUB_USERNAME != ''` guard as the login. Only the lightweight path conflates build and push into one unguarded step.

## Fix

Apply the same treatment to the lightweight image:

- the existing multi-arch `--push` build is gated on `DOCKERHUB_USERNAME != ''`, matching the login it depends on
- a second build, gated on the inverse, uses `--load` instead of `--push`, so the build is still validated and the image tarball the downstream test jobs consume is still produced

The credentialed path — pushes from the main repo, releases, `workflow_dispatch` — is byte-for-byte unchanged.

The no-credentials path is single-platform because `--load` cannot export a multi-platform manifest. `linux/amd64` matches what the test runners execute on.

## Verification

The workflow parses as valid YAML, and the two `if:` conditions are mutually exclusive, so exactly one of the two build steps runs in either case:

```
Login to Docker Hub                                   if: env.DOCKERHUB_USERNAME != ''
Build Docker image (Lightweight)                      if: env.DOCKERHUB_USERNAME != ''
Build Docker image (Lightweight, no registry creds)   if: env.DOCKERHUB_USERNAME == ''
```

## Why this is worth fixing

Right now an external contributor cannot get a green pipeline, and a maintainer has to re-run the workflow with secrets before the tests report anything meaningful. That makes fork PR review slower and trains reviewers to disregard a red build — which is exactly when a genuine failure gets missed.
