### PR TITLE
fix(ci): harden Dockerfile downloads (transient TLS reset fails the build; missing --fail writes corrupt jars)

### DIFF
--- a/sink-connector/docker/Dockerfile-sink-on-debezium-base-image
+++ b/sink-connector/docker/Dockerfile-sink-on-debezium-base-image
@@ -18,20 +18,40 @@ COPY deploy/libs/* /kafka/connect/clickhouse-kafka-sink-connector/
 #    docker-maven-download confluent common-config "$CONFLUENT_VERSION" e1a4dc2b6d1d8d8c2df47db580276f38 && \
 #    docker-maven-download confluent common-utils "$CONFLUENT_VERSION" ad9e39d87c6a9fa1a9b19e6ce80392fa && \
 
+# Every download below uses the same hardened curl flags:
+#
+#   --fail            a bare `curl -L` treats an HTTP error as success: it exits
+#                     0 and writes the error BODY to the output path. A 404 or a
+#                     403 therefore produced a ~340-byte XML document named
+#                     *.jar and the image built "successfully" with a corrupt
+#                     dependency. --fail makes curl exit 22 instead.
+#   --retry 5
+#   --retry-connrefused
+#   --retry-all-errors  the build has been failing on transient TLS resets from
+#                     packages.confluent.io ("curl: (35) OpenSSL SSL_connect:
+#                     Connection reset by peer"), which aborts the whole image
+#                     build and skips every downstream CI job. A single reset
+#                     should be retried, not fatal.
+#   --connect-timeout / --max-time
+#                     bound a hung connection so the job fails fast instead of
+#                     burning the runner's wall clock.
+#
+# Kept as separate RUN layers to preserve the existing layer cache behaviour.
+
 # Copy apicurio
-RUN 'curl' '-L' '--output' '/kafka/connect/clickhouse-kafka-sink-connector/apicurio.tgz' 'https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-distro-connect-converter/2.1.5.Final/apicurio-registry-distro-connect-converter-2.1.5.Final.tar.gz' \
+RUN 'curl' '-fsSL' '--retry' '5' '--retry-connrefused' '--retry-all-errors' '--connect-timeout' '30' '--max-time' '600' '--output' '/kafka/connect/clickhouse-kafka-sink-connector/apicurio.tgz' 'https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-distro-connect-converter/2.1.5.Final/apicurio-registry-distro-connect-converter-2.1.5.Final.tar.gz' \
       && 'tar' 'xvfz' '/kafka/connect/clickhouse-kafka-sink-connector/apicurio.tgz' '-C' '/kafka/connect/clickhouse-kafka-sink-connector' \
       && 'rm' '-vf' '/kafka/connect/clickhouse-kafka-sink-connector/apicurio.tgz/apicurio.tgz'
 
 # Copy confluent
-RUN 'curl' '-L' '--output' '/kafka/libs/kafka-connect-avro-converter-7.2.1.jar' 'https://packages.confluent.io/maven/io/confluent/kafka-connect-avro-converter/7.2.1/kafka-connect-avro-converter-7.2.1.jar'
-RUN 'curl' '-L' '--output' '/kafka/libs/kafka-avro-serializer-7.2.1.jar' 'https://packages.confluent.io/maven/io/confluent/kafka-avro-serializer/7.2.1/kafka-avro-serializer-7.2.1.jar'
-RUN 'curl' '-L' '--output' '/kafka/libs/kafka-schema-registry-7.2.1.jar' 'https://packages.confluent.io/maven/io/confluent/kafka-schema-registry/7.2.1/kafka-schema-registry-7.2.1.jar'
+RUN 'curl' '-fsSL' '--retry' '5' '--retry-connrefused' '--retry-all-errors' '--connect-timeout' '30' '--max-time' '600' '--output' '/kafka/libs/kafka-connect-avro-converter-7.2.1.jar' 'https://packages.confluent.io/maven/io/confluent/kafka-connect-avro-converter/7.2.1/kafka-connect-avro-converter-7.2.1.jar'
+RUN 'curl' '-fsSL' '--retry' '5' '--retry-connrefused' '--retry-all-errors' '--connect-timeout' '30' '--max-time' '600' '--output' '/kafka/libs/kafka-avro-serializer-7.2.1.jar' 'https://packages.confluent.io/maven/io/confluent/kafka-avro-serializer/7.2.1/kafka-avro-serializer-7.2.1.jar'
+RUN 'curl' '-fsSL' '--retry' '5' '--retry-connrefused' '--retry-all-errors' '--connect-timeout' '30' '--max-time' '600' '--output' '/kafka/libs/kafka-schema-registry-7.2.1.jar' 'https://packages.confluent.io/maven/io/confluent/kafka-schema-registry/7.2.1/kafka-schema-registry-7.2.1.jar'
 
 
-RUN 'curl' '-L' '--output' '/kafka/libs/kafka-schema-registry-client-7.2.1.jar' 'https://packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/7.2.1/kafka-schema-registry-client-7.2.1.jar'
-RUN 'curl' '-L' '--output' '/kafka/libs/common-config-7.2.1.jar' 'https://packages.confluent.io/maven/io/confluent/common-config/7.2.1/common-config-7.2.1.jar'
-RUN 'curl' '-L' '--output' '/kafka/libs/common-utils-7.2.1.jar' 'https://packages.confluent.io/maven/io/confluent/common-utils/7.2.1/common-utils-7.2.1.jar'
+RUN 'curl' '-fsSL' '--retry' '5' '--retry-connrefused' '--retry-all-errors' '--connect-timeout' '30' '--max-time' '600' '--output' '/kafka/libs/kafka-schema-registry-client-7.2.1.jar' 'https://packages.confluent.io/maven/io/confluent/kafka-schema-registry-client/7.2.1/kafka-schema-registry-client-7.2.1.jar'
+RUN 'curl' '-fsSL' '--retry' '5' '--retry-connrefused' '--retry-all-errors' '--connect-timeout' '30' '--max-time' '600' '--output' '/kafka/libs/common-config-7.2.1.jar' 'https://packages.confluent.io/maven/io/confluent/common-config/7.2.1/common-config-7.2.1.jar'
+RUN 'curl' '-fsSL' '--retry' '5' '--retry-connrefused' '--retry-all-errors' '--connect-timeout' '30' '--max-time' '600' '--output' '/kafka/libs/common-utils-7.2.1.jar' 'https://packages.confluent.io/maven/io/confluent/common-utils/7.2.1/common-utils-7.2.1.jar'
 
 RUN chown -R kafka:kafka /kafka/connect/
 


### PR DESCRIPTION
** Please review before merging; we do not own this repo. This fixes the currently-failing CI build on #1304. Full detail as committed:

```
fix(ci): harden Dockerfile downloads - a transient TLS reset fails the build

The `build-kafka-lightweight / build` job on PR #1304 failed and took six
downstream jobs with it (publish-lightweight-jar, checksum-tests-lightweight,
java-tests-kafka, java-tests-lightweight, and both testflows jobs were all
SKIPPED behind it). Maven itself was fine; the failure is in the Docker image
build:

  #10 [ 5/11] RUN 'curl' '-L' '--output'
      '/kafka/libs/kafka-connect-avro-converter-7.2.1.jar'
      'https://packages.confluent.io/maven/io/confluent/kafka-connect-avro-converter/7.2.1/kafka-connect-avro-converter-7.2.1.jar'
  #10 0.202 curl: (35) OpenSSL SSL_connect: Connection reset by peer in
            connection to packages.confluent.io:443
  ERROR: failed to solve: ... did not complete successfully: exit code: 35

(run 32575512953, head 44d32d32)

The URL is not broken -- it returns HTTP 200 on retry. A single transient TLS
reset from packages.confluent.io aborted the whole image build, because the
seven downloads in this Dockerfile run as a bare `curl -L` with no retry.

A second, more dangerous defect in the same lines
-------------------------------------------------
`curl -L` without `--fail` treats an HTTP error as SUCCESS: it exits 0 and
writes the error BODY to the output path. Verified on curl 7.76.1, the same
version the base image ships:

  $ curl -L --output bad.jar <404 url>; echo $?
  0
  $ ls -l bad.jar
  353 bytes
  $ head -c 60 bad.jar
  <?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchKe...

So a 404 or 403 from the artifact host produces a ~350-byte XML document named
*.jar and the image builds "successfully" with a corrupt dependency. That
failure would surface far downstream, as a puzzling ClassNotFound or a zip
error, rather than at the download that caused it.

The fix
-------
All seven downloads now use:

  --fail                 exit non-zero on an HTTP error instead of writing the
                         error body to a .jar
  --retry 5
  --retry-connrefused
  --retry-all-errors     retry the transient resets rather than failing the
                         build on the first one
  --connect-timeout 30
  --max-time 600         bound a hung connection so the job fails fast

Kept as separate RUN layers so the existing layer-cache behaviour is unchanged.

Version gate
------------
`--retry-all-errors` requires curl >= 7.71. This Dockerfile is
FROM debezium/connect-base:1.9.5.Final, which ships curl 7.76.1 (verified by
running `curl --version` inside quay.io/debezium/connect-base:1.9.5.Final), so
the flag is supported. Worth stating explicitly because a host with an older
curl rejects the flag outright with "option --retry-all-errors: is unknown",
which would turn a robustness fix into a hard build break.

Scope
-----
Six Dockerfiles in the repo contain curl invocations, but the CI workflows
build only Dockerfile-sink-on-debezium-base-image, so only that file is
changed here.

Verification (curl 7.76.1, matching the base image)
---------------------------------------------------
  case                                   exit   result
  ----                                   ----   ------
  real jar, new flags                    0      8645-byte jar written
  404 url, old flags (-L only)           0      353-byte XML error page
                                                written as .jar  <- the defect
  404 url, new flags                     22     no file written; stderr shows
                                                6 attempts (1 + 5 retries),
                                                confirming the retry loop runs

No Java or connector behaviour is touched by this change.

```
