### PR TITLE
fix(test): CI testCompile fails, BitBytesTest imports absent Mockito

### DIFF
--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapperBitBytesTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapperBitBytesTest.java
@@ -6,8 +6,9 @@ import io.debezium.data.Bits;
 import org.apache.kafka.connect.data.Schema;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
 import java.nio.ByteBuffer;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -34,34 +35,84 @@ import java.util.HashMap;
  * end-to-end on MySQL 8.0.36 -&gt; sink connector -&gt; ClickHouse 24.8.14:
  * {@code BIT(8)} values 0x80/0xAA/0xFF all landed as hex EFBFBD with
  * {@code length()=3} instead of 1.
+ *
+ * <p>The recording {@link PreparedStatement} below is a {@link Proxy}, matching
+ * the JDBC test-double idiom already used by {@code ClosedConnectionRefreshTest}
+ * and {@code SystemConnectionRefreshTest}. This module has no mocking framework
+ * on its test classpath, and one is not needed to observe a single setter.
  */
 public class ClickHouseDataTypeMapperBitBytesTest {
+
+    /**
+     * Records the single {@code setXxx} call {@code convert()} makes for a
+     * BYTES value, so the test can assert on the exact value bound to the
+     * statement.
+     */
+    private static final class RecordingStatement {
+        private String stringValue;
+        private byte[] bytesValue;
+        private int callCount;
+
+        private final PreparedStatement statement = (PreparedStatement) Proxy.newProxyInstance(
+                PreparedStatement.class.getClassLoader(),
+                new Class<?>[]{PreparedStatement.class},
+                handler());
+
+        private InvocationHandler handler() {
+            return (proxy, method, args) -> {
+                switch (method.getName()) {
+                    case "setString":
+                        callCount++;
+                        stringValue = (String) args[1];
+                        return null;
+                    case "setBytes":
+                        callCount++;
+                        bytesValue = (byte[]) args[1];
+                        return null;
+                    case "toString":
+                        return "RecordingStatement";
+                    case "hashCode":
+                        return System.identityHashCode(proxy);
+                    case "equals":
+                        return proxy == args[0];
+                    default:
+                        // Nothing else is expected on the BYTES path. Failing
+                        // loudly keeps an unnoticed behaviour change from
+                        // silently satisfying these assertions.
+                        throw new AssertionError(
+                                "unexpected PreparedStatement call: " + method.getName());
+                }
+            };
+        }
+    }
 
     private static ClickHouseSinkConnectorConfig config() {
         return new ClickHouseSinkConnectorConfig(new HashMap<>());
     }
 
-    private static void convertBits(Object value, PreparedStatement ps) throws SQLException {
+    /**
+     * Drives the BYTES branch exactly as the writer does and returns the value
+     * bound to the statement. {@code persist.raw.bytes} defaults to false, so
+     * the hex-encoding path is the one exercised here.
+     */
+    private static String convertBits(Object value) throws SQLException {
+        RecordingStatement recorder = new RecordingStatement();
         ClickHouseDataTypeMapper.convert(
-                Schema.Type.BYTES, Bits.LOGICAL_NAME, value, 1, ps, config(),
+                Schema.Type.BYTES, Bits.LOGICAL_NAME, value, 1, recorder.statement, config(),
                 ClickHouseDataType.String, ZoneId.of("UTC"));
+        Assertions.assertEquals(1, recorder.callCount,
+                "expected exactly one binding call for a BYTES value");
+        Assertions.assertNull(recorder.bytesValue,
+                "persist.raw.bytes defaults to false, so setBytes must not be used");
+        return recorder.stringValue;
     }
 
     /** Every high-bit byte must survive; before the fix all three became EF BF BD. */
     @Test
     public void bitHighBytesAreNotReplacedWithUtf8ReplacementChar() throws SQLException {
-        byte[][] payloads = {
-            new byte[] {(byte) 0x80},
-            new byte[] {(byte) 0xAA},
-            new byte[] {(byte) 0xFF},
-        };
-        String[] expected = {"80", "aa", "ff"};
-
-        for (int i = 0; i < payloads.length; i++) {
-            PreparedStatement ps = Mockito.mock(PreparedStatement.class);
-            convertBits(payloads[i], ps);
-            Mockito.verify(ps).setString(1, expected[i]);
-        }
+        Assertions.assertEquals("80", convertBits(new byte[] {(byte) 0x80}));
+        Assertions.assertEquals("aa", convertBits(new byte[] {(byte) 0xAA}));
+        Assertions.assertEquals("ff", convertBits(new byte[] {(byte) 0xFF}));
     }
 
     /** BIT(64) of all ones must not collapse to eight replacement characters. */
@@ -70,19 +121,13 @@ public class ClickHouseDataTypeMapperBitBytesTest {
         byte[] allOnes = new byte[8];
         Arrays.fill(allOnes, (byte) 0xFF);
 
-        PreparedStatement ps = Mockito.mock(PreparedStatement.class);
-        convertBits(allOnes, ps);
-
-        Mockito.verify(ps).setString(1, "ffffffffffffffff");
+        Assertions.assertEquals("ffffffffffffffff", convertBits(allOnes));
     }
 
     /** Low bytes were already correct and must stay byte-identical. */
     @Test
     public void bitLowBytesAreUnchanged() throws SQLException {
-        PreparedStatement ps = Mockito.mock(PreparedStatement.class);
-        convertBits(new byte[] {0x01, 0x7F}, ps);
-
-        Mockito.verify(ps).setString(1, "017f");
+        Assertions.assertEquals("017f", convertBits(new byte[] {0x01, 0x7F}));
     }
 
     /**
@@ -93,20 +138,13 @@ public class ClickHouseDataTypeMapperBitBytesTest {
     public void byteArrayAndByteBufferAgree() throws SQLException {
         byte[] payload = {(byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF};
 
-        PreparedStatement fromArray = Mockito.mock(PreparedStatement.class);
-        convertBits(payload, fromArray);
-
-        PreparedStatement fromBuffer = Mockito.mock(PreparedStatement.class);
-        convertBits(ByteBuffer.wrap(payload), fromBuffer);
-
-        Mockito.verify(fromArray).setString(1, "deadbeef");
-        Mockito.verify(fromBuffer).setString(1, "deadbeef");
+        Assertions.assertEquals("deadbeef", convertBits(payload));
+        Assertions.assertEquals("deadbeef", convertBits(ByteBuffer.wrap(payload)));
     }
 
     /** A zero-length BIT payload must not throw. */
     @Test
     public void emptyPayloadIsHandled() {
-        PreparedStatement ps = Mockito.mock(PreparedStatement.class);
-        Assertions.assertDoesNotThrow(() -> convertBits(new byte[0], ps));
+        Assertions.assertDoesNotThrow(() -> Assertions.assertEquals("", convertBits(new byte[0])));
     }
 }


### PR DESCRIPTION
Created by OmniWatcher on behalf of the Jump Trading DBA team. **Marked WIP / DO NOT MERGE: we do not own this repository — please review and merge at your discretion.**

## The failure

The Pull Request Pipeline on #1304 is red. `build-kafka-lightweight / build` fails at `testCompile`, and every downstream job — `checksum-tests-lightweight`, `testflows-lightweight-x86`, `testflows-lightweight-x86-hikari-pool`, `java-tests-kafka`, `java-tests-lightweight`, `publish-lightweight-jar` — is `SKIPPED` behind it. One compile error is the entire red pipeline.

```
[ERROR] ClickHouseDataTypeMapperBitBytesTest.java:[9,19] package org.mockito does not exist
```

[Run 32498447256, job 96822329785](https://github.com/Altinity/clickhouse-sink-connector/actions/runs/32498447256/job/96822329785).

## Root cause

`ClickHouseDataTypeMapperBitBytesTest`, added by #1387 (`0a73fc8`), imports `org.mockito.Mockito`. The `sink-connector` module has no Mockito on its test classpath — and neither does any other module in this repository:

```
$ grep -rl "org.mockito" . --include=*.java --include=*.xml
./sink-connector/src/test/java/.../ClickHouseDataTypeMapperBitBytesTest.java
```

The only hit is the offending file itself. The pom comment `<!--Mockito for unit test-->` (`sink-connector/pom.xml:410`) sits above a `com.github.stefanbirkner:system-rules` dependency, and the import was written against that misleading label. The class never compiled anywhere.

This is my error in #1387 and I am fixing it rather than leaving it for you.

## The fix

Rewrite the recording `PreparedStatement` as a `java.lang.reflect.Proxy` — the JDBC test-double idiom this module already uses in `ClosedConnectionRefreshTest` and `SystemConnectionRefreshTest`. Observing a single setter call does not need a mocking framework, so the build is fixed **without adding a dependency to a shared module**.

The double is deliberately *stricter* than the Mockito version it replaces. It asserts exactly one binding call occurs, asserts `setBytes` is never used (`persist.raw.bytes` defaults to `false`, so the hex path is the one under test), and throws `AssertionError` on any unexpected `PreparedStatement` method instead of silently returning a default.

Coverage is unchanged — the same five cases: high-byte round-trip (0x80/0xAA/0xFF), `BIT(64)` all-ones, low bytes unchanged, `byte[]`/`ByteBuffer` agreement, empty payload.

**No production code is touched.** The `ClickHouseDataTypeMapper` fix from #1387 is byte-for-byte unmodified; `git diff --stat` is one test file, +71/−33.

## Verification (maven 3.9.11, JDK 17)

| Check | Result |
|---|---|
| `mvn -B package install -DskipTests=true --file pom.xml` in `sink-connector` — the exact command CI runs | **BUILD SUCCESS**; reproduces the identical `package org.mockito does not exist` before this change |
| `ClickHouseDataTypeMapperBitBytesTest` | **5/5 pass** |
| Failing-first proof | Reverting `ClickHouseDataTypeMapper` to its pre-#1387 state gives **4 of 5 failures**, with exactly the corruption being guarded: `expected: <80> but was: <�>`, `expected: <ffffffffffffffff> but was: <��������>`. Restored, 5/5 pass. |
| Full module suite `mvn test` | 171 run, 0 failures, **20 errors** |

Those 20 errors are all testcontainers `Could not find a valid Docker environment`, and they are **not** caused by this change or by #1387: the untouched baseline `ec4faa5` (the commit immediately before #1387 landed) produces **the same 20 errors** on the same host — 166 run / 20 errors there vs 171 run / 20 errors here, the delta being exactly the 5 tests this file adds. My build host has no Docker daemon; your CI runners do, so those suites will execute normally there.

## What this PR does not address

Two data-integrity defects confirmed still present in `1304-8fc8e9ae...-lt` during our end-to-end testing (MySQL 8.0.36 ROW/FULL/GTID to connector to ClickHouse 24.8.14). Naming them rather than omitting them silently; both are pre-existing, neither is a regression, and both predate #1386/#1387:

1. **DDL rename/add NULL-fills buffered rows.** Rows buffered before an `ALTER ... CHANGE COLUMN` are written against the post-rename schema, so the renamed and newly-added columns land as `NULL` while MySQL holds real values. Row counts still match, so a count-based checksum job reports the table clean. #1321's column-visibility waiter is active and does not prevent it.
2. **A table with a UNIQUE key but no PRIMARY KEY is auto-created with an empty sort key** (`ORDER BY tuple()`), so ReplacingMergeTree collapses every row into one — 5 rows in MySQL became 1 in ClickHouse. The obvious fix is wrong: ordering by all data columns trades total collapse for permanent duplication, since an `UPDATE` to any non-key column yields a different sorting key and both versions survive `FINAL`. A correct fix must key on the source's stable row identity.

Happy to follow up on either if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
