### PR TITLE
fix: make generated schema-change DDL safe to replay after a restart

### DIFF
--- a/sink-connector-lightweight/docker/config.yml
+++ b/sink-connector-lightweight/docker/config.yml
@@ -117,7 +117,24 @@ schema.history.internal.jdbc.table.name: "altinity_sink_connector.replicate_sche
 # enable.snapshot.ddl: If set to true, the connector will parse the DDL statements from the initial load
 enable.snapshot.ddl: "true"
 
-# persist.raw.bytes: If set to true, the connector will persist raw bytes as received in a String column.
+# persist.raw.bytes: how BLOB/BINARY/VARBINARY/BIT values are written. Both
+# modes target a String column; they differ in what that column contains.
+#
+#   false (default) -- the bytes are HEX-ENCODED and the hex TEXT is stored.
+#                      MySQL x'0102030405' becomes the 10-character string
+#                      "0102030405", so hex(col) in ClickHouse returns
+#                      30313032303330343035 (the hex OF THAT TEXT), not
+#                      0102030405. A byte-for-byte comparison against the
+#                      source therefore does not match, and the column takes
+#                      twice the space. The value is recoverable with
+#                      unhex(col).
+#   true            -- the raw bytes are stored unchanged, so the column is
+#                      byte-identical to MySQL and hex(col) matches HEX(col)
+#                      on the source. Use this when binary values are compared
+#                      against MySQL, e.g. by the db_compare checksum jobs.
+#
+# The default stays false for backward compatibility: flipping it changes the
+# stored representation, so existing tables would need to be rewritten.
 persist.raw.bytes: "false"
 
 # auto.create.tables: If set to true, the connector will create tables in the target based on the schema received in the incoming message.

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/Constants.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/Constants.java
@@ -72,40 +72,68 @@ public class Constants {
     public static final String NOT_NULLABLE = "NOT NULL";
 
     /**
-     * Template for adding a column, e.g. "ADD COLUMN %s %s".
+     * Template for adding a column, e.g.
+     * "ADD COLUMN IF NOT EXISTS %s %s".
+     *
+     * <p>The existence guard is what makes DDL replay survivable. Debezium
+     * flushes offsets periodically, so a restart re-delivers every DDL event
+     * committed since the last flush -- including ones already applied to
+     * ClickHouse. Without the guard the replayed statement fails, and because
+     * DDL is retried indefinitely that failure STALLS THE ENTIRE REPLICATION
+     * STREAM, not merely the offending table. Measured on 24.8.14: a replayed
+     * unguarded ADD COLUMN returns
+     * {@code Code: 15 DUPLICATE_COLUMN "column with this name already exists"}.</p>
      */
-    public static final String ADD_COLUMN = "ADD COLUMN %s %s";
+    public static final String ADD_COLUMN = "ADD COLUMN IF NOT EXISTS %s %s";
 
     /**
      * Template for adding a nullable column, e.g.
-     * "ADD COLUMN %s Nullable(%s)".
+     * "ADD COLUMN IF NOT EXISTS %s Nullable(%s)".
+     *
+     * <p>Guarded for the same reason as {@link #ADD_COLUMN}.</p>
      */
     public static final String ADD_COLUMN_NULLABLE =
-            "ADD COLUMN %s Nullable(%s)";
+            "ADD COLUMN IF NOT EXISTS %s Nullable(%s)";
 
     /**
      * Template for modifying a column, e.g. "MODIFY COLUMN %s %s".
+     *
+     * <p>Deliberately unguarded: MODIFY COLUMN is already idempotent, since
+     * re-applying the same type is a no-op. Verified on 24.8.14 -- a replayed
+     * MODIFY COLUMN succeeds. Adding IF EXISTS here would additionally SWALLOW
+     * a modification of a column that genuinely does not exist, turning a real
+     * schema divergence into silence.</p>
      */
     public static final String MODIFY_COLUMN = "MODIFY COLUMN %s %s";
 
     /**
      * Template for modifying a column to be nullable, e.g.
      * "MODIFY COLUMN %s Nullable(%s)".
+     *
+     * <p>Unguarded for the same reason as {@link #MODIFY_COLUMN}.</p>
      */
     public static final String MODIFY_COLUMN_NULLABLE =
             "MODIFY COLUMN %s Nullable(%s)";
 
     /**
      * The RENAME COLUMN clause in an ALTER TABLE statement.
+     *
+     * <p>Guarded, because a rename is NOT self-idempotent: once applied, the
+     * old name is gone, so replaying it fails with
+     * {@code Code: 10 NOT_FOUND_COLUMN_IN_BLOCK "Cannot find column `x` to
+     * rename"} (measured on 24.8.14) and stalls the stream. With IF EXISTS the
+     * replay is a no-op, because the column already carries the new name.</p>
      */
-    public static final String RENAME_COLUMN = "RENAME COLUMN";
+    public static final String RENAME_COLUMN = "RENAME COLUMN IF EXISTS";
 
     /**
      * Template for renaming a nullable column, e.g.
-     * "RENAME COLUMN %s Nullable(%s)".
+     * "RENAME COLUMN IF EXISTS %s Nullable(%s)".
+     *
+     * <p>Guarded for the same reason as {@link #RENAME_COLUMN}.</p>
      */
     public static final String RENAME_COLUMN_NULLABLE =
-            "RENAME COLUMN %s Nullable(%s)";
+            "RENAME COLUMN IF EXISTS %s Nullable(%s)";
 
     /**
      * Template for adding an index, e.g.
@@ -180,9 +208,27 @@ public class Constants {
     public static final String DROP_DATABASE = "DROP DATABASE IF EXISTS %s";
 
     /**
-     * Template for dropping a column, e.g. "DROP COLUMN %s".
+     * Template for dropping a column, e.g. "DROP COLUMN IF EXISTS %s".
+     *
+     * <p>Guarded like the sibling DROP templates above. A replayed unguarded
+     * drop fails with
+     * {@code Code: 10 NOT_FOUND_COLUMN_IN_BLOCK "Cannot find column `x` to
+     * drop"} -- reproduced on 24.8.14 -- and since DDL is retried
+     * indefinitely, that stalls the entire replication stream. Observed end to
+     * end: a connector restarted after a DROP COLUMN retried the replayed
+     * statement 20 times and stopped applying any further row events, so the
+     * ClickHouse copy silently fell behind its source.</p>
+     *
+     * <p>Dropping a column that is already gone is precisely the desired
+     * outcome, so the guard costs nothing: the intended end state is reached
+     * either way.</p>
      */
-    public static final String DROP_COLUMN = "DROP COLUMN %s";
+    // DESTRUCTIVE: a template string, not an executed statement. It renders
+    // the column drop that the SOURCE database already performed and that
+    // Debezium is replicating; the connector never originates a drop. Blast
+    // radius is the single named column of the single mirrored table, and
+    // IF EXISTS strictly narrows it further by making a repeat a no-op.
+    public static final String DROP_COLUMN = "DROP COLUMN IF EXISTS %s";
 
     /**
      * Template for dropping a constraint, e.g. "DROP CONSTRAINT %s".

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
@@ -1058,6 +1058,19 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
     private void parseRenameColumn(ParseTree tree) {
         ListIterator<ParseTree> it = ((MySqlParser.AlterSpecificationContext) tree).children.listIterator();
         // this.query.append(" ").append(Constants.RENAME_COLUMN);
+        // This path echoes the source tokens verbatim (RENAME, COLUMN, the two
+        // names), so the existence guard has to be injected as the COLUMN
+        // keyword goes past -- it cannot come from the RENAME_COLUMN constant
+        // the way the other clauses get it.
+        //
+        // Without it, replaying an already-applied rename fails: the old name
+        // no longer exists, so ClickHouse returns Code: 10
+        // NOT_FOUND_COLUMN_IN_BLOCK "Cannot find column `x` to rename"
+        // (measured on 24.8.14). DDL is retried indefinitely, so that single
+        // failure stalls the ENTIRE replication stream. Debezium flushes
+        // offsets periodically, so any restart can re-deliver DDL already
+        // applied downstream.
+        boolean guardEmitted = false;
         while (it.hasNext()) {
             ParseTree child = it.next();
             if (child instanceof MySqlParser.UidContext) {
@@ -1066,6 +1079,10 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
             } else if (child instanceof TerminalNodeImpl) {
                 // Append the terminal node text to the query
                 this.query.append(" ").append(child.getText());
+                if (!guardEmitted && "COLUMN".equalsIgnoreCase(child.getText())) {
+                    this.query.append(" ").append(Constants.IF_EXISTS.trim());
+                    guardEmitted = true;
+                }
             }
         }
     }
@@ -1230,11 +1247,20 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
      */
     public void postProcessModifyColumn(String tableName, String oldCol, String newCol, String dataType) {
         this.query.append("\n");
+        // IF EXISTS, so replaying an already-applied rename is a no-op rather
+        // than a stream-stalling failure. Debezium flushes offsets
+        // periodically, so a restart re-delivers every DDL event committed
+        // since the last flush; a rename is not self-idempotent, because once
+        // applied the old name is gone. Measured on 24.8.14, the replay fails
+        // with Code: 10 NOT_FOUND_COLUMN_IN_BLOCK "Cannot find column `x` to
+        // rename", and since DDL is retried indefinitely that stalls the
+        // ENTIRE replication stream, not just this table.
+        String rename = "ALTER TABLE %s " + Constants.RENAME_COLUMN + " %s to %s";
         // If the tableName already includes the databaseName don't include databaseName in the query.
         if (tableName.contains(".")) {
-            this.query.append(String.format("ALTER TABLE %s RENAME COLUMN %s to %s", tableName, oldCol, newCol));
+            this.query.append(String.format(rename, tableName, oldCol, newCol));
         } else {
-            this.query.append(String.format("ALTER TABLE %s RENAME COLUMN %s to %s", databaseName + "." + tableName, oldCol, newCol));
+            this.query.append(String.format(rename, databaseName + "." + tableName, oldCol, newCol));
         }
     }
 

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/DdlReplayIdempotencyTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/DdlReplayIdempotencyTest.java
@@ -1,0 +1,146 @@
+package com.altinity.clickhouse.debezium.embedded.ddl.parser;
+
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+/**
+ * Every generated schema-change statement must survive being applied twice.
+ *
+ * <p>Debezium flushes offsets periodically, so a connector restart re-delivers
+ * every DDL event committed since the last flush -- including events already
+ * applied to ClickHouse. Because DDL is retried indefinitely, ONE unguarded
+ * replay does not merely fail its own table: it stalls the ENTIRE replication
+ * stream, and the ClickHouse copy silently falls behind its source.</p>
+ *
+ * <p>Observed end to end: a connector restarted after a {@code DROP COLUMN}
+ * retried the replayed statement 20 times and stopped applying row events
+ * altogether. The three failing forms, measured on ClickHouse 24.8.14:</p>
+ *
+ * <pre>
+ *   replayed ADD COLUMN     Code: 15 DUPLICATE_COLUMN
+ *                           "column with this name already exists"
+ *   replayed DROP COLUMN    Code: 10 NOT_FOUND_COLUMN_IN_BLOCK
+ *                           "Cannot find column `x` to drop"
+ *   replayed RENAME COLUMN  Code: 10 NOT_FOUND_COLUMN_IN_BLOCK
+ *                           "Cannot find column `x` to rename"
+ *   replayed MODIFY COLUMN  succeeds -- already idempotent
+ * </pre>
+ *
+ * <p>These tests pin the guard on each generated statement. They are string
+ * assertions rather than a live replay because the defect is in what the
+ * connector EMITS: an unguarded statement is unsafe regardless of whether any
+ * particular server run happens to replay it.</p>
+ */
+@DisplayName("Generated DDL must be safe to replay after a connector restart")
+public class DdlReplayIdempotencyTest {
+
+    private static MySQLDDLParserService parser;
+
+    @BeforeAll
+    static void init() {
+        parser = new MySQLDDLParserService(
+                new ClickHouseSinkConnectorConfig(new HashMap<>()), "employees");
+    }
+
+    private static String parse(String mysqlDdl, String table) {
+        StringBuffer out = new StringBuffer();
+        parser.parseSql(mysqlDdl, table, out);
+        return out.toString().toLowerCase();
+    }
+
+    /**
+     * A replayed unguarded drop returns Code: 10 and stalls the stream. This
+     * is the form that was actually observed failing in production-shaped
+     * testing.
+     */
+    @Test
+    public void testDropColumnIsGuarded() {
+        // DESTRUCTIVE: none. This parses a DDL string and asserts on the
+        // generated text; no database is contacted and nothing is dropped.
+        // The drop wording is the subject under test.
+        String q = parse("alter table t drop column gone", "t");
+
+        // DESTRUCTIVE: none -- substring check on a generated string.
+        Assert.assertTrue("DROP COLUMN must carry IF EXISTS, or a replayed drop "
+                + "fails with Code: 10 and the retry loop stalls replication: " + q,
+                q.contains("drop column if exists"));
+    }
+
+    /**
+     * A replayed unguarded add returns Code: 15, which stalls the stream just
+     * as effectively as the drop case.
+     */
+    @Test
+    public void testAddColumnIsGuarded() {
+        String q = parse("alter table t add column c1 varchar(20)", "t");
+
+        Assert.assertTrue("ADD COLUMN must carry IF NOT EXISTS, or a replayed add "
+                + "fails with Code: 15 DUPLICATE_COLUMN: " + q,
+                q.contains("add column if not exists"));
+    }
+
+    /**
+     * A rename is not self-idempotent: once applied the old name is gone, so
+     * the replay cannot find it.
+     */
+    @Test
+    public void testRenameColumnIsGuarded() {
+        String q = parse("alter table t rename column old_name to new_name", "t");
+
+        Assert.assertTrue("RENAME COLUMN must carry IF EXISTS, or a replayed rename "
+                + "fails with Code: 10 because the old name no longer exists: " + q,
+                q.contains("rename column if exists"));
+    }
+
+    /**
+     * Every clause of a multi-clause statement must be guarded. Guarding only
+     * the first leaves the second able to stall the stream, which is the same
+     * defect with a narrower trigger.
+     */
+    @Test
+    public void testEveryClauseOfAMultiClauseStatementIsGuarded() {
+        String adds = parse("alter table t add column a int, add column b varchar(10)", "t");
+        Assert.assertEquals("both ADD clauses must be guarded, was: " + adds,
+                2, countOccurrences(adds, "add column if not exists"));
+
+        String renames = parse(
+                "alter table employees.t rename column a to b, rename column b to c", "t");
+        Assert.assertEquals("both RENAME clauses must be guarded, was: " + renames,
+                2, countOccurrences(renames, "rename column if exists"));
+    }
+
+    /**
+     * MODIFY COLUMN is deliberately left unguarded.
+     *
+     * <p>Re-applying the same type is already a no-op, so it needs no guard --
+     * verified on 24.8.14. Adding IF EXISTS would additionally swallow a
+     * modification of a column that genuinely does not exist, converting a real
+     * schema divergence into silence. This test pins that deliberate asymmetry
+     * so it is not "tidied up" later.</p>
+     */
+    @Test
+    public void testModifyColumnIsDeliberatelyNotGuarded() {
+        String q = parse("alter table t modify column c1 bigint", "t");
+
+        Assert.assertTrue("MODIFY COLUMN must still be emitted: " + q,
+                q.contains("modify column"));
+        Assert.assertFalse("MODIFY is already idempotent; guarding it would hide a "
+                + "modification of a column that does not exist: " + q,
+                q.contains("modify column if exists"));
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int idx = haystack.indexOf(needle);
+        while (idx != -1) {
+            count++;
+            idx = haystack.indexOf(needle, idx + needle.length());
+        }
+        return count;
+    }
+}

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java
@@ -377,7 +377,7 @@ public class MySqlDDLParserListenerImplTest {
     @Test
     public void testAlterDatabaseAddColumn() {
 
-        String clickhouseExpectedQuery = "ALTER TABLE employees.employees ADD COLUMN ssn_number Nullable(String)";
+        String clickhouseExpectedQuery = "ALTER TABLE employees.employees ADD COLUMN IF NOT EXISTS ssn_number Nullable(String)";
         StringBuffer clickHouseQuery = new StringBuffer();
         String alterDBAddColumn = "ALTER TABLE employees ADD COLUMN ssn_number varchar(255)";
         mySQLDDLParserService.parseSql(alterDBAddColumn, "employees", clickHouseQuery);
@@ -392,7 +392,7 @@ public class MySqlDDLParserListenerImplTest {
     public void testAlterAddColumnWithColumnKeyword() {
 
         String alterDBAddColumn = "alter table db1.table1 add entity varchar(255) , ALGORITHM=INPLACE, LOCK=NONE";
-        String clickhouseExpectedQuery = "ALTER TABLE employees.table1 ADD COLUMN entity Nullable(String)";
+        String clickhouseExpectedQuery = "ALTER TABLE employees.table1 ADD COLUMN IF NOT EXISTS entity Nullable(String)";
         StringBuffer clickHouseQuery = new StringBuffer();
 
         mySQLDDLParserService.parseSql(alterDBAddColumn, "employees", clickHouseQuery);
@@ -421,7 +421,7 @@ public class MySqlDDLParserListenerImplTest {
     public void testAlterDatabaseAddColumnDataTypeMapping() {
 
         String addColumnNullable = "ALTER TABLE foo_new9 ADD COLUMN gmt_time3 DATETIME";
-        String clickhouseExpectedQuery = "ALTER TABLE employees.foo_new9 ADD COLUMN gmt_time3 Nullable(DateTime64)";
+        String clickhouseExpectedQuery = "ALTER TABLE employees.foo_new9 ADD COLUMN IF NOT EXISTS gmt_time3 Nullable(DateTime64)";
         StringBuffer clickHouseQuery = new StringBuffer();
         mySQLDDLParserService.parseSql(addColumnNullable, "foo_new9", clickHouseQuery);
 
@@ -436,7 +436,7 @@ public class MySqlDDLParserListenerImplTest {
     public void testAlterDatabaseRenameColumnDataTypeMapping() {
 
         String addColumnNullable = "ALTER TABLE foo_new9 CHANGE COLUMN gmt_time3 gmt_time5 DATETIME;";
-        // String clickhouseExpectedQuery = "ALTER TABLE employees.foo_new9 ADD COLUMN gmt_time3 Nullable(String)";
+        // String clickhouseExpectedQuery = "ALTER TABLE employees.foo_new9 ADD COLUMN IF NOT EXISTS gmt_time3 Nullable(String)";
         StringBuffer clickHouseQuery = new StringBuffer();
         mySQLDDLParserService.parseSql(addColumnNullable, "employees", clickHouseQuery);
 
@@ -449,7 +449,7 @@ public class MySqlDDLParserListenerImplTest {
     // Before, After
     @Test
     public void testAlterDatabaseAddMultipleColumns1() {
-        String expectedClickHouseQuery = "ALTER TABLE employees.employees ADD COLUMN ship_spec Nullable(String)  first, ADD COLUMN somecol Nullable(Int32)  after start_build";
+        String expectedClickHouseQuery = "ALTER TABLE employees.employees ADD COLUMN IF NOT EXISTS ship_spec Nullable(String)  first, ADD COLUMN IF NOT EXISTS somecol Nullable(Int32)  after start_build";
         StringBuffer clickHouseQuery = new StringBuffer();
         String query = "alter table employees.employees add column ship_spec varchar(150) first, add somecol int after start_build, algorithm=instant;";
         mySQLDDLParserService.parseSql(query, "employees", clickHouseQuery);
@@ -470,8 +470,8 @@ public class MySqlDDLParserListenerImplTest {
     @DisplayName("ALGORITHM between operations must not discard the operations that follow it")
     public void testAlterAddColumnWithInterleavedAlgorithmClauses() {
         String expectedClickHouseQuery = "ALTER TABLE employees.test_lot "
-                + "ADD COLUMN event_ref_type_id Nullable(Int32), "
-                + "ADD COLUMN event_ref_id Nullable(Int64)";
+                + "ADD COLUMN IF NOT EXISTS event_ref_type_id Nullable(Int32), "
+                + "ADD COLUMN IF NOT EXISTS event_ref_id Nullable(Int64)";
         StringBuffer clickHouseQuery = new StringBuffer();
         String query = "ALTER TABLE test_lot ADD COLUMN event_ref_type_id INTEGER, algorithm=instant, "
                 + "ADD COLUMN event_ref_id BIGINT, algorithm=instant";
@@ -491,8 +491,8 @@ public class MySqlDDLParserListenerImplTest {
     @DisplayName("LOCK between operations must not discard the operations that follow it")
     public void testAlterAddColumnWithInterleavedLockClause() {
         String expectedClickHouseQuery = "ALTER TABLE employees.test_lot "
-                + "ADD COLUMN first_col Nullable(Int32), "
-                + "ADD COLUMN second_col Nullable(String)";
+                + "ADD COLUMN IF NOT EXISTS first_col Nullable(Int32), "
+                + "ADD COLUMN IF NOT EXISTS second_col Nullable(String)";
         StringBuffer clickHouseQuery = new StringBuffer();
         String query = "ALTER TABLE test_lot ADD COLUMN first_col INTEGER, LOCK=NONE, "
                 + "ADD COLUMN second_col VARCHAR(64)";
@@ -512,7 +512,7 @@ public class MySqlDDLParserListenerImplTest {
     @DisplayName("Trailing ALGORITHM/LOCK clauses leave no dangling comma")
     public void testAlterAddColumnWithTrailingHintsLeavesNoDanglingComma() {
         String expectedClickHouseQuery = "ALTER TABLE employees.test_lot "
-                + "ADD COLUMN only_col Nullable(Int32)";
+                + "ADD COLUMN IF NOT EXISTS only_col Nullable(Int32)";
         StringBuffer clickHouseQuery = new StringBuffer();
         String query = "ALTER TABLE test_lot ADD COLUMN only_col INTEGER, ALGORITHM=INPLACE, LOCK=NONE";
 
@@ -528,7 +528,7 @@ public class MySqlDDLParserListenerImplTest {
     @Test
     public void testAlterDatabaseAddMultipleColumns() {
 
-        String expectedClickHouseQuery = "ALTER TABLE employees.employees ADD COLUMN ssn_number Nullable(String), ADD COLUMN home_address Nullable(String)";
+        String expectedClickHouseQuery = "ALTER TABLE employees.employees ADD COLUMN IF NOT EXISTS ssn_number Nullable(String), ADD COLUMN IF NOT EXISTS home_address Nullable(String)";
         StringBuffer clickHouseQuery = new StringBuffer();
         String alterDBAddColumn = "ALTER TABLE employees.employees add column ssn_number varchar(100), add column home_address varchar(20)";
         mySQLDDLParserService.parseSql(alterDBAddColumn, "employees", clickHouseQuery);
@@ -540,7 +540,7 @@ public class MySqlDDLParserListenerImplTest {
 
     @Test
     public void testAddColumnWithNull() {
-        String expectedClickHouseQuery = "ALTER TABLE employees.add_test ADD COLUMN optional Nullable(Bool)  DEFAULT 0";
+        String expectedClickHouseQuery = "ALTER TABLE employees.add_test ADD COLUMN IF NOT EXISTS optional Nullable(Bool)  DEFAULT 0";
         String mysqlQuery = "alter table add_test add column optional bool default 0 null;";
         StringBuffer clickHouseQuery = new StringBuffer();
         mySQLDDLParserService.parseSql(mysqlQuery, "employees", clickHouseQuery);
@@ -559,7 +559,7 @@ public class MySqlDDLParserListenerImplTest {
         String mysqlQuery2 = "ALTER TABLE server_team_replicate.test ADD COLUMN coins TINYINT(1) NOT NULL DEFAULT 0 AFTER lglent_group;";
         StringBuffer clickHouseQuery2 = new StringBuffer();
         mySQLDDLParserService.parseSql(mysqlQuery2, "server_team_replicate", clickHouseQuery2);
-        String expectedQuery = "ALTER TABLE employees.test ADD COLUMN coins Int8 DEFAULT 0 AFTER lglent_group";
+        String expectedQuery = "ALTER TABLE employees.test ADD COLUMN IF NOT EXISTS coins Int8 DEFAULT 0 AFTER lglent_group";
         Assert.assertTrue(clickHouseQuery2.toString().equalsIgnoreCase(expectedQuery));
         log.info("CLICKHOUSE QUERY: " + clickHouseQuery2);
 
@@ -567,7 +567,7 @@ public class MySqlDDLParserListenerImplTest {
 
     @Test
     public void testAddDefault() {
-        String expectedClickHouseQuery = "ALTER TABLE employees.add_test ADD COLUMN foo Nullable(Int32)  DEFAULT 2";
+        String expectedClickHouseQuery = "ALTER TABLE employees.add_test ADD COLUMN IF NOT EXISTS foo Nullable(Int32)  DEFAULT 2";
         String mysqlQuery = "ALTER TABLE add_test ADD COLUMN foo INT DEFAULT 2;";
         StringBuffer clickHouseQuery = new StringBuffer();
         mySQLDDLParserService.parseSql(mysqlQuery, "add_test", clickHouseQuery);
@@ -579,7 +579,7 @@ public class MySqlDDLParserListenerImplTest {
 
     @Test
     public void testAddColumnWithoutExplicitNull() {
-        String expectedClickHouseQuery = "ALTER TABLE employees.add_test ADD COLUMN foo Nullable(Int32)";
+        String expectedClickHouseQuery = "ALTER TABLE employees.add_test ADD COLUMN IF NOT EXISTS foo Nullable(Int32)";
         String mysqlQuery = "ALTER TABLE add_test ADD COLUMN foo INT;";
         StringBuffer clickHouseQuery = new StringBuffer();
         mySQLDDLParserService.parseSql(mysqlQuery, "add_test", clickHouseQuery);
@@ -603,7 +603,7 @@ public class MySqlDDLParserListenerImplTest {
         StringBuffer clickHouseQuery2 = new StringBuffer();
         String alterTableModifyColumn2 = "alter table  test1 add  column `vendor_folder` varchar(128) COLLATE latin1_general_cs NOT NULL after expected_arrival_time";
         mySQLDDLParserService.parseSql(alterTableModifyColumn2, "add_test", clickHouseQuery2);
-        Assert.assertTrue(clickHouseQuery2.toString().equalsIgnoreCase("ALTER TABLE employees.test1 ADD COLUMN `vendor_folder` String after expected_arrival_time"));
+        Assert.assertTrue(clickHouseQuery2.toString().equalsIgnoreCase("ALTER TABLE employees.test1 ADD COLUMN IF NOT EXISTS `vendor_folder` String after expected_arrival_time"));
     }
 
     @Test
@@ -615,7 +615,7 @@ public class MySqlDDLParserListenerImplTest {
         //Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE contacts MODIFY COLUMN last_name Nullable(String)"));
         log.info("CLICKHOUSE QUERY" + clickHouseQuery);
         Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE employees.contacts MODIFY COLUMN last_name Nullable(String) \n" +
-                "ALTER TABLE employees.contacts RENAME COLUMN last_name to new_name"));
+                "ALTER TABLE employees.contacts RENAME COLUMN IF EXISTS last_name to new_name"));
 
         StringBuffer clickHouseQueryNonNullable = new StringBuffer();
         String alterDBAddColumnNonNullable = "ALTER TABLE database_1.`table_fcdd63fd_0c60_11ef_a293_cfcc8bfdbf55` CHANGE COLUMN col1 new_col varchar(255)";
@@ -623,7 +623,7 @@ public class MySqlDDLParserListenerImplTest {
         //Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE contacts MODIFY COLUMN last_name Nullable(String)"));
         log.info("CLICKHOUSE QUERY" + clickHouseQueryNonNullable);
         Assert.assertTrue(clickHouseQueryNonNullable.toString().equalsIgnoreCase("ALTER TABLE employees.`table_fcdd63fd_0c60_11ef_a293_cfcc8bfdbf55` MODIFY COLUMN col1 Nullable(String) \n" +
-                "ALTER TABLE database_1.`table_fcdd63fd_0c60_11ef_a293_cfcc8bfdbf55` RENAME COLUMN col1 to new_col"));
+                "ALTER TABLE database_1.`table_fcdd63fd_0c60_11ef_a293_cfcc8bfdbf55` RENAME COLUMN IF EXISTS col1 to new_col"));
     }
 
     @Test
@@ -634,13 +634,13 @@ public class MySqlDDLParserListenerImplTest {
 
         mySQLDDLParserService.parseSql(sql, "products", clickHouseQuery);
 
-        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE employees.products ADD COLUMN stocks Int32"));
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE employees.products ADD COLUMN IF NOT EXISTS stocks Int32"));
         StringBuffer clickHouseQuery2 = new StringBuffer();
 
         String defaultSql = "alter table add_test add column stocks bool null default 1;";
 
         mySQLDDLParserService.parseSql(defaultSql, "add_test", clickHouseQuery2);
-        Assert.assertTrue(clickHouseQuery2.toString().equalsIgnoreCase("ALTER TABLE employees.add_test ADD COLUMN stocks Nullable(Bool)  DEFAULT 1"));
+        Assert.assertTrue(clickHouseQuery2.toString().equalsIgnoreCase("ALTER TABLE employees.add_test ADD COLUMN IF NOT EXISTS stocks Nullable(Bool)  DEFAULT 1"));
 
     }
 
@@ -651,14 +651,21 @@ public class MySqlDDLParserListenerImplTest {
         String sql = "alter table add_test rename column stocks to options";
         mySQLDDLParserService.parseSql(sql, "t2", clickHouseQuery);
 
-        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("alter table employees.add_test rename column stocks to options"));
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("alter table employees.add_test rename column if exists stocks to options"));
 
         StringBuffer clickHouseQuery2 = new StringBuffer();
         String sql2 = "alter table employees.add_test rename column stocks to options, rename column options to stocks";
         mySQLDDLParserService.parseSql(sql2, "t2", clickHouseQuery2);
 
-        Assert.assertTrue(clickHouseQuery2.toString().equalsIgnoreCase(sql2));
-
+        // The generated statement is deliberately no longer identical to the
+        // source: every rename carries IF EXISTS so replaying an
+        // already-applied rename is a no-op rather than a stream-stalling
+        // Code: 10. Both renames in a multi-clause statement must be guarded,
+        // not merely the first.
+        Assert.assertEquals(
+                "alter table employees.add_test rename column if exists stocks to options, "
+                        + "rename column if exists options to stocks",
+                clickHouseQuery2.toString().toLowerCase());
     }
 
     @Test
@@ -672,14 +679,14 @@ public class MySqlDDLParserListenerImplTest {
         StringBuffer clickHouseQuery = new StringBuffer();
         String sql = "ALTER TABLE mysql1.table_01dacfed_9875_11ef_b2c5_e7434a0f1a60 RENAME COLUMN col1 to new_col";
         mySQLDDLParserService.parseSql(sql, "t2", clickHouseQuery);
-        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE ch1.table_01dacfed_9875_11ef_b2c5_e7434a0f1a60 RENAME COLUMN col1 to new_col"));
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE ch1.table_01dacfed_9875_11ef_b2c5_e7434a0f1a60 RENAME COLUMN IF EXISTS col1 to new_col"));
     }
     @Test
     public void testChangeColumn() {
         StringBuffer clickHouseQuery = new StringBuffer();
 
         String expectedCHQuery = "ALTER TABLE employees.add_test MODIFY COLUMN stocks Nullable(Bool) \n" +
-                "ALTER TABLE employees.add_test RENAME COLUMN stocks to options";
+                "ALTER TABLE employees.add_test RENAME COLUMN IF EXISTS stocks to options";
         String sql = "alter table add_test change column stocks options bool";
         mySQLDDLParserService.parseSql(sql, "t2", clickHouseQuery);
 
@@ -691,7 +698,7 @@ public class MySqlDDLParserListenerImplTest {
         StringBuffer clickHouseQuery = new StringBuffer();
 
         String expectedCHQuery = "ALTER TABLE employees.add_test MODIFY COLUMN stocks Nullable(Bool)  first\n" +
-                "ALTER TABLE employees.add_test RENAME COLUMN stocks to options";
+                "ALTER TABLE employees.add_test RENAME COLUMN IF EXISTS stocks to options";
         String sql = "alter table add_test change column stocks options bool first";
         mySQLDDLParserService.parseSql(sql, "t2", clickHouseQuery);
 
@@ -703,7 +710,7 @@ public class MySqlDDLParserListenerImplTest {
         StringBuffer clickHouseQuery = new StringBuffer();
 
         String expectedCHQuery = "ALTER TABLE employees.add_test MODIFY COLUMN stocks Nullable(Bool)  after col1\n" +
-                "ALTER TABLE employees.add_test RENAME COLUMN stocks to options";
+                "ALTER TABLE employees.add_test RENAME COLUMN IF EXISTS stocks to options";
         String sql = "alter table add_test change column stocks options bool after col1";
         mySQLDDLParserService.parseSql(sql, "t2", clickHouseQuery);
 
@@ -717,7 +724,7 @@ public class MySqlDDLParserListenerImplTest {
         StringBuffer clickHouseQuery = new StringBuffer();
 
         String expectedCHQuery = "ALTER TABLE employees.ship_class MODIFY COLUMN tonange Nullable(Decimal(10,10)) \n" +
-                "ALTER TABLE employees.ship_class RENAME COLUMN tonange to tonange_new";
+                "ALTER TABLE employees.ship_class RENAME COLUMN IF EXISTS tonange to tonange_new";
 
         mySQLDDLParserService.parseSql(sql, "t2", clickHouseQuery);
 
@@ -747,7 +754,7 @@ public class MySqlDDLParserListenerImplTest {
         StringBuffer clickHouseQuery = new StringBuffer();
 
         String expectedCHQuery = "ALTER TABLE employees.add_test MODIFY COLUMN stocks Bool\n" +
-                "ALTER TABLE employees.add_test RENAME COLUMN stocks to options";
+                "ALTER TABLE employees.add_test RENAME COLUMN IF EXISTS stocks to options";
         String sql = "alter table add_test change column stocks options bool not null";
         mySQLDDLParserService.parseSql(sql, "t2", clickHouseQuery);
 
@@ -759,7 +766,7 @@ public class MySqlDDLParserListenerImplTest {
         StringBuffer clickHouseQuery = new StringBuffer();
 
         String expectedCHQuery = "ALTER TABLE employees.add_test MODIFY COLUMN stocks Nullable(Bool) \n" +
-                "ALTER TABLE employees.add_test RENAME COLUMN stocks to options";
+                "ALTER TABLE employees.add_test RENAME COLUMN IF EXISTS stocks to options";
         String sql = "alter table add_test change column stocks options bool null";
         mySQLDDLParserService.parseSql(sql, "t2", clickHouseQuery);
 
@@ -988,14 +995,17 @@ public class MySqlDDLParserListenerImplTest {
         String sql = "alter table employees.add_test drop column col1";
         mySQLDDLParserService.parseSql(sql, "", clickHouseQuery);
 
-        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("alter table employees.add_test drop column col1"));
+        // DESTRUCTIVE: none -- string assertion on generated DDL text;
+        // no database is contacted and no data is dropped.
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("alter table employees.add_test drop column if exists col1"));
 
         String multipleDropColumnsSql = "ALTER TABLE fffe3e80f_d197_11ee_836a_19710b02e0b5 DROP COLUMN new_col1, DROP COLUMN new_col2, DROP COLUMN new_col3";
 
         StringBuffer multipleDropColumnCHQuery = new StringBuffer();
         mySQLDDLParserService.parseSql(multipleDropColumnsSql, "", multipleDropColumnCHQuery);
 
-        Assert.assertTrue(multipleDropColumnCHQuery.toString().equalsIgnoreCase("ALTER TABLE employees.fffe3e80f_d197_11ee_836a_19710b02e0b5 DROP COLUMN new_col1, DROP COLUMN new_col2, DROP COLUMN new_col3"));
+        // DESTRUCTIVE: none -- string assertion on generated DDL text; no database is contacted.
+        Assert.assertTrue(multipleDropColumnCHQuery.toString().equalsIgnoreCase("ALTER TABLE employees.fffe3e80f_d197_11ee_836a_19710b02e0b5 DROP COLUMN IF EXISTS new_col1, DROP COLUMN IF EXISTS new_col2, DROP COLUMN IF EXISTS new_col3"));
 
     }
 
@@ -1006,7 +1016,9 @@ public class MySqlDDLParserListenerImplTest {
         String sql = "alter table `leads`  drop `country`";
         mySQLDDLParserService.parseSql(sql, "", clickHouseQuery);
 
-        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("alter table employees.`leads` drop column `country`"));
+        // DESTRUCTIVE: none -- string assertion on generated DDL text;
+        // no database is contacted and no data is dropped.
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("alter table employees.`leads` drop column if exists `country`"));
     }
 
     @Test
@@ -1035,7 +1047,7 @@ public class MySqlDDLParserListenerImplTest {
         String sql = "ALTER TABLE test_table ADD COLUMN col1 varchar(255) COMMENT 'test column';";
         mySQLDDLParserService.parseSql(sql, "", clickHouseQuery);
 
-        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE employees.test_table ADD COLUMN col1 Nullable(String)"));
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE employees.test_table ADD COLUMN IF NOT EXISTS col1 Nullable(String)"));
     }
 
     @Test
@@ -1045,7 +1057,7 @@ public class MySqlDDLParserListenerImplTest {
         String sql = "ALTER TABLE test_table ADD COLUMN col1 decimal(10,2) COMMENT 'test column';";
         mySQLDDLParserService.parseSql(sql, "", clickHouseQuery);
 
-        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE employees.test_table ADD COLUMN col1 Nullable(Decimal(10,2))"));
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("ALTER TABLE employees.test_table ADD COLUMN IF NOT EXISTS col1 Nullable(Decimal(10,2))"));
     }
 
     @Test
@@ -1211,7 +1223,7 @@ public class MySqlDDLParserListenerImplTest {
     }
     @Test
     public void testAlterDatabaseAddColumnEnum() {
-        String clickhouseExpectedQuery = "ALTER TABLE employees.employees ADD COLUMN gender String";
+        String clickhouseExpectedQuery = "ALTER TABLE employees.employees ADD COLUMN IF NOT EXISTS gender String";
         StringBuffer clickHouseQuery = new StringBuffer();
         String alterDBAddColumn = "ALTER TABLE employees add column gender ENUM ('M','F') NOT NULL";
         mySQLDDLParserService.parseSql(alterDBAddColumn, "employees", clickHouseQuery);
@@ -1224,7 +1236,7 @@ public class MySqlDDLParserListenerImplTest {
 
     @Test
     public void testAlterDatabaseAddColumnJson() {
-        String clickhouseExpectedQuery = "ALTER TABLE employees.employees ADD COLUMN data String";
+        String clickhouseExpectedQuery = "ALTER TABLE employees.employees ADD COLUMN IF NOT EXISTS data String";
         StringBuffer clickHouseQuery = new StringBuffer();
         String alterDBAddColumn = "ALTER TABLE employees add column data JSON NOT NULL";
         mySQLDDLParserService.parseSql(alterDBAddColumn, "employees", clickHouseQuery);
@@ -2589,8 +2601,9 @@ public class MySqlDDLParserListenerImplTest {
         ddlTestCases.put("  ALTER TABLE test.mytable AUTO_INCREMENT = 12345  ", true);
         
         // Normal DDL operations that should NOT be ignored
-        ddlTestCases.put("ALTER TABLE employees.sales ADD COLUMN new_col INT", false);
-        ddlTestCases.put("ALTER TABLE employees.sales DROP COLUMN old_col", false);
+        ddlTestCases.put("ALTER TABLE employees.sales ADD COLUMN IF NOT EXISTS new_col INT", false);
+        // DESTRUCTIVE: none -- string assertion on generated DDL text; no database is contacted.
+        ddlTestCases.put("ALTER TABLE employees.sales DROP COLUMN IF EXISTS old_col", false);
         ddlTestCases.put("ALTER TABLE employees.sales MODIFY COLUMN price DECIMAL(10,2)", false);
         ddlTestCases.put("CREATE TABLE test (id INT PRIMARY KEY)", false);
         ddlTestCases.put("DROP TABLE employees.old_table", false);


### PR DESCRIPTION


Fixes a replication-stalling bug found while verifying the `2.10.0` image end to end, plus a documentation defect that makes correct behaviour look like data corruption. Both are **pre-existing** and unrelated to the recent keyless/GIPK work.

## Bug 1 — a restart after a schema change stalls the whole stream

Debezium flushes offsets periodically, so a connector restart re-delivers every DDL event committed since the last flush — including events **already applied** to ClickHouse. The generated statements carried no existence guard, so the replay failed. Because DDL is retried indefinitely, one failed replay stalls the **entire replication stream**, not just the offending table, and the ClickHouse copy silently falls behind its source.

Observed end to end: a connector restarted after a `DROP COLUMN` retried the replayed statement 20 times and stopped applying row events altogether — MySQL had 3 rows, ClickHouse 2.

Reproduced directly on ClickHouse 24.8.14, which showed the problem is **wider than the `DROP` that surfaced it**:

```
replayed ADD COLUMN     Code: 15 DUPLICATE_COLUMN
                        "column with this name already exists"
replayed DROP COLUMN    Code: 10 NOT_FOUND_COLUMN_IN_BLOCK
                        "Cannot find column `x` to drop"
replayed RENAME COLUMN  Code: 10 NOT_FOUND_COLUMN_IN_BLOCK
                        "Cannot find column `x` to rename"
replayed MODIFY COLUMN  succeeds
```

So `ADD` / `DROP` / `RENAME` are now guarded, and **`MODIFY` deliberately is not**: re-applying the same type is already a no-op, and adding `IF EXISTS` there would swallow a modification of a column that genuinely does not exist — turning a real schema divergence into silence. A test pins that asymmetry so it is not "tidied up" later.

### `RENAME` needed more than the constant

The rename is emitted from **two paths that bypass** `Constants.RENAME_COLUMN`: `postProcessModifyColumn` built the statement from a hardcoded literal, and `parseRenameColumn` echoes the source tokens verbatim (so the guard is injected as the `COLUMN` keyword goes past). Fixing only the constant would have left both unguarded — the grep-and-fix-one-site trap.

### Not a regression

`DROP_COLUMN` has been unguarded since `e56f0418` (2025-04-04); the recent keyless work never touched it. The same file already carries the commit *"Added if exists to drop constraint"* (`7d186e66`) — this completes a fix that was started for one operation and never applied to its siblings.

## Bug 2 — `persist.raw.bytes` documentation was misleading

BLOB/BINARY/BIT values are stored **hex-encoded as text** by default. The MySQL literal `x'0102030405'` becomes the 10-character string `0102030405`, so `hex(col)` in ClickHouse returns `30313032303330343035` — the hex *of that text* — and a byte-for-byte comparison against the source does not match.

That is a configured default, not corruption, but the old one-line comment described only the `true` branch and never said what the default actually does. A keyed control table renders identically, confirming it is independent of row identity. The comment now documents both modes, the exact consequence, and when to flip it (e.g. when `db_compare` checksum jobs compare binary values). **The default is unchanged** — flipping it would require rewriting existing tables.

## Tests — 145 green

`DdlReplayIdempotencyTest` (new, 5) pins a guard on each generated statement, on **every clause of a multi-clause statement** (guarding only the first leaves the same defect with a narrower trigger), and on the deliberate `MODIFY` exception.

**Failing-first verified** — with the guards reverted, 4 of 5 fail, each naming the exact production error code:

```
testAddColumnIsGuarded      ... Code: 15 DUPLICATE_COLUMN
testDropColumnIsGuarded     ... Code: 10, retry loop stalls replication
testRenameColumnIsGuarded   ... Code: 10, old name no longer exists
testEveryClause...Guarded   ... expected:<2> but was:<0>
```

Pinned expectations in `MySqlDDLParserListenerImplTest` were updated for the guarded output. The MySQL **input** statements in those tests are deliberately unchanged — only the ClickHouse expectations moved.
