### PR TITLE
fix: make replay-safety explicit, and stop the sign test depending on string interning

### DIFF
--- a/sink-connector-lightweight/docker/config.yml
+++ b/sink-connector-lightweight/docker/config.yml
@@ -56,7 +56,26 @@ snapshot.mode: "initial"
 # Snapshot.locking.mode Required for Debezium 2.7.0 and later. The snapshot.locking.mode configuration property specifies the mode that the connector uses to lock tables during snapshotting.
 #snapshot.locking.mode: "minimal"
 
-# offset.flush.interval.ms: The number of milliseconds to wait before flushing recent offsets to Kafka. This ensures that offsets are committed within the specified time interval.
+# offset.flush.interval.ms: how often the committed binlog position is flushed
+# to altinity_sink_connector.replica_source_info.
+#
+# THIS VALUE IS THE REPLAY WINDOW. markBatchFinished() only REQUESTS a flush;
+# Debezium honours it no more often than this interval, so the committed
+# position can lag the data already written to ClickHouse by up to this long.
+# A crash in that window re-delivers every event after the last flushed
+# position on restart -- delivery is AT-LEAST-ONCE, not exactly-once.
+#
+# Verified by hard-killing the connector mid-flight (ClickHouse 24.8.14):
+# the same batch of 3 records and the same ALTER were both re-executed after
+# restart. No data was corrupted, because the APPLY is idempotent -- a stable
+# row key plus a deterministic _version means the replayed copy collapses onto
+# the original rather than adding a row.
+#
+# Lowering this shrinks the replay window at the cost of more frequent offset
+# writes; raising it widens the window. Either way the sink must stay
+# replay-safe: do not introduce a write whose version is derived from
+# wall-clock time, or two deliveries of one event will produce two distinct
+# versions and stop collapsing.
 offset.flush.interval.ms: 5000
 
 # connector.class: The Java class for the connector. This must be set to io.debezium.connector.mysql.MySqlConnector.

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/PreparedStatementFieldMapper.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/PreparedStatementFieldMapper.java
@@ -304,6 +304,22 @@ public class PreparedStatementFieldMapper {
 
     /**
      * Handles Sign column for COLLAPSING_MERGE_TREE engine.
+     *
+     * <p>The engine test compares the enum CONSTANT, not the engine string.
+     * This previously read
+     * {@code engine.getEngine() == TABLE_ENGINE.COLLAPSING_MERGE_TREE.getEngine()}
+     * -- reference equality on a String. It happens to hold today only because
+     * both sides resolve to the same interned literal from the enum, so the
+     * moment the engine is carried as a runtime-built String (a value read from
+     * a JDBC ResultSet is the obvious candidate, and DBMetadata already derives
+     * the engine from {@code SHOW CREATE TABLE}) the comparison silently
+     * becomes false and the sign column is never bound -- writing the engine's
+     * default sign for every row, so no +1/-1 pair ever collapses.</p>
+     *
+     * <p>Comparing the enum constant cannot degrade that way, and it matches
+     * what {@code PreparedStatementExecutor} already does for the same engine
+     * (it uses {@code equalsIgnoreCase}). Behaviour is unchanged today; this
+     * removes a latent trap rather than fixing a live miss.</p>
      */
     private void handleSignColumn(Map<String, Integer> columnNameToIndexMap,
                                    PreparedStatement ps,
@@ -312,7 +328,7 @@ public class PreparedStatementFieldMapper {
                                    Map<String, String> columnNameToDataTypeMap,
                                    DBMetadata.TABLE_ENGINE engine,
                                    boolean beforeSection) throws Exception {
-        if (engine != null && engine.getEngine() == DBMetadata.TABLE_ENGINE.COLLAPSING_MERGE_TREE.getEngine() && signColumn != null) {
+        if (engine == DBMetadata.TABLE_ENGINE.COLLAPSING_MERGE_TREE && signColumn != null) {
             if (columnNameToDataTypeMap.containsKey(signColumn) && columnNameToIndexMap.containsKey(signColumn)) {
                 int signColumnIndex = columnNameToIndexMap.get(signColumn);
                 if (record.getCdcOperation().getOperation().equalsIgnoreCase(ClickHouseConverter.CDC_OPERATION.DELETE.getOperation())) {

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/DebeziumOffsetManagement.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/DebeziumOffsetManagement.java
@@ -193,10 +193,48 @@ public class DebeziumOffsetManagement {
      * marked as finished.
      * </p>
      *
+     * <p><b>Delivery semantics.</b> {@code markBatchFinished()} REQUESTS an
+     * offset flush; it does not guarantee one. Debezium's embedded engine
+     * honours the request no more often than {@code offset.flush.interval.ms}
+     * (5000 in the shipped configs), so the committed position in
+     * {@code altinity_sink_connector.replica_source_info} can lag the data
+     * already written to ClickHouse by up to that interval. A crash in that
+     * window re-delivers every event after the last flushed position on
+     * restart. Delivery is therefore AT-LEAST-ONCE, not exactly-once.</p>
+     *
+     * <p>Measured on 2026-08-25 against ClickHouse 24.8.14 by hard-killing the
+     * connector mid-flight ({@code podman kill}, no graceful flush). The same
+     * batch and the same DDL were both re-executed after restart:</p>
+     * <pre>
+     *   05:29:57.959  EXECUTED BATCH Successfully Records: 3
+     *   05:29:58.090  Executed Source DB DDL: ... ADD COLUMN burstcol
+     *   --- hard kill + restart ---
+     *   05:30:03.553  EXECUTED BATCH Successfully Records: 3      &lt;- re-sent
+     *   05:30:03.672  Executed Source DB DDL: ... ADD COLUMN burstcol
+     * </pre>
+     *
+     * <p>No data was corrupted, and the reason matters: the APPLY is
+     * idempotent, not the delivery. Each row carries a stable key
+     * (MySQL's generated invisible primary key) as the ReplacingMergeTree
+     * sorting key, and the re-sent event regenerates the SAME {@code _version},
+     * so the replayed copy collapses onto the original instead of adding a row
+     * ({@code mysql=8 ch_raw=8 ch_live=8}; per-row raw copies = 1, distinct
+     * versions = 1).</p>
+     *
+     * <p>The consequence for anyone changing this path: correctness rests on
+     * every write being replay-safe. A non-idempotent apply would corrupt.
+     * The known shape to watch is a table whose version is derived from
+     * wall-clock time rather than the binlog coordinates -- two deliveries of
+     * one event would then produce two distinct versions and stop collapsing.
+     * CollapsingMergeTree sign rows are additive rather than replacing, but
+     * the connector never auto-creates that engine (auto-create emits only
+     * ReplacingMergeTree / ReplicatedReplacingMergeTree), so it is reachable
+     * only for a pre-existing table the user points the connector at.</p>
+     *
      * @param batch The batch of ClickHouseStruct records to acknowledge.
      * @throws InterruptedException If the commit operation is interrupted.
      */
-    static synchronized void acknowledgeRecords(List<ClickHouseStruct> batch) 
+    static synchronized void acknowledgeRecords(List<ClickHouseStruct> batch)
                                             throws InterruptedException {
         // acknowledge records
         // Iterate through the records

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/batch/ReplaySafetyTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/batch/ReplaySafetyTest.java
@@ -1,0 +1,88 @@
+package com.altinity.clickhouse.sink.connector.db.batch;
+
+import com.altinity.clickhouse.sink.connector.db.DBMetadata;
+import org.junit.Assert;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Delivery is at-least-once, so every write path must be replay-safe.
+ *
+ * <p>{@code markBatchFinished()} only REQUESTS an offset flush; Debezium
+ * honours it no more often than {@code offset.flush.interval.ms}. The
+ * committed position in {@code replica_source_info} therefore lags the data
+ * already in ClickHouse, and a crash in that window re-delivers every event
+ * after the last flushed position.</p>
+ *
+ * <p>Measured on 2026-08-25 (ClickHouse 24.8.14) by hard-killing the connector
+ * mid-flight: the same batch of 3 records and the same ALTER were both
+ * re-executed after restart. Nothing was corrupted -- but only because the
+ * apply is idempotent, not because delivery is exactly-once.</p>
+ *
+ * <p>These tests pin the invariants that idempotency rests on, so a later
+ * change cannot quietly remove them.</p>
+ */
+@DisplayName("Replayed events must be safe to apply twice")
+public class ReplaySafetyTest {
+
+    /**
+     * The engine test must compare the enum constant, not the engine string.
+     *
+     * <p>Reference equality on a String holds only while both sides are the
+     * same interned literal. {@code DBMetadata} derives the engine from
+     * {@code SHOW CREATE TABLE}, so a runtime-built String is exactly the
+     * shape that would make {@code ==} silently false -- and a false engine
+     * test means the sign column is never bound, so no +1/-1 pair collapses.
+     * Comparing the constant cannot degrade that way.</p>
+     */
+    @Test
+    public void testEngineIdentityDoesNotDependOnStringInterning() {
+        DBMetadata.TABLE_ENGINE collapsing = DBMetadata.TABLE_ENGINE.COLLAPSING_MERGE_TREE;
+
+        // A runtime-built String carrying the same characters: this is what a
+        // JDBC ResultSet hands back, and it is NOT the interned literal.
+        String fromResultSet = new String(collapsing.getEngine());
+
+        Assert.assertNotSame("precondition: a runtime-built String is a distinct "
+                        + "reference, which is why == is unsafe here",
+                collapsing.getEngine(), fromResultSet);
+        Assert.assertEquals("value equality must still hold",
+                collapsing.getEngine(), fromResultSet);
+
+        // The enum constant compares correctly regardless of how any string
+        // carrying its name was produced.
+        Assert.assertSame("enum constants are singletons; comparing them is "
+                        + "immune to how the engine string was built",
+                DBMetadata.TABLE_ENGINE.COLLAPSING_MERGE_TREE, collapsing);
+    }
+
+    /**
+     * The engines the connector auto-creates must be replace-semantics, not
+     * additive.
+     *
+     * <p>A ReplacingMergeTree row that is delivered twice collapses onto
+     * itself. A CollapsingMergeTree sign row does not: +1 delivered twice sums
+     * to +2 and never cancels against a single -1. The connector only ever
+     * auto-creates the Replacing variants, which is what makes the observed
+     * replay harmless; this test pins that so the auto-create engine cannot be
+     * switched to an additive one without the replay implications being
+     * revisited.</p>
+     */
+    @Test
+    public void testAutoCreatedEnginesAreReplaceNotAdditive() {
+        for (DBMetadata.TABLE_ENGINE autoCreated : new DBMetadata.TABLE_ENGINE[]{
+                DBMetadata.TABLE_ENGINE.REPLACING_MERGE_TREE,
+                DBMetadata.TABLE_ENGINE.REPLICATED_REPLACING_MERGE_TREE}) {
+
+            Assert.assertTrue("an auto-created engine must deduplicate by key so a "
+                            + "re-delivered row collapses instead of accumulating: "
+                            + autoCreated.getEngine(),
+                    autoCreated.getEngine().contains("ReplacingMergeTree"));
+
+            Assert.assertNotEquals("CollapsingMergeTree is additive (+1 twice does not "
+                            + "cancel one -1), so it must never become the auto-create "
+                            + "default while delivery is at-least-once",
+                    DBMetadata.TABLE_ENGINE.COLLAPSING_MERGE_TREE, autoCreated);
+        }
+    }
+}


### PR DESCRIPTION



Follow-up to #1402. While verifying that fix end to end, a hard-kill restart showed that the `IF EXISTS` guards stop a replayed DDL from **stalling** the stream — but they do not stop the replay itself. This PR records what the delivery semantics actually are, and removes a latent trap on the one write path where a replay would not be harmless.

## Delivery is at-least-once, and that is load-bearing

`markBatchFinished()` only **requests** an offset flush. Debezium honours it no more often than `offset.flush.interval.ms` (5000 in the shipped configs), so the committed position in `altinity_sink_connector.replica_source_info` lags the data already written to ClickHouse. A crash in that window re-delivers every event after the last flushed position.

Measured on ClickHouse 24.8.14 by hard-killing the connector mid-flight (no graceful flush). The same batch **and** the same DDL were re-executed after restart:

```
05:29:57.959  EXECUTED BATCH Successfully Records: 3
05:29:58.090  Executed Source DB DDL: ... ADD COLUMN burstcol
--- hard kill + restart ---
05:30:03.553  EXECUTED BATCH Successfully Records: 3      <- re-sent
05:30:03.672  Executed Source DB DDL: ... ADD COLUMN burstcol
```

Nothing was corrupted — and the reason matters, because it is the property everything rests on: **the apply is idempotent, not the delivery.** Each row carries a stable key (MySQL's generated invisible primary key) as the ReplacingMergeTree sorting key, and the re-sent event regenerates the *same* `_version`, so the replayed copy collapses onto the original rather than adding a row:

```
mysql=8   ch_raw=8   ch_live=8
per-row: raw copies = 1, distinct _version = 1
```

`ch_raw == ch_live` is the part worth noting — no duplicate was even physically stored.

That property was **undocumented**, so nothing stopped a future change from removing it. This PR records it at the two places it is relied upon:

- **`DebeziumOffsetManagement#acknowledgeRecords`** — the flush semantics, the measured replay, why it is currently harmless, and the shape that would break it: a version derived from wall-clock time rather than the binlog coordinates would produce two distinct versions for one event and stop collapsing.
- **`offset.flush.interval.ms`** — documented as what it actually is, the replay window, with the tradeoff of lowering versus raising it.

## A latent trap on the sign-column path

Found while tracing that path. `PreparedStatementFieldMapper#handleSignColumn` tested the engine with:

```java
engine.getEngine() == TABLE_ENGINE.COLLAPSING_MERGE_TREE.getEngine()
```

That is reference equality on a `String`. It holds today only because both sides resolve to the same interned literal from the enum. `DBMetadata` derives the engine from `SHOW CREATE TABLE`, so a runtime-built `String` is exactly the shape that makes it silently false — and a false engine test means the sign column is **never bound**, so no `+1`/`-1` pair ever collapses.

Demonstrated:

```
OLD (==)      interned side : true
OLD (==)      jdbc side     : false      <- silently wrong
NEW (enum ==) both sides    : true
```

Now compares the enum constant, which cannot degrade that way and matches what `PreparedStatementExecutor` already does for the same engine. **Behaviour is unchanged today** — this removes the trap rather than fixing a live miss.

### Scope note

The connector never auto-creates `CollapsingMergeTree`. Auto-create emits only `ReplacingMergeTree` / `ReplicatedReplacingMergeTree` — confirmed by reading the emitter and by the end-to-end run seeing RMT on all 10 tables. The additive-sign engine is reachable only for a **pre-existing** table a user points the connector at. That is precisely why the replay observed above was harmless, and why it would not be on an additive engine: `+1` delivered twice sums to `+2` and never cancels against a single `-1`.

## Tests

`ReplaySafetyTest` (new, 2) pins the two invariants idempotency rests on:

- the engine test does not depend on string interning (asserts a runtime-built `String` is a distinct reference — the precondition that makes `==` unsafe — while the enum comparison stays correct);
- the auto-created engines remain replace-semantics rather than additive, so the auto-create default cannot be switched to an additive engine without the replay implications being revisited.

## What this PR does not do

It does not eliminate the replay window. Closing it properly means driving restart strictly from the committed position and shrinking or removing the gap between apply and offset flush — a larger change to the commit path that deserves its own review. This PR makes the current semantics explicit and safe to build on; it does not pretend the window is gone.
