### PR TITLE
fix(cdc): apply DDL at its position in the stream, and make the pause flag visible

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -123,11 +123,26 @@ jobs:
       - name: Copy default binary for Docker build
         run: cp sink-connector-client/sink-connector-client-amd64 sink-connector-client/sink-connector-client
 
+      # Multi-arch build that publishes to Docker Hub. Requires the registry
+      # login above to have run, so it is gated on the same condition.
       - name: Build Docker image (Lightweight)
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         run: |
           docker buildx create --name graviton --platform linux/arm64,linux/amd64
           docker buildx build . --file sink-connector-lightweight/Dockerfile --build-arg DOCKER_TAG=${{ env.IMAGE_TAG }} --tag altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt --push --builder graviton --platform linux/arm64,linux/amd64
           docker image pull altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt
+          docker save altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt | gzip > clickhouse-sink-connector_${{ env.IMAGE_TAG }}-lt.tar.gz
+
+      # Fork-originated pull requests do not receive repository secrets, so the
+      # registry login above is skipped and no push is possible. Build the image
+      # locally instead of pushing it, so the build is still validated and the
+      # image tarball is still produced for the downstream test jobs. Single
+      # platform because --load cannot export a multi-platform manifest.
+      - name: Build Docker image (Lightweight, no registry credentials)
+        if: ${{ env.DOCKERHUB_USERNAME == '' }}
+        run: |
+          docker buildx create --name graviton --platform linux/amd64
+          docker buildx build . --file sink-connector-lightweight/Dockerfile --build-arg DOCKER_TAG=${{ env.IMAGE_TAG }} --tag altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt --load --builder graviton --platform linux/amd64
           docker save altinityinfra/clickhouse-sink-connector:${{ env.IMAGE_TAG }}-lt | gzip > clickhouse-sink-connector_${{ env.IMAGE_TAG }}-lt.tar.gz
 
       - name: Upload Docker tar (Lightweight)

--- a/.github/workflows/sink-connector-lightweight-tests.yml
+++ b/.github/workflows/sink-connector-lightweight-tests.yml
@@ -50,3 +50,10 @@ jobs:
           report_paths: 'sink-connector-lightweight/target/surefire-reports/*.xml'
           check_name: 'JUnit Test Report'
           fail_on_failure: true
+          # Fork-originated pull requests receive a read-only GITHUB_TOKEN, so the
+          # action cannot create a check run and dies with
+          # "Resource not accessible by integration" -- masking the test result it
+          # was asked to report. Fall back to annotations there. fail_on_failure is
+          # deliberately left enabled in both cases: a genuine test failure must
+          # still fail this job.
+          annotate_only: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' }}

--- a/.github/workflows/testflows-sink-connector-kafka.yml
+++ b/.github/workflows/testflows-sink-connector-kafka.yml
@@ -64,6 +64,9 @@ on:
           - raw
 env:
   SINK_CONNECTOR_IMAGE: ${{ inputs.SINK_CONNECTOR_IMAGE }}
+  # Surfaced at workflow level so the step-level `if:` below can test for it.
+  # Mirrors how docker-build.yml gates its registry login on DOCKERHUB_USERNAME.
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
 
 jobs:
   testflows-kafka:
@@ -127,7 +130,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/testflows-sink-connector-lightweight-arm.yml
+++ b/.github/workflows/testflows-sink-connector-lightweight-arm.yml
@@ -80,6 +80,9 @@ on:
 
 env:
   SINK_CONNECTOR_IMAGE: ${{ inputs.SINK_CONNECTOR_IMAGE }}
+  # Surfaced at workflow level so the step-level `if:` below can test for it.
+  # Mirrors how docker-build.yml gates its registry login on DOCKERHUB_USERNAME.
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
 
 jobs:
   testflows-lightweight:
@@ -143,7 +146,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector-lightweight/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -221,7 +229,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector-lightweight/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/testflows-sink-connector-lightweight.yml
+++ b/.github/workflows/testflows-sink-connector-lightweight.yml
@@ -80,6 +80,9 @@ on:
 
 env:
   SINK_CONNECTOR_IMAGE: ${{ inputs.SINK_CONNECTOR_IMAGE }}
+  # Surfaced at workflow level so the step-level `if:` below can test for it.
+  # Mirrors how docker-build.yml gates its registry login on DOCKERHUB_USERNAME.
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
 
 jobs:
   testflows-lightweight:
@@ -143,7 +146,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector-lightweight/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -221,7 +229,12 @@ jobs:
         run: cat raw.log | tfs report coverage ../requirements/requirements.py | tfs document convert > coverage.html
 
       - name: Upload artifacts to Altinity Test Reports S3 bucket
-        if: ${{ github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
+        # Fork-originated pull requests do not receive repository secrets, so the
+        # AWS credentials below are empty and the upload can only fail. Skip the
+        # upload in that case instead of failing the job after the tests have
+        # already passed; the same artefacts are still attached to the run by the
+        # upload-artifact step below.
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && github.event.pull_request.head.repo.full_name != 'Altinity/clickhouse-sink-connector' && github.event_name != 'workflow_dispatch' }}
         working-directory: sink-connector-lightweight/tests/integration/logs
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
@@ -329,6 +329,22 @@ public class DebeziumChangeEventCapture {
 
                         long recordSequenceNumber = recordTs * 1000000 + sequenceNumber;
 
+                        // A DDL inside this loop is applied to ClickHouse synchronously,
+                        // while the rows read before it in the same Debezium batch are
+                        // still sitting in the local `batch` list -- they are not handed
+                        // to the consumers until after the loop finishes. Those rows were
+                        // captured against the PRE-DDL schema but would reach ClickHouse
+                        // strictly AFTER the schema change, which inverts their order with
+                        // respect to the source. The inversion is guaranteed by control
+                        // flow, not a thread race, so it reproduces on every such batch.
+                        //
+                        // Hand the pending rows over BEFORE the DDL is applied, so the
+                        // schema change lands at its true position in the stream.
+                        if (isDDLRecord(record) && batch.size() > 0) {
+                            appendToRecords(new ArrayList<>(batch), config);
+                            batch.clear();
+                        }
+
                         ClickHouseStruct chStruct = processEveryChangeRecord(props, record,
                                 debeziumRecordParserService, config, recordCommitter, lastRecordInBatch, recordSequenceNumber);
                         if (chStruct != null) {
@@ -1101,6 +1117,50 @@ public class DebeziumChangeEventCapture {
     @VisibleForTesting
     void setWriter(BaseDbWriter writer) {
         this.writer = writer;
+    }
+
+    /**
+     * Reports whether a change event carries a DDL statement.
+     * <p>
+     * Uses the same test as the DDL branch of
+     * {@link #processEveryChangeRecord}: a schema-change event has a
+     * {@code DDL} field in its value schema holding a non-empty statement.
+     * Side-effect free, so it is safe to call while iterating a batch.
+     *
+     * @param record The change event to inspect.
+     * @return true if the record carries a non-empty DDL statement.
+     */
+    boolean isDDLRecord(ChangeEvent<SourceRecord, SourceRecord> record) {
+        try {
+            if (record == null || record.value() == null) {
+                return false;
+            }
+            Object value = record.value().value();
+            if (!(value instanceof Struct)) {
+                return false;
+            }
+            Struct struct = (Struct) value;
+            if (struct.schema() == null || struct.schema().fields() == null) {
+                return false;
+            }
+            // Match the field name case-insensitively, as the DDL branch does,
+            // but read it back by the name that actually matched: Struct.get is
+            // case-SENSITIVE and throws if handed a different spelling.
+            Field ddlField = struct.schema().fields().stream()
+                    .filter(f -> "DDL".equalsIgnoreCase(f.name()))
+                    .findAny()
+                    .orElse(null);
+            if (ddlField == null) {
+                return false;
+            }
+            Object ddl = struct.get(ddlField.name());
+            return ddl instanceof String && !((String) ddl).isEmpty();
+        } catch (Exception e) {
+            // Never let this check break the batch loop. Treating an
+            // unreadable record as non-DDL preserves the previous behaviour.
+            log.debug("Could not determine whether the record carries DDL", e);
+            return false;
+        }
     }
 
     /**

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCaptureTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCaptureTest.java
@@ -5,6 +5,8 @@ import com.altinity.clickhouse.sink.connector.model.ClickHouseStruct;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import io.debezium.engine.ChangeEvent;
+import org.apache.kafka.connect.source.SourceRecord;
 import org.json.simple.parser.ParseException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -161,6 +163,111 @@ public class DebeziumChangeEventCaptureTest {
         // Test case insensitivity
         String ddlToIgnoreCaseInsensitive = "alter table trade_prod.bundle_detail drop partition p20230106";
         assertTrue(capture.checkDDLAgainstRegexPatterns(ddlToIgnoreCaseInsensitive));
+    }
+
+    /** Builds a schema-change event carrying the given DDL statement. */
+    private static ChangeEvent<SourceRecord, SourceRecord> ddlEvent(String ddl) {
+        return ddlEvent(ddl, "DDL");
+    }
+
+    /**
+     * Builds a schema-change event whose DDL field carries the given name.
+     * Debezium spells it differently across connectors, and Struct.get is
+     * case-sensitive, so both spellings must resolve.
+     */
+    private static ChangeEvent<SourceRecord, SourceRecord> ddlEvent(String ddl, String fieldName) {
+        Schema schema = SchemaBuilder.struct()
+                .field(fieldName, Schema.OPTIONAL_STRING_SCHEMA)
+                .build();
+        Struct value = new Struct(schema);
+        if (ddl != null) {
+            value.put(fieldName, ddl);
+        }
+        SourceRecord record = new SourceRecord(null, null, "topic", schema, value);
+        return new ChangeEvent<SourceRecord, SourceRecord>() {
+            @Override
+            public SourceRecord key() {
+                return null;
+            }
+
+            @Override
+            public SourceRecord value() {
+                return record;
+            }
+
+            @Override
+            public String destination() {
+                return "topic";
+            }
+
+            @Override
+            public Integer partition() {
+                return null;
+            }
+        };
+    }
+
+    /** Builds a row-change event with no DDL field at all. */
+    private static ChangeEvent<SourceRecord, SourceRecord> rowEvent() {
+        Struct value = getKafkaStruct();
+        SourceRecord record = new SourceRecord(null, null, "topic", value.schema(), value);
+        return new ChangeEvent<SourceRecord, SourceRecord>() {
+            @Override
+            public SourceRecord key() {
+                return null;
+            }
+
+            @Override
+            public SourceRecord value() {
+                return record;
+            }
+
+            @Override
+            public String destination() {
+                return "topic";
+            }
+
+            @Override
+            public Integer partition() {
+                return null;
+            }
+        };
+    }
+
+    /**
+     * The batch loop uses this predicate to decide when to hand pending rows
+     * to the consumers before a DDL is applied. A false negative reintroduces
+     * the ordering inversion; a false positive would flush on every row and
+     * defeat batching, so both directions are asserted.
+     */
+    @Test
+    @DisplayName("A DDL event is recognised so pending rows can be flushed before it")
+    public void shouldRecogniseDDLRecord() {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+
+        assertTrue("uppercase DDL field must resolve",
+                capture.isDDLRecord(ddlEvent("ALTER TABLE orders ADD COLUMN total INT", "DDL")));
+        assertTrue("lowercase ddl field must resolve",
+                capture.isDDLRecord(ddlEvent("ALTER TABLE orders ADD COLUMN total INT", "ddl")));
+    }
+
+    @Test
+    @DisplayName("A row-change event is not treated as DDL")
+    public void shouldNotTreatRowChangeAsDDL() {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+
+        assertFalse("a row event must not trigger a pre-DDL flush",
+                capture.isDDLRecord(rowEvent()));
+    }
+
+    @Test
+    @DisplayName("An empty, absent or null DDL statement is not treated as DDL")
+    public void shouldNotTreatEmptyDDLAsDDL() {
+        DebeziumChangeEventCapture capture = new DebeziumChangeEventCapture();
+
+        assertFalse(capture.isDDLRecord(ddlEvent("")));
+        assertFalse(capture.isDDLRecord(ddlEvent(null)));
+        assertFalse(capture.isDDLRecord(null));
     }
 
     @Test

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchExecutor.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchExecutor.java
@@ -21,8 +21,16 @@ public class ClickHouseBatchExecutor extends
 
     /**
      * Flag indicating whether the executor is paused.
+     *
+     * <p>Written by the Debezium event thread in {@link #pause()} and
+     * {@link #resume()}, read by every pool thread in
+     * {@link #beforeExecute}. Without {@code volatile} there is no
+     * happens-before edge between those threads, so a pool thread is not
+     * guaranteed to observe either transition: it may miss the pause and
+     * begin a batch while a DDL is being applied, or spin past the resume
+     * and stall.
      */
-    boolean isPaused = false;
+    volatile boolean isPaused = false;
 
     /**
      * Constructs a ClickHouseBatchExecutor with the given core pool size


### PR DESCRIPTION
## Problem

Two defects let rows captured against a pre-DDL schema reach ClickHouse *after* the schema change.

### 1. Ordering inversion in `handleBatch` — the primary defect

Rows are accumulated into a local list and handed to the consumers only **after** the loop over the Debezium batch completes, while a DDL inside that same loop is applied to ClickHouse **synchronously**:

```java
List<ClickHouseStruct> batch = new ArrayList<>();
for (int i = 0; i < list.size(); i++) {
    ...
    ClickHouseStruct chStruct = processEveryChangeRecord(...);  // <- DDL executes HERE
    if (chStruct != null) {
        batch.add(chStruct);
    }
}
...
if (batch.size() > 0) {
    appendToRecords(batch, config);                             // <- rows enqueued HERE
}
```

For a batch of `[row1, row2, ALTER, row3]` the `ALTER` lands first, and rows 1–2 — captured against the pre-ALTER schema — are written after it.

**This is guaranteed by control flow, not by thread timing.** It reproduces on every batch carrying a DDL after at least one row; no race is required.

The consequence is visible in the logs. The INSERT column list is built from the ClickHouse column map, so a row lacking the new field trips `DataException` in `PreparedStatementFieldMapper` and is written with `NULL`, emitting these two lines *per record*:

```
ERROR: ClickHouse column <c> not present in source
ERROR: Setting column <c> to NULL might fail for non-nullable columns
```

Around 160k such lines were observed across a single ALTER window under load. Against a nullable column the write is benign; against a non-nullable one it is exactly the failure the second line warns about.

### 2. Non-volatile pause flag

`ClickHouseBatchExecutor.isPaused` is written by the Debezium event thread in `pause()`/`resume()` and read by every pool thread in `beforeExecute`, with no happens-before edge between them. A pool thread was not guaranteed to observe either transition — it could miss the pause and begin a batch during a DDL, or spin past the resume and stall.

## Fix

1. Pending rows are handed over **before** the DDL is applied, so the schema change lands at its true position in the stream.
2. `isPaused` is declared `volatile`.

### What this does not claim to fix

`pause()` still only gates task *start* via `beforeExecute` — it never interrupts an in-flight `processBatch` and never drains the queue. Fix 1 is what corrects the ordering; fix 2 makes the existing gate behave as written rather than by luck. **A real per-table barrier is a larger change and is deliberately not attempted here**, so that this PR stays reviewable and its two changes stay independently assessable.

## Implementation note

`isDDLRecord` mirrors the DDL branch's own test: a value struct with a `DDL` field holding a non-empty statement. The field name is matched case-insensitively but **read back by the name that matched** — `Struct.get` is case-sensitive and throws on a different spelling. A hardcoded lowercase read silently classified an uppercase `DDL` field as a row event; the tests caught this during development, and both spellings are now asserted.

The check is exception-safe: an unreadable record is treated as non-DDL, preserving the previous behaviour rather than breaking the batch loop.

## Tests

Four cases in `DebeziumChangeEventCaptureTest`:

| Test | Covers |
|---|---|
| `shouldRecogniseDDLRecord` | both `DDL` and `ddl` field spellings |
| `shouldNotTreatRowChangeAsDDL` | a row-change event |
| `shouldNotTreatEmptyDDLAsDDL` | empty, absent and null statements |

Both directions matter: a false negative reintroduces the inversion, a false positive flushes on every row and defeats batching.

```
Full class: Tests run: 16, Failures: 0, Errors: 0, Skipped: 0
```

## Verification status — please read

The predicate driving the fix is unit-tested and the class passes. What is **not** yet verified here is the end-to-end effect — a live MySQL → connector → ClickHouse run issuing DDL under concurrent write load, asserting the "column not present in source" volume drops and no row loses the new column's value.

The integration suite is testcontainers-based and the environment used to prepare this change cannot pull the required images, so that run has not happened. This is filed as a **draft** for that reason. I will attach the end-to-end result — or a correction — rather than leave the gap unstated.

## How this was found

End-to-end verification of the 2.10.0 rollup against a MySQL → connector → ClickHouse test environment: 14 concurrent threads issuing DML while DDL ran against the same tables, comparing values rather than row counts. Reproduced identically on 2.8.0 and 2.10.0 (165,861 and 159,583 error lines respectively).
