### PR TITLE
fix(ci): REST API double-start throws JavalinBindException on port 7000

### DIFF
--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/api/DebeziumEmbeddedRestApi.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/api/DebeziumEmbeddedRestApi.java
@@ -96,6 +96,19 @@ public class DebeziumEmbeddedRestApi {
                     + "Set rest.api.auth.username and rest.api.auth.password.");
         }
 
+        // `app` is static, so a second startRestApi() in the same JVM would call
+        // Javalin.start() again on the same port and throw
+        // JavalinBindException("Port already in use"). That is exactly what
+        // happens in the integration suite, where several tests each bring up
+        // the embedded application in one forked JVM: the first bind wins and
+        // every later one dies in a pool thread, failing the job on a port
+        // collision rather than on anything the test was asserting. Reuse the
+        // already-running server instead of racing it.
+        if (app != null) {
+            log.info("REST API already running on port {}; reusing the existing "
+                    + "server instead of binding again", cliPort);
+            return;
+        }
         app = Javalin.create().start(Integer.parseInt(cliPort));
 
         if (authEnabled) {
@@ -319,8 +332,14 @@ public class DebeziumEmbeddedRestApi {
      * Stops the Javalin REST API server.
      */
     public static void stop() {
-        if (app != null)
+        if (app != null) {
             app.stop();
+            // Clear the reference so a later startRestApi() binds a fresh
+            // server. Leaving a stopped instance here would make the
+            // already-running check above short-circuit and silently skip the
+            // restart, leaving the REST API dead after any stop/start cycle.
+            app = null;
+        }
     }
 
     /**

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/api/DebeziumEmbeddedRestApiDoubleStartTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/api/DebeziumEmbeddedRestApiDoubleStartTest.java
@@ -1,0 +1,98 @@
+package com.altinity.clickhouse.debezium.embedded.api;
+
+import io.javalin.Javalin;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Properties;
+
+/**
+ * {@code DebeziumEmbeddedRestApi.app} is static and {@code startRestApi()}
+ * called {@code Javalin.create().start(port)} unconditionally, so a second
+ * start in the same JVM threw
+ * {@code JavalinBindException: Port already in use. Make sure no other process
+ * is using port 7000 and try again.}
+ *
+ * <p>The integration suite runs several tests that each bring up the embedded
+ * application inside one forked JVM, so the first bind won and every later one
+ * died in a pool thread -- failing the job on a port collision rather than on
+ * whatever the test was actually asserting. Observed on CI run 32568334759,
+ * job java-tests-lightweight, repeated across pool-53/60/85/92/99.</p>
+ *
+ * <p>These tests exercise the start/stop lifecycle directly rather than
+ * standing up Debezium, so they need no Docker and run in the unit suite.</p>
+ */
+public class DebeziumEmbeddedRestApiDoubleStartTest {
+
+    @AfterEach
+    public void tearDown() {
+        DebeziumEmbeddedRestApi.stop();
+    }
+
+    /** An ephemeral free port, so the test never fights a real service. */
+    private static String freePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return String.valueOf(socket.getLocalPort());
+        }
+    }
+
+    private static Properties propsOn(String port) {
+        Properties props = new Properties();
+        props.setProperty("cli.port", port);
+        return props;
+    }
+
+    /**
+     * The defect: calling startRestApi() twice must not throw. Before the fix
+     * the second call raised JavalinBindException.
+     */
+    @Test
+    public void startingTwiceDoesNotThrowBindException() throws Exception {
+        String port = freePort();
+
+        DebeziumEmbeddedRestApi.startRestApi(propsOn(port), null, null, new Properties());
+        Javalin first = DebeziumEmbeddedRestApi.app();
+        Assertions.assertNotNull(first, "first start must bind a server");
+
+        Assertions.assertDoesNotThrow(
+                () -> DebeziumEmbeddedRestApi.startRestApi(
+                        propsOn(port), null, null, new Properties()),
+                "a second startRestApi() in the same JVM must reuse the running "
+                        + "server, not bind the port again");
+
+        Assertions.assertSame(first, DebeziumEmbeddedRestApi.app(),
+                "the second call must reuse the same server instance");
+    }
+
+    /**
+     * stop() must clear the static reference, otherwise the already-running
+     * check would short-circuit forever and the REST API would stay dead after
+     * any stop/start cycle.
+     */
+    @Test
+    public void stopThenStartBindsAFreshServer() throws Exception {
+        String port = freePort();
+
+        DebeziumEmbeddedRestApi.startRestApi(propsOn(port), null, null, new Properties());
+        Javalin first = DebeziumEmbeddedRestApi.app();
+
+        DebeziumEmbeddedRestApi.stop();
+        Assertions.assertNull(DebeziumEmbeddedRestApi.app(),
+                "stop() must clear the reference so a restart can bind again");
+
+        DebeziumEmbeddedRestApi.startRestApi(propsOn(port), null, null, new Properties());
+        Assertions.assertNotNull(DebeziumEmbeddedRestApi.app(),
+                "the REST API must come back after a stop/start cycle");
+        Assertions.assertNotSame(first, DebeziumEmbeddedRestApi.app(),
+                "a restart must produce a new server instance");
+    }
+
+    /** stop() on a server that was never started must be a no-op, not an NPE. */
+    @Test
+    public void stopWithoutStartIsSafe() {
+        Assertions.assertDoesNotThrow(DebeziumEmbeddedRestApi::stop);
+    }
+}


### PR DESCRIPTION
**Please review before merging; we do not own this repo. This fixes a flaky CI failure in java-tests-lightweight. Full detail as committed:

```
fix(ci): REST API double-start throws JavalinBindException on port 7000

DebeziumEmbeddedRestApi.app is static and startRestApi() called
`Javalin.create().start(port)` unconditionally, so a second start in the same
JVM bound the same port again and threw:

  io.javalin.util.JavalinBindException: Port already in use.
  Make sure no other process is using port 7000 and try again.

The integration suite runs several tests that each bring up the embedded
application inside one forked JVM. The first bind wins; every later one dies
in a pool thread, so the job fails on a port collision rather than on whatever
the test was asserting. Observed on CI run 32568334759, job
java-tests-lightweight, repeated across pool-53, pool-60, pool-85, pool-92 and
pool-99.

The fix is to reuse the running server instead of racing it: if `app` is
already set, log and return.

stop() also now clears the reference. Without that, the new already-running
check would short-circuit forever and the REST API would stay dead after any
stop/start cycle -- the /stop and /start endpoints exercised by
SinkConnectorClientRestAPITest depend on a restart actually rebinding.

Verification (maven 3.9.11 / JDK 17)
------------------------------------
  mvn -B package install -DskipTests=true       BUILD SUCCESS (the exact CI command)
  DebeziumEmbeddedRestApiDoubleStartTest        3/3 pass
    with the fix reverted                       2/3 FAIL, reproducing the CI
                                                exception verbatim:
                                                io.javalin.util.JavalinBindException:
                                                Port already in use.

The new tests exercise the start/stop lifecycle directly rather than standing
up Debezium, so they need no Docker and run in the ordinary unit suite. Each
binds an ephemeral free port (ServerSocket(0)) rather than 7000, so the test
itself can never collide with a real service or with a parallel job.

Cases covered:
  - startRestApi() twice must not throw, and must reuse the same instance
  - stop() then start() must bind a FRESH server (guards the cleared reference)
  - stop() without a preceding start must be a no-op, not an NPE

No connector or replication behaviour is touched by this change.

```
