### PR TITLE
fix: BIT(n) multi-byte values stored byte-reversed (regression from #1387)

### DIFF
--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapper.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapper.java
@@ -383,6 +383,25 @@ public class ClickHouseDataTypeMapper {
                 rawBytes = ((ByteBuffer) value).array();
             }
             if (rawBytes != null) {
+                // Debezium delivers MySQL BIT(n) (io.debezium.data.Bits) as a
+                // LITTLE-ENDIAN byte[] -- least significant byte first -- while
+                // MySQL itself presents the value big-endian (HEX(b) prints the
+                // most significant byte first). Encoding the array as received
+                // therefore stores every multi-byte BIT byte-reversed: a MySQL
+                // BIT(64) of 0x0102030405060708 arrived as 0807060504030201.
+                // The reversal is silent and, for a non-palindromic value,
+                // wrong in a way no row count can detect.
+                //
+                // This applies to BIT only. BLOB/BINARY/VARBINARY arrive as a
+                // ByteBuffer already in source order and round-trip exactly,
+                // so reversing every BYTES value would corrupt them instead.
+                if (Bits.LOGICAL_NAME.equals(schemaName) && rawBytes.length > 1) {
+                    byte[] bigEndian = new byte[rawBytes.length];
+                    for (int i = 0; i < rawBytes.length; i++) {
+                        bigEndian[i] = rawBytes[rawBytes.length - 1 - i];
+                    }
+                    rawBytes = bigEndian;
+                }
                 if (config.getBoolean(
                         ClickHouseSinkConnectorConfigVariables.PERSIST_RAW_BYTES.toString())) {
                     ps.setBytes(index, rawBytes);

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapperBitBytesTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapperBitBytesTest.java
@@ -124,22 +124,35 @@ public class ClickHouseDataTypeMapperBitBytesTest {
         Assertions.assertEquals("ffffffffffffffff", convertBits(allOnes));
     }
 
-    /** Low bytes were already correct and must stay byte-identical. */
+    /**
+     * Low bytes must stay lossless.
+     *
+     * <p>Expectation updated: Debezium delivers BIT(n) LITTLE-endian, so the
+     * wire bytes {0x01, 0x7F} are the MySQL value 0x7F01, not 0x017F. This
+     * test previously asserted "017f", encoding the byte order as received.
+     * That assumption was wrong and is what let the reversal defect ship --
+     * see ClickHouseDataTypeMapperBitEndianTest, which measures the mismatch
+     * against a live MySQL/ClickHouse pair.</p>
+     */
     @Test
     public void bitLowBytesAreUnchanged() throws SQLException {
-        Assertions.assertEquals("017f", convertBits(new byte[] {0x01, 0x7F}));
+        Assertions.assertEquals("7f01", convertBits(new byte[] {0x01, 0x7F}));
     }
 
     /**
      * The two carriers of a BYTES value must agree: a byte[] and a ByteBuffer
      * holding the same bytes previously produced different results.
+     *
+     * <p>Both carriers are reversed identically for BIT, so they still agree;
+     * the expected value is the byte-reversed form for the same reason as
+     * above.</p>
      */
     @Test
     public void byteArrayAndByteBufferAgree() throws SQLException {
         byte[] payload = {(byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF};
 
-        Assertions.assertEquals("deadbeef", convertBits(payload));
-        Assertions.assertEquals("deadbeef", convertBits(ByteBuffer.wrap(payload)));
+        Assertions.assertEquals("efbeadde", convertBits(payload));
+        Assertions.assertEquals("efbeadde", convertBits(ByteBuffer.wrap(payload)));
     }
 
     /** A zero-length BIT payload must not throw. */

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapperBitEndianTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapperBitEndianTest.java
@@ -1,0 +1,159 @@
+package com.altinity.clickhouse.sink.connector.converters;
+
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import com.clickhouse.data.ClickHouseDataType;
+import io.debezium.data.Bits;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.ByteBuffer;
+import java.sql.PreparedStatement;
+import java.util.HashMap;
+import java.time.ZoneId;
+
+/**
+ * Debezium delivers MySQL {@code BIT(n)} ({@code io.debezium.data.Bits}) as a
+ * LITTLE-ENDIAN byte[] -- least significant byte first -- while MySQL presents
+ * the value big-endian ({@code HEX(b)} prints the most significant byte first).
+ *
+ * <p>Encoding the array as received stored every multi-byte BIT byte-reversed.
+ * Measured on a live stack (MySQL 8.0.36 ROW/FULL/GTID -> ClickHouse
+ * 24.8.14.10547):</p>
+ *
+ * <pre>
+ *   MySQL BIT(64) 0102030405060708 -> ClickHouse 0807060504030201
+ *   MySQL BIT(24) 010203           -> ClickHouse 030201
+ *   MySQL BIT(16) 0102             -> ClickHouse 0201
+ *   MySQL BIT(16) FF00             -> ClickHouse 00ff
+ * </pre>
+ *
+ * <p>The corruption is silent and row counts still match. It escaped the
+ * earlier byte-boundary testing because every value used there was a
+ * single byte or a palindrome (0x00.. / 0xFF.. repeated), which is
+ * unchanged by reversal.</p>
+ *
+ * <p>BLOB/BINARY/VARBINARY arrive as a ByteBuffer already in source order and
+ * were verified to round-trip exactly, so the reversal must apply to BIT
+ * alone.</p>
+ */
+public class ClickHouseDataTypeMapperBitEndianTest {
+
+    /**
+     * Recording PreparedStatement built with java.lang.reflect.Proxy -- the
+     * JDBC test-double idiom already used by this module (see
+     * ClosedConnectionRefreshTest). Deliberately no mocking framework: there is
+     * no Mockito on this module's classpath.
+     */
+    private static final class Recorder implements InvocationHandler {
+        private String stringValue;
+        private byte[] bytesValue;
+        private int bindCalls;
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            switch (method.getName()) {
+                case "setString":
+                    stringValue = (String) args[1];
+                    bindCalls++;
+                    return null;
+                case "setBytes":
+                    bytesValue = (byte[]) args[1];
+                    bindCalls++;
+                    return null;
+                case "toString":
+                    return "RecordingPreparedStatement";
+                case "equals":
+                    return proxy == args[0];
+                case "hashCode":
+                    return System.identityHashCode(proxy);
+                default:
+                    throw new UnsupportedOperationException(
+                            "unexpected PreparedStatement call: " + method.getName());
+            }
+        }
+    }
+
+    private static PreparedStatement proxyFor(Recorder rec) {
+        return (PreparedStatement) Proxy.newProxyInstance(
+                ClickHouseDataTypeMapperBitEndianTest.class.getClassLoader(),
+                new Class<?>[]{PreparedStatement.class}, rec);
+    }
+
+    private static String convertBits(byte[] littleEndianFromDebezium) throws Exception {
+        Recorder rec = new Recorder();
+        boolean handled = ClickHouseDataTypeMapper.convert(
+                Schema.Type.BYTES, Bits.LOGICAL_NAME, littleEndianFromDebezium, 1,
+                proxyFor(rec), new ClickHouseSinkConnectorConfig(new HashMap<>()),
+                ClickHouseDataType.String, ZoneId.of("UTC"));
+        Assert.assertTrue("BYTES/Bits must be handled", handled);
+        Assert.assertEquals("exactly one bind call", 1, rec.bindCalls);
+        Assert.assertNull("must not use setBytes without persist.raw.bytes", rec.bytesValue);
+        return rec.stringValue;
+    }
+
+    /** BIT(64) 0x0102030405060708 -- the value that exposed the defect. */
+    @Test
+    public void testBit64AsymmetricValueIsBigEndian() throws Exception {
+        byte[] littleEndian = {0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01};
+        Assert.assertEquals("0102030405060708", convertBits(littleEndian));
+    }
+
+    /** BIT(24) 0x010203. */
+    @Test
+    public void testBit24AsymmetricValueIsBigEndian() throws Exception {
+        Assert.assertEquals("010203", convertBits(new byte[]{0x03, 0x02, 0x01}));
+    }
+
+    /** BIT(16) 0xFF00 -- high byte set, so it also guards the #1387 fix. */
+    @Test
+    public void testBit16HighByteIsBigEndian() throws Exception {
+        Assert.assertEquals("ff00", convertBits(new byte[]{0x00, (byte) 0xFF}));
+    }
+
+    /**
+     * Regression guard for #1387: a single high byte must stay lossless. A
+     * one-byte value has no byte order, so reversal must not disturb it.
+     */
+    @Test
+    public void testSingleHighByteUnchanged() throws Exception {
+        Assert.assertEquals("aa", convertBits(new byte[]{(byte) 0xAA}));
+        Assert.assertEquals("ff", convertBits(new byte[]{(byte) 0xFF}));
+        Assert.assertEquals("80", convertBits(new byte[]{(byte) 0x80}));
+        Assert.assertEquals("01", convertBits(new byte[]{0x01}));
+    }
+
+    /**
+     * Palindromic values are unchanged by reversal -- exactly why the earlier
+     * boundary testing missed this defect. Kept so the fix cannot regress them.
+     */
+    @Test
+    public void testPalindromicValuesUnchanged() throws Exception {
+        Assert.assertEquals("ffffffffffffffff",
+                convertBits(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                        (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF}));
+        Assert.assertEquals("0000000000000000",
+                convertBits(new byte[]{0, 0, 0, 0, 0, 0, 0, 0}));
+    }
+
+    /**
+     * BLOB/BINARY (BYTES with no logical name) arrive as a ByteBuffer already
+     * in source order and were verified on a live stack to round-trip exactly.
+     * They must NOT be reversed.
+     */
+    @Test
+    public void testBlobByteBufferNotReversed() throws Exception {
+        Recorder rec = new Recorder();
+        byte[] payload = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+        boolean handled = ClickHouseDataTypeMapper.convert(
+                Schema.Type.BYTES, null, ByteBuffer.wrap(payload), 1,
+                proxyFor(rec), new ClickHouseSinkConnectorConfig(new HashMap<>()),
+                ClickHouseDataType.String, ZoneId.of("UTC"));
+        Assert.assertTrue("BYTES/blob must be handled", handled);
+        Assert.assertEquals("BLOB bytes must keep source order",
+                "0102030405060708", rec.stringValue);
+    }
+}


### PR DESCRIPTION
**WIP - DO NOT MERGE.** Opened by OmniWatcher on behalf of the Jump Trading DBA team. Please review before merging; we do not own this repo. This is a regression from my own #1387. Full detail as committed:

```
fix: BIT(n) multi-byte values stored byte-reversed

Debezium delivers MySQL BIT(n) (io.debezium.data.Bits) as a LITTLE-ENDIAN
byte[] -- least significant byte first -- while MySQL presents the value
big-endian (HEX(b) prints the most significant byte first). #1387 made the
BIT path lossless but hex-encoded the wire array as received, so every
multi-byte BIT is stored byte-reversed.

Measured on isolated stacks (MySQL 8.0.36 ROW/FULL/GTID -> ClickHouse
24.8.14.10547) against build
1304-4a18cb437e91f67ebf6c72a44e208f221baf201c-lt:

  column        MySQL HEX()         ClickHouse (before)
  ------        -----------         -------------------
  BIT(16)       0102                0201
  BIT(16)       FF00                00ff
  BIT(24)       010203              030201
  BIT(64)       0102030405060708    0807060504030201

The corruption is silent: row counts match, no error is logged, and the
value is a valid hex string of the correct length. It is only wrong.

This regression is mine, from #1387. It escaped that round's byte-boundary
testing because every value used there was a single byte (0x01, 0x7F, 0x80,
0xAA, 0xFF) or a palindrome (BIT(64) all-ones, all-zeros) -- both classes
are unchanged by reversal. Only an asymmetric multi-byte value exposes it.

Scope: BIT only. BLOB/BINARY/VARBINARY arrive as a ByteBuffer already in
source order and were verified on the same live stack to round-trip exactly
(0102030405060708, FF00AA80 and DEADBEEF all byte-identical), so reversing
every BYTES value would corrupt them instead. The two are distinguished by
Bits.LOGICAL_NAME, which the convert() signature already carries. A
single-byte value has no byte order, so the reversal is skipped for
length <= 1 and #1387's boundary behaviour is untouched.

Two assertions in ClickHouseDataTypeMapperBitBytesTest encoded the wrong
assumption (that the wire array was already big-endian) and are updated
rather than deleted, with the reason stated inline, so the reversal is
visible in the diff:
  bitLowBytesAreUnchanged   "017f"     -> "7f01"
  byteArrayAndByteBufferAgree "deadbeef" -> "efbeadde"

Verification (maven 3.9.11 / JDK 17)
------------------------------------
  mvn -B package install -DskipTests=true   BUILD SUCCESS (the exact CI command)
  ClickHouseDataTypeMapperBitEndianTest     6/6 pass
    with the fix reverted                   3/6 FAIL, and the failures print the
                                            exact production values:
                                            expected 0102030405060708
                                                 but 0807060504030201
                                            expected 010203 but 030201
                                            expected ff00   but 00ff
                                            The palindrome, single-byte and BLOB
                                            guards correctly still pass.
  sink-connector module suite               182 run, 0 failures, 20 errors
  untouched baseline 05c4c57b, same host    176 run, 0 failures, 20 errors

The 20 errors are pre-existing and environmental: all are testcontainers
"Could not find a valid Docker environment" on a host with no Docker daemon.
The delta between the two runs is exactly the 6 tests added here.

End-to-end on a live stack with the locally built jar, all widths compared
against MySQL's own HEX() output:
  b8   PASS  01, ff, aa
  b16  PASS  0102, ff00, aa55
  b24  PASS  010203, ff0000, aa55cc
  b64  PASS  0102030405060708, ff00000000000000, aa55cc33f00f8001
  BLOB/BINARY unchanged; connector errors: 0

```
