### PR TITLE
fix: no-PK tables collapse to one row; pre-ALTER rows NULL-fill added columns

### DIFF
--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
@@ -277,7 +277,20 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
     public void enterColumnCreateTable(MySqlParser.ColumnCreateTableContext columnCreateTableContext) {
         StringBuilder orderByColumns = new StringBuilder();
         StringBuilder partitionByColumn = new StringBuilder();
-        Set<String> columnNames = parseCreateTable(columnCreateTableContext, orderByColumns, partitionByColumn);
+        StringBuilder uniqueKeyColumns = new StringBuilder();
+        Set<String> columnNames = parseCreateTable(columnCreateTableContext, orderByColumns, partitionByColumn,
+                uniqueKeyColumns);
+
+        // A table with a UNIQUE key but no PRIMARY KEY would otherwise be created
+        // with ORDER BY tuple(): every row compares equal, so ReplacingMergeTree
+        // collapses the whole table into one row. The UNIQUE key is the source's
+        // stable row identity, so use it as the sorting key. Only applied when no
+        // PRIMARY KEY was found -- the PRIMARY KEY always wins.
+        if (orderByColumns.length() == 0 && uniqueKeyColumns.length() > 0) {
+            log.info("Table has no PRIMARY KEY; using UNIQUE key as the ClickHouse sorting key: "
+                    + uniqueKeyColumns);
+            orderByColumns.append(uniqueKeyColumns);
+        }
 
         String isDeletedColumn = IS_DELETED_COLUMN;
 
@@ -500,6 +513,29 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
      */
     private Set<String> parseCreateTable(MySqlParser.CreateTableContext ctx, StringBuilder orderByColumns,
                                          StringBuilder partitionByColumns) {
+        return parseCreateTable(ctx, orderByColumns, partitionByColumns, new StringBuilder());
+    }
+
+    /**
+     * Overload that additionally collects the first UNIQUE key of the table.
+     *
+     * <p>A MySQL table may declare a UNIQUE key but no PRIMARY KEY. Such a
+     * table was previously created as
+     * {@code ReplacingMergeTree(...) ORDER BY tuple()}: with an empty sorting
+     * key every row compares equal, so ReplacingMergeTree collapses the entire
+     * table down to a single row. The UNIQUE key is the source's stable row
+     * identity, which is exactly what the sorting key must be, so it is used
+     * as the fallback when no PRIMARY KEY is present.</p>
+     *
+     * @param ctx The context of the CREATE TABLE statement.
+     * @param orderByColumns A StringBuilder to store the PRIMARY KEY columns.
+     * @param partitionByColumns A StringBuilder to store the PARTITION BY columns.
+     * @param uniqueKeyColumns A StringBuilder receiving the first UNIQUE key
+     *                         declared, used only when no PRIMARY KEY exists.
+     * @return A set of column names defined in the CREATE TABLE statement.
+     */
+    private Set<String> parseCreateTable(MySqlParser.CreateTableContext ctx, StringBuilder orderByColumns,
+                                         StringBuilder partitionByColumns, StringBuilder uniqueKeyColumns) {
         List<ParseTree> pt = ctx.children;
         Set<String> columnNames = new HashSet<>();
 
@@ -532,7 +568,7 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
                         // Do nothing for TerminalNodeImpl, just skip it
                     } else if (subtree instanceof MySqlParser.ColumnDeclarationContext) {
                         // Parse column definitions
-                        parseColumnDefinitions(subtree, orderByColumns, columnNames);
+                        parseColumnDefinitions(subtree, orderByColumns, columnNames, uniqueKeyColumns);
                     } else if(subtree instanceof MySqlParser.ConstraintDeclarationContext) {
                         for (ParseTree constraintTree: ((MySqlParser.ConstraintDeclarationContext) subtree).children) {
                             if (constraintTree instanceof MySqlParser.PrimaryKeyTableConstraintContext) {
@@ -541,6 +577,21 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
                                         String primaryKeyColumns = primaryKeyTree.getText();
                                         if (primaryKeyColumns != null && !primaryKeyColumns.isEmpty()) {
                                             orderByColumns.append(primaryKeyColumns);
+                                        }
+                                    }
+                                }
+                            } else if (constraintTree instanceof MySqlParser.UniqueKeyTableConstraintContext) {
+                                // Table-level: UNIQUE KEY (col, ...). Only the FIRST unique
+                                // key is retained; it is used as the sorting key when the
+                                // table declares no PRIMARY KEY.
+                                if (uniqueKeyColumns.length() == 0) {
+                                    for (ParseTree uniqueKeyTree: ((MySqlParser.UniqueKeyTableConstraintContext) constraintTree).children) {
+                                        if (uniqueKeyTree instanceof MySqlParser.IndexColumnNamesContext) {
+                                            String uniqueColumns = uniqueKeyTree.getText();
+                                            if (uniqueColumns != null && !uniqueColumns.isEmpty()) {
+                                                uniqueKeyColumns.append(uniqueColumns);
+                                            }
+                                            break;
                                         }
                                     }
                                 }
@@ -606,6 +657,22 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
      * @param columnNames A set to hold the column names parsed from the statement.
      */
     private void parseColumnDefinitions(ParseTree subtree, StringBuilder orderByColumns, Set<String> columnNames) {
+        parseColumnDefinitions(subtree, orderByColumns, columnNames, new StringBuilder());
+    }
+
+    /**
+     * Overload that additionally records a column-level {@code UNIQUE}
+     * constraint (for example {@code uk INT NOT NULL UNIQUE}) so that a table
+     * without a PRIMARY KEY can still be given a real sorting key.
+     *
+     * @param subtree The parse subtree of the column declaration.
+     * @param orderByColumns A StringBuilder to append PRIMARY KEY columns to.
+     * @param columnNames A set to hold the column names parsed from the statement.
+     * @param uniqueKeyColumns A StringBuilder receiving the first UNIQUE column,
+     *                         used only when no PRIMARY KEY exists.
+     */
+    private void parseColumnDefinitions(ParseTree subtree, StringBuilder orderByColumns, Set<String> columnNames,
+                                        StringBuilder uniqueKeyColumns) {
         String columnName = null;
         String colDataType = null;
         boolean isNullColumn = true;
@@ -633,6 +700,15 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
                             isNullColumn = false;
                             orderByColumns.append(columnName);
                             break;
+                        }
+                    } else if (colDefinitionChildTree instanceof MySqlParser.UniqueKeyColumnConstraintContext) {
+                        // Column-level: `uk INT NOT NULL UNIQUE`. Retained only as a
+                        // fallback sorting key for tables that declare no PRIMARY KEY.
+                        // Unlike PRIMARY KEY this does NOT force the column NOT NULL:
+                        // MySQL permits NULLs in a UNIQUE column, so the ClickHouse
+                        // column nullability must keep following the source DDL.
+                        if (uniqueKeyColumns.length() == 0 && columnName != null) {
+                            uniqueKeyColumns.append(columnName);
                         }
                     } else if (colDefinitionChildTree instanceof MySqlParser.GeneratedColumnConstraintContext) {
                         for (ParseTree generatedColumnTree: ((MySqlParser.GeneratedColumnConstraintContext) colDefinitionChildTree).children) {

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/CreateTableUniqueKeySortKeyTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/CreateTableUniqueKeySortKeyTest.java
@@ -1,0 +1,122 @@
+package com.altinity.clickhouse.debezium.embedded.ddl.parser;
+
+import com.altinity.clickhouse.debezium.embedded.cdc.DebeziumChangeEventCapture;
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+/**
+ * A MySQL table may declare a UNIQUE key but no PRIMARY KEY. Such a table was
+ * created in ClickHouse as {@code ReplacingMergeTree(...) ORDER BY tuple()}:
+ * with an empty sorting key every row compares equal, so ReplacingMergeTree
+ * collapses the whole table down to a single row.
+ *
+ * <p>Measured on the connector before this fix (MySQL 8.0.36 ROW/FULL/GTID ->
+ * ClickHouse 24.8.14): a five-row table with a UNIQUE key and no PRIMARY KEY
+ * arrived as ONE row. Total, silent data loss.</p>
+ *
+ * <p>The UNIQUE key is the source's stable row identity, which is precisely
+ * what the sorting key must be, so it is used when no PRIMARY KEY exists.
+ * Note that ordering by all data columns is NOT a valid alternative: an UPDATE
+ * to a non-key column then produces a different sorting key, so both versions
+ * survive FINAL and the table gains permanent duplicates instead.</p>
+ */
+public class CreateTableUniqueKeySortKeyTest {
+
+    private static MySQLDDLParserService mySQLDDLParserService;
+
+    @BeforeAll
+    static public void init() {
+        mySQLDDLParserService = new MySQLDDLParserService(
+                new ClickHouseSinkConnectorConfig(new HashMap<>()), "employees");
+        DebeziumChangeEventCapture.isNewReplacingMergeTreeEngine = true;
+    }
+
+    /**
+     * Column-level UNIQUE (`uk INT NOT NULL UNIQUE`) with no PRIMARY KEY.
+     * This is the exact shape that reproduced the 5-rows-to-1 collapse.
+     */
+    @Test
+    public void testColumnLevelUniqueKeyUsedAsSortKeyWhenNoPrimaryKey() {
+        String createQuery = "CREATE TABLE nopk_ddl (uk INT NOT NULL UNIQUE, v VARCHAR(64)) ENGINE=InnoDB;";
+        StringBuffer clickHouseQuery = new StringBuffer();
+        mySQLDDLParserService.parseSql(createQuery, "nopk_ddl", clickHouseQuery);
+
+        String query = clickHouseQuery.toString();
+        Assert.assertFalse("ORDER BY tuple() collapses every row into one",
+                query.toLowerCase().contains("order by tuple()"));
+        Assert.assertTrue("UNIQUE key must become the sorting key, was: " + query,
+                query.toLowerCase().contains("order by uk"));
+    }
+
+    /**
+     * Table-level UNIQUE KEY (...) with no PRIMARY KEY.
+     */
+    @Test
+    public void testTableLevelUniqueKeyUsedAsSortKeyWhenNoPrimaryKey() {
+        String createQuery = "CREATE TABLE nopk_tbl (uk INT NOT NULL, v VARCHAR(64), "
+                + "UNIQUE KEY uk_idx (uk)) ENGINE=InnoDB;";
+        StringBuffer clickHouseQuery = new StringBuffer();
+        mySQLDDLParserService.parseSql(createQuery, "nopk_tbl", clickHouseQuery);
+
+        String query = clickHouseQuery.toString();
+        Assert.assertFalse("ORDER BY tuple() collapses every row into one",
+                query.toLowerCase().contains("order by tuple()"));
+        Assert.assertTrue("UNIQUE key must become the sorting key, was: " + query,
+                query.toLowerCase().contains("order by") && query.contains("uk"));
+    }
+
+    /**
+     * A composite table-level UNIQUE KEY must be used in full: keying on only
+     * part of it would merge genuinely distinct rows.
+     */
+    @Test
+    public void testCompositeUniqueKeyUsedInFull() {
+        String createQuery = "CREATE TABLE nopk_composite (a INT NOT NULL, b INT NOT NULL, "
+                + "v VARCHAR(64), UNIQUE KEY ab_idx (a, b)) ENGINE=InnoDB;";
+        StringBuffer clickHouseQuery = new StringBuffer();
+        mySQLDDLParserService.parseSql(createQuery, "nopk_composite", clickHouseQuery);
+
+        String query = clickHouseQuery.toString();
+        Assert.assertFalse("ORDER BY tuple() collapses every row into one",
+                query.toLowerCase().contains("order by tuple()"));
+        Assert.assertTrue("both UNIQUE key columns must be in the sorting key, was: " + query,
+                query.contains("a") && query.contains("b"));
+    }
+
+    /**
+     * Regression guard: when a PRIMARY KEY exists it always wins, and a UNIQUE
+     * key present alongside it must not alter the sorting key.
+     */
+    @Test
+    public void testPrimaryKeyWinsOverUniqueKey() {
+        String createQuery = "CREATE TABLE pk_and_uk (id INT NOT NULL PRIMARY KEY, "
+                + "uk INT NOT NULL UNIQUE, v VARCHAR(64)) ENGINE=InnoDB;";
+        StringBuffer clickHouseQuery = new StringBuffer();
+        mySQLDDLParserService.parseSql(createQuery, "pk_and_uk", clickHouseQuery);
+
+        String query = clickHouseQuery.toString();
+        Assert.assertTrue("PRIMARY KEY must remain the sorting key, was: " + query,
+                query.toLowerCase().contains("order by id"));
+    }
+
+    /**
+     * Regression guard: a table with neither a PRIMARY KEY nor a UNIQUE key has
+     * no stable row identity to key on, so it must still fall back to
+     * ORDER BY tuple(). Inventing a key here (for example ordering by all data
+     * columns) would trade collapse for permanent duplication on UPDATE.
+     */
+    @Test
+    public void testNoKeyAtAllStillFallsBackToTuple() {
+        String createQuery = "CREATE TABLE nokey (a INT, v VARCHAR(64)) ENGINE=InnoDB;";
+        StringBuffer clickHouseQuery = new StringBuffer();
+        mySQLDDLParserService.parseSql(createQuery, "nokey", clickHouseQuery);
+
+        Assert.assertTrue("no key of any kind must still yield ORDER BY tuple(), was: "
+                        + clickHouseQuery,
+                clickHouseQuery.toString().toLowerCase().contains("order by tuple()"));
+    }
+}

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/QueryFormatter.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/QueryFormatter.java
@@ -11,8 +11,10 @@ import org.apache.logging.log4j.Logger;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Class responsible for generating raw queries for the ClickHouse JDBC library.
@@ -79,10 +81,39 @@ public class QueryFormatter {
             boolean includeKafkaMetaData,
             boolean includeRawData,
             String rawDataColumn, String dbName) {
+        return getInsertQueryUsingInputFunction(tableName, fields, columnNameToDataTypeMap,
+                includeKafkaMetaData, includeRawData, rawDataColumn, dbName, null);
+    }
+
+    /**
+     * Overload accepting the configured ReplacingMergeTree delete column name.
+     *
+     * <p>The delete column is configurable
+     * ({@code replacingmergetree.delete.column}), so it cannot be recognised
+     * from a constant. It is never present in the source record but is
+     * populated by the connector, so it must not be filtered out of the
+     * INSERT column list.</p>
+     *
+     * @param tableName               the name of the ClickHouse table.
+     * @param fields                  the list of fields from the source schema.
+     * @param columnNameToDataTypeMap a map of column names to their corresponding data types.
+     * @param includeKafkaMetaData    flag indicating whether Kafka metadata columns should be included.
+     * @param includeRawData          flag indicating whether raw data should be included in the query.
+     * @param rawDataColumn           the name of the raw data column.
+     * @param dbName                  the name of the database.
+     * @param deleteColumn            the configured ReplacingMergeTree delete column, may be null.
+     * @return a MutablePair containing the generated INSERT query and a map of column names to their indices.
+     */
+    public MutablePair<String, Map<String, Integer>> getInsertQueryUsingInputFunction(
+            String tableName, List<Field> fields,
+            Map<String, String> columnNameToDataTypeMap,
+            boolean includeKafkaMetaData,
+            boolean includeRawData,
+            String rawDataColumn, String dbName, String deleteColumn) {
 
         // Create column data structures
         ColumnData columnData = createColumns(tableName, fields, columnNameToDataTypeMap,
-                includeKafkaMetaData, includeRawData, rawDataColumn, dbName);
+                includeKafkaMetaData, includeRawData, rawDataColumn, dbName, deleteColumn);
 
         if (columnData == null) {
             return null;
@@ -272,6 +303,35 @@ public class QueryFormatter {
      */
     private ColumnData createColumns(String tableName, List<Field> fields, Map<String, String> columnNameToDataTypeMap,
                                      boolean includeKafkaMetaData, boolean includeRawData, String rawDataColumn, String dbName) {
+        return createColumns(tableName, fields, columnNameToDataTypeMap, includeKafkaMetaData,
+                includeRawData, rawDataColumn, dbName, null);
+    }
+
+    /**
+     * Returns true for columns the connector populates itself rather than
+     * copying from the source record: {@code _version}, {@code is_deleted},
+     * {@code _sign}, the replication-history validity columns, and the
+     * configured ReplacingMergeTree delete column. These are never present in
+     * the incoming record's schema and must always remain in the INSERT
+     * column list.
+     *
+     * @param colName      the ClickHouse column name to test.
+     * @param deleteColumn the configured delete column name, may be null.
+     * @return true if the connector populates this column itself.
+     */
+    private boolean isConnectorManagedColumn(String colName, String deleteColumn) {
+        return colName.equalsIgnoreCase(ClickHouseDbConstants.VERSION_COLUMN)
+                || colName.equalsIgnoreCase(ClickHouseDbConstants.IS_DELETED_COLUMN)
+                || colName.equalsIgnoreCase(ClickHouseDbConstants.SIGN_COLUMN)
+                || colName.equalsIgnoreCase(ClickHouseDbConstants.DELETED_TIME_COLUMN)
+                || colName.equalsIgnoreCase(ClickHouseDbConstants.DELETED_FROM_TIME_COLUMN)
+                || (deleteColumn != null && !deleteColumn.isEmpty()
+                        && colName.equalsIgnoreCase(deleteColumn));
+    }
+
+    private ColumnData createColumns(String tableName, List<Field> fields, Map<String, String> columnNameToDataTypeMap,
+                                     boolean includeKafkaMetaData, boolean includeRawData, String rawDataColumn,
+                                     String dbName, String deleteColumn) {
 
         if (fields == null) {
             log.error("getInsertQueryUsingInputFunction, fields empty");
@@ -284,11 +344,42 @@ public class QueryFormatter {
         StringBuilder colNamesDelimited = new StringBuilder();
         StringBuilder colNamesToDataTypes = new StringBuilder();
 
+        // Names the incoming record actually carries. A record buffered before an
+        // ALTER TABLE ... ADD/CHANGE COLUMN does not carry the columns that the
+        // ALTER introduced, yet columnNameToDataTypeMap reflects the ClickHouse
+        // table AFTER the ALTER. Including such a column in the INSERT column list
+        // binds it to NULL and silently overwrites the real source value (row
+        // counts still match, so count-based checksums report the table clean).
+        // Omitting it from the column list instead lets ClickHouse apply the
+        // column's DEFAULT, which is what the ALTER established.
+        Set<String> recordFieldNames = new HashSet<>();
+        for (Field field : fields) {
+            if (field != null && field.name() != null) {
+                recordFieldNames.add(field.name().toLowerCase());
+            }
+        }
+
         // Loop over each column to generate the insert query and map data types
         for (Map.Entry<String, String> entry : columnNameToDataTypeMap.entrySet()) {
             String sourceColumnName = entry.getKey();
             String sourceColumnNameWithBackTicks = "`" + entry.getKey() + "`";
             String dataType = ClickHouseUtils.escape(entry.getValue(), '\'');
+
+            // Skip ClickHouse columns absent from this record's schema. Columns the
+            // connector itself populates (Kafka metadata, raw data, _version,
+            // is_deleted/_sign, replication-history) are never present in the source
+            // record and must stay in the column list.
+            if (!recordFieldNames.contains(sourceColumnName.toLowerCase())
+                    && !isKafkaMetaDataColumn(sourceColumnName)
+                    && !sourceColumnName.equalsIgnoreCase(rawDataColumn)
+                    && !isConnectorManagedColumn(sourceColumnName, deleteColumn)) {
+                log.debug(String.format(
+                        "Table Name: %s, Database: %s, Column(%s) omitted from INSERT: "
+                                + "not present in this record's schema (pre-ALTER record); "
+                                + "the ClickHouse DEFAULT applies instead of NULL",
+                        tableName, dbName, sourceColumnNameWithBackTicks));
+                continue;
+            }
 
             // Override data type if necessary
             if (ColumnOverrides.getColumnOverride(dataType) != null) {

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/GroupInsertQueryWithBatchRecords.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/GroupInsertQueryWithBatchRecords.java
@@ -184,7 +184,10 @@ public class GroupInsertQueryWithBatchRecords {
                         config.getString(
                                 ClickHouseSinkConnectorConfigVariables.STORE_RAW_DATA_COLUMN
                                         .toString()),
-                        record.getDatabase());
+                        record.getDatabase(),
+                        config.getString(
+                                ClickHouseSinkConnectorConfigVariables
+                                        .REPLACING_MERGE_TREE_DELETE_COLUMN.toString()));
 
         String insertQueryTemplate = response.getKey();
         if (response.getKey() == null || response.getValue() == null) {

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/QueryFormatterPreAlterRecordTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/QueryFormatterPreAlterRecordTest.java
@@ -1,0 +1,144 @@
+package com.altinity.clickhouse.sink.connector.db;
+
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A record buffered before an {@code ALTER TABLE ... ADD COLUMN} /
+ * {@code CHANGE COLUMN} does not carry the columns the ALTER introduced, but
+ * the ClickHouse column map reflects the table AFTER the ALTER.
+ *
+ * <p>Previously every ClickHouse column was placed in the INSERT column list
+ * regardless of whether the record carried it, so the missing columns were
+ * bound to NULL -- silently overwriting the real source values. Row counts
+ * still matched, so count-based checksum jobs reported the table clean.</p>
+ *
+ * <p>Measured on the connector before this fix (MySQL 8.0.36 ROW/FULL/GTID ->
+ * ClickHouse 24.8.14), deterministic across 12 independent trials: of three
+ * rows written around two ALTERs, two came back with NULLs where MySQL held
+ * real values.</p>
+ *
+ * <p>Omitting the absent column from the column list instead lets ClickHouse
+ * apply the column's DEFAULT, which is what the ALTER established.</p>
+ */
+public class QueryFormatterPreAlterRecordTest {
+
+    /** Columns of the ClickHouse table AFTER the ALTER added c_int_u. */
+    private static Map<String, String> postAlterColumns() {
+        Map<String, String> m = new LinkedHashMap<>();
+        m.put("id", "Int32");
+        m.put("a_int", "Nullable(Int64)");
+        m.put("b_str", "Nullable(String)");
+        m.put("c_int_u", "Nullable(UInt32)");
+        m.put("_version", "UInt64");
+        m.put("is_deleted", "UInt8");
+        return m;
+    }
+
+    /** Fields of a record captured BEFORE the ALTER: no c_int_u. */
+    private static List<Field> preAlterFields() {
+        List<Field> fields = new ArrayList<>();
+        fields.add(new Field("id", 0, Schema.INT32_SCHEMA));
+        fields.add(new Field("a_int", 1, Schema.INT64_SCHEMA));
+        fields.add(new Field("b_str", 2, Schema.STRING_SCHEMA));
+        return fields;
+    }
+
+    @Test
+    public void testColumnAbsentFromPreAlterRecordIsOmittedNotNullFilled() {
+        MutablePair<String, Map<String, Integer>> response =
+                new QueryFormatter().getInsertQueryUsingInputFunction(
+                        "ddl_churn", preAlterFields(), postAlterColumns(),
+                        false, false, null, "repro_db");
+
+        String query = response.left;
+        Assert.assertFalse(
+                "c_int_u is absent from this record; including it binds NULL over the real "
+                        + "MySQL value. Query was: " + query,
+                query.contains("c_int_u"));
+        Assert.assertFalse("c_int_u must not be bound",
+                response.right.containsKey("c_int_u"));
+    }
+
+    /**
+     * The connector populates _version and is_deleted itself; they are never in
+     * the source record and must survive the filter.
+     */
+    @Test
+    public void testConnectorManagedColumnsAlwaysRetained() {
+        MutablePair<String, Map<String, Integer>> response =
+                new QueryFormatter().getInsertQueryUsingInputFunction(
+                        "ddl_churn", preAlterFields(), postAlterColumns(),
+                        false, false, null, "repro_db");
+
+        Assert.assertTrue("_version must remain in the INSERT",
+                response.right.containsKey("_version"));
+        Assert.assertTrue("is_deleted must remain in the INSERT",
+                response.right.containsKey("is_deleted"));
+    }
+
+    /**
+     * The ReplacingMergeTree delete column is configurable, so it cannot be
+     * recognised from a constant. If it were filtered out, deletes would stop
+     * being marked.
+     */
+    @Test
+    public void testConfiguredDeleteColumnRetained() {
+        Map<String, String> columns = postAlterColumns();
+        columns.put("sign", "Int8");
+
+        MutablePair<String, Map<String, Integer>> response =
+                new QueryFormatter().getInsertQueryUsingInputFunction(
+                        "ddl_churn", preAlterFields(), columns,
+                        false, false, null, "repro_db", "sign");
+
+        Assert.assertTrue("configured delete column must remain in the INSERT",
+                response.right.containsKey("sign"));
+    }
+
+    /**
+     * Regression guard: when the record carries every column, nothing is
+     * filtered and the query is unchanged.
+     */
+    @Test
+    public void testRecordCarryingAllColumnsIsUnaffected() {
+        List<Field> fields = preAlterFields();
+        fields.add(new Field("c_int_u", 3, Schema.INT32_SCHEMA));
+
+        MutablePair<String, Map<String, Integer>> response =
+                new QueryFormatter().getInsertQueryUsingInputFunction(
+                        "ddl_churn", fields, postAlterColumns(),
+                        false, false, null, "repro_db");
+
+        Assert.assertTrue("c_int_u is present in the record and must be inserted",
+                response.right.containsKey("c_int_u"));
+        Assert.assertEquals("all five columns plus the connector's two",
+                6, response.right.size());
+    }
+
+    /**
+     * Regression guard: the placeholder count must match the column count,
+     * otherwise the prepared statement is malformed.
+     */
+    @Test
+    public void testPlaceholderCountMatchesColumnCount() {
+        MutablePair<String, Map<String, Integer>> response =
+                new QueryFormatter().getInsertQueryUsingInputFunction(
+                        "ddl_churn", preAlterFields(), postAlterColumns(),
+                        false, false, null, "repro_db");
+
+        String query = response.left;
+        long placeholders = query.substring(query.indexOf("VALUES")).chars()
+                .filter(c -> c == '?').count();
+        Assert.assertEquals("placeholder count must equal bound column count, query: " + query,
+                response.right.size(), (int) placeholders);
+    }
+}


### PR DESCRIPTION
**WIP - DO NOT MERGE.** Opened by OmniWatcher on behalf of the Jump Trading DBA team. Please review before merging; we do not own this repo. Full detail below, as committed.

```
fix: no-PK tables collapse to one row; pre-ALTER rows NULL-fill added columns

Two silent data-loss defects found while testing build
1304-128ef211a808115314ca5914574656a5ba150a7f-lt side by side against
1304-8fc8e9ae07007c208fecf304b83489312bd947e5-lt on isolated stacks
(MySQL 8.0.36 ROW/FULL/GTID -> ClickHouse 24.8.14.10547). Both defects
reproduce identically on both builds, so neither is a regression.

1. Table with a UNIQUE key but no PRIMARY KEY collapses to a single row
--------------------------------------------------------------------
MySqlDDLParserListenerImpl collected PRIMARY KEY constraints but never
UNIQUE ones, so such a table was created as

    ReplacingMergeTree(_version, is_deleted) ORDER BY tuple()

With an empty sorting key every row compares equal, so ReplacingMergeTree
collapses the entire table. Measured: 5 rows in MySQL, 1 in ClickHouse.
Total, silent loss.

The UNIQUE key is the source's stable row identity, which is exactly what
the sorting key must be, so it is now used when no PRIMARY KEY exists.
Both carriers are handled: the column-level form (`uk INT NOT NULL UNIQUE`,
#uniqueKeyColumnConstraint) and the table-level form
(`UNIQUE KEY uk_idx (a, b)`, #uniqueKeyTableConstraint). Only the first
UNIQUE key is used, and a PRIMARY KEY always wins.

Ordering by all data columns is deliberately NOT used: an UPDATE to a
non-key column then yields a different sorting key, so both versions
survive FINAL and the table gains permanent duplicates instead. Verified
on the live stack that an UPDATE after this fix still leaves 5 rows, not 6.

Unlike PRIMARY KEY, a column-level UNIQUE does not force the column NOT
NULL -- MySQL permits NULLs in a UNIQUE column -- so nullability continues
to follow the source DDL.

2. Rows buffered before ALTER TABLE ADD COLUMN are written with NULL
--------------------------------------------------------------------
QueryFormatter.createColumns built the INSERT column list purely from the
ClickHouse table's current columns, ignoring which fields the incoming
record actually carries. A record buffered before an
ALTER TABLE ... ADD COLUMN does not carry the new column, so it was bound
to NULL, overwriting the real source value. Row counts still matched, so
count-based checksum jobs reported the table clean.

Measured, deterministic across 12 independent trials on both builds: of
three rows written around two ALTERs, two came back with NULLs where MySQL
held real values.

Columns absent from the record's schema are now omitted from the INSERT so
ClickHouse applies the column's DEFAULT -- which is what the ALTER
established. Verified end to end: c_int_u now arrives as 0 and 7 (the
MySQL values) where it previously arrived NULL.

Columns the connector populates itself are never in the source record and
are explicitly retained: Kafka metadata, the raw-data column, _version,
is_deleted, _sign, the replication-history validity columns, and the
configured ReplacingMergeTree delete column. That last one is
configurable (replacingmergetree.delete.column) so it cannot be recognised
from a constant; it is threaded through a new overload, leaving the
existing 7-argument signature untouched.

Known limitation, deliberately not addressed here
-------------------------------------------------
The RENAME half of the NULL-fill defect remains. For
ALTER TABLE ... CHANGE COLUMN b_str b_renamed, a row buffered before the
rename carries `b_str` while the ClickHouse table now has `b_renamed`, so
the value is still written as NULL ("Column index missing for column
b_renamed"). Fixing that needs the DDL parser's rename mapping to be
carried into the writer's column resolution, which is a larger cross-module
change; bundling it with this verified fix would put both at risk. The ADD
COLUMN half is fixed and verified.

Verification (maven 3.9.11 / JDK 17)
------------------------------------
  mvn -B package install -DskipTests=true      BUILD SUCCESS (exact CI command)
  CreateTableUniqueKeySortKeyTest              5/5 pass
    with the fix reverted                      3/5 FAIL ("ORDER BY tuple()
                                               collapses every row into one");
                                               the 2 regression guards still pass
  QueryFormatterPreAlterRecordTest             5/5 pass
    with the fix reverted                      1/4 FAIL, emitting
                                               INSERT INTO `ddl_churn`(`id`,`a_int`,
                                               `b_str`,`c_int_u`,...) -- the NULL-fill
  sink-connector module suite                  176 run, 0 failures, 20 errors
  untouched baseline 096e6352, same host       171 run, 0 failures, 20 errors

The 20 errors are pre-existing and environmental: all are testcontainers
"Could not find a valid Docker environment" on a host without a Docker
daemon. The delta between the two runs is exactly the 5 tests added here.
MySqlDDLParserListenerImplTest.testAutoCreateTable also fails identically
on the untouched baseline (it still expects the pre-#1386 Float32 mapping
for DOUBLE) and is unrelated to this change.

Both fixes were additionally verified end to end by running the locally
built jar as a third stack against its own MySQL and ClickHouse:
sorting_key=uk with 5/5 rows preserved and no duplicate after UPDATE, and
c_int_u arriving as its real value instead of NULL, with insert/update/
delete on a normal keyed table unaffected and zero connector errors.

```
