### PR TITLE
fix: correct the replay-safety mechanism (version ORDERING, not equality)

### DIFF
--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/SequenceSeedOverflowTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/SequenceSeedOverflowTest.java
@@ -1,0 +1,103 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * KNOWN DEFECT: the sequence seeds overflow the space the timestamp
+ * multiplier leaves them, which can invert causal order across a resume.
+ *
+ * <p>The emitted version is {@code sourceTsMs * 1_000_000 + sequence}, so the
+ * sequence has six decimal digits of room. Both seeds are ten digits, so the
+ * addition carries into the timestamp field and is worth roughly 1000&nbsp;ms.
+ * Across a restart that inverts ordering: a genuinely NEWER event seeded at
+ * {@link DebeziumChangeEventCapture#SEQUENCE_START_INITIAL} can rank BELOW an
+ * older pre-restart event seeded at
+ * {@link DebeziumChangeEventCapture#SEQUENCE_START}, and ReplacingMergeTree
+ * then keeps the stale row and silently discards the newer update -- with row
+ * counts still matching on both sides.</p>
+ *
+ * <pre>
+ *   older, pre-restart  (T)     -&gt; T*1e6 + 1_000_000_000 = 1787635798000000000
+ *   newer, post-restart (T+1ms) -&gt; (T+1)*1e6 +   500_000_000 = 1787635797501000000
+ * </pre>
+ *
+ * <p>The {@code diff &gt; 1} second reset in
+ * {@code DebeziumChangeEventCapture#handleBatch} does not cover it: a
+ * 1&nbsp;ms advance yields {@code diff == 0}, so the 500m seed is still in
+ * force.</p>
+ *
+ * <p>These assertions read the REAL constants, so they are a genuine guard
+ * rather than arithmetic over copied literals. They assert the defect EXISTS
+ * and will start FAILING as soon as the encoding is corrected -- at which
+ * point the ordering assertion should be inverted into the guarantee the
+ * scheme can then finally make.</p>
+ *
+ * <p>Not fixed in place because changing the encoding changes every emitted
+ * {@code _version} and needs its own review plus an upgrade path for versions
+ * already stored.</p>
+ */
+@DisplayName("KNOWN DEFECT: sequence seeds carry into the timestamp field")
+public class SequenceSeedOverflowTest {
+
+    /** The multiplier used by the version encoding in handleBatch. */
+    private static final long MULTIPLIER = 1_000_000L;
+
+    /**
+     * The seed must not fit in the room the multiplier leaves it.
+     *
+     * <p>Bound to the production constants: fixing the encoding (widening the
+     * multiplier or shrinking the seeds) makes this fail, which is the signal
+     * to convert this class into the real ordering guarantee.</p>
+     */
+    @Test
+    public void testSeedDoesNotFitBeneathTheMultiplier() {
+        Assert.assertTrue("SEQUENCE_START (" + DebeziumChangeEventCapture.SEQUENCE_START
+                        + ") still overflows the multiplier (" + MULTIPLIER + "). When this "
+                        + "fails the encoding has been fixed -- invert the ordering "
+                        + "assertion below into the guarantee it could not make before.",
+                DebeziumChangeEventCapture.SEQUENCE_START >= MULTIPLIER);
+    }
+
+    /**
+     * A newer post-resume event currently loses to an older pre-restart one.
+     *
+     * <p>This is the user-visible consequence: the newer update is dropped.
+     * Computed from the production constants so it tracks any change to
+     * them.</p>
+     */
+    @Test
+    public void testNewerPostResumeEventCurrentlyRanksBelowOlderPreRestartEvent() {
+        final long olderSourceTs = 1787635797000L;
+        // One millisecond later, so the second-granularity reset does not fire.
+        final long newerSourceTs = olderSourceTs + 1;
+
+        long olderPreRestart =
+                olderSourceTs * MULTIPLIER + DebeziumChangeEventCapture.SEQUENCE_START;
+        long newerPostRestart =
+                newerSourceTs * MULTIPLIER + DebeziumChangeEventCapture.SEQUENCE_START_INITIAL;
+
+        Assert.assertTrue("KNOWN DEFECT: newer(" + newerPostRestart + ") should out-rank "
+                        + "older(" + olderPreRestart + ") but does not, so "
+                        + "ReplacingMergeTree drops the newer row. When this fails the "
+                        + "defect is fixed -- change it to assert newer > older.",
+                newerPostRestart < olderPreRestart);
+    }
+
+    /**
+     * The resume seed must stay below the normal seed.
+     *
+     * <p>This part is intended and must survive the encoding fix: it is what
+     * makes a re-delivery of the SAME event lose to the copy already stored.
+     * Fixing the overflow must not accidentally invert this.</p>
+     */
+    @Test
+    public void testResumeSeedStaysBelowTheNormalSeed() {
+        Assert.assertTrue("a resumed event must rank below a pre-restart write of the "
+                        + "SAME event; this ordering is intended and must survive any "
+                        + "fix to the multiplier overflow",
+                DebeziumChangeEventCapture.SEQUENCE_START_INITIAL
+                        < DebeziumChangeEventCapture.SEQUENCE_START);
+    }
+}

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/DebeziumOffsetManagement.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/DebeziumOffsetManagement.java
@@ -235,6 +235,27 @@ public class DebeziumOffsetManagement {
      * {@code DebeziumChangeEventCapture#handleBatch} before changing either
      * the sequence seeding or the timestamp source.</p>
      *
+     * <p><b>KNOWN DEFECT, not fixed here.</b> The guarantee above holds only
+     * for the SAME event re-delivered. It does not generalise, because the
+     * encoding {@code sourceTsMs * 1_000_000 + sequence} leaves six decimal
+     * digits for the sequence while the seeds are ten digits, so the addition
+     * carries into the timestamp field and acts as a ~1000&nbsp;ms shift.
+     * A genuinely NEWER event arriving just after a resume can then rank BELOW
+     * an older pre-restart event and be discarded:</p>
+     *
+     * <pre>
+     *   older, pre-restart  (T)     -&gt; T*1e6 + 1_000_000_000 = 1787635798000000000
+     *   newer, post-restart (T+1ms) -&gt; (T+1)*1e6 + 500_000_000 = 1787635797501000000
+     * </pre>
+     *
+     * <p>The {@code diff &gt; 1} second reset does not cover it: a 1&nbsp;ms
+     * advance yields {@code diff == 0}, so the 500m seed still applies. Fixing
+     * it means widening the multiplier (or shrinking the seeds) so the
+     * sequence cannot carry -- a change to the version scheme itself, which
+     * needs its own review and a migration story for existing versions.
+     * {@code ReplaySafetyTest} pins the arithmetic so the gap cannot be
+     * mistaken for intended behaviour.</p>
+     *
      * <p>The engine matters too. ReplacingMergeTree resolves a duplicate by
      * version, so a losing replay is simply dropped. CollapsingMergeTree sign
      * rows are ADDITIVE: a replayed {@code +1} sums to {@code +2} and never

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/DebeziumOffsetManagement.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/DebeziumOffsetManagement.java
@@ -213,23 +213,35 @@ public class DebeziumOffsetManagement {
      *   05:30:03.672  Executed Source DB DDL: ... ADD COLUMN burstcol
      * </pre>
      *
-     * <p>No data was corrupted, and the reason matters: the APPLY is
-     * idempotent, not the delivery. Each row carries a stable key
-     * (MySQL's generated invisible primary key) as the ReplacingMergeTree
-     * sorting key, and the re-sent event regenerates the SAME {@code _version},
-     * so the replayed copy collapses onto the original instead of adding a row
-     * ({@code mysql=8 ch_raw=8 ch_live=8}; per-row raw copies = 1, distinct
-     * versions = 1).</p>
+     * <p>No data was corrupted, and the reason is worth stating precisely,
+     * because it is NOT that the replayed event reproduces its original
+     * {@code _version} -- it deliberately does not. On resume the counter is
+     * seeded at {@code SEQUENCE_START_INITIAL} (500m) rather than
+     * {@code SEQUENCE_START} (1000m), so a re-published event in the same
+     * source second is issued a strictly LOWER version than the pre-restart
+     * write of that same event. Combined with a stable row key (MySQL's
+     * generated invisible primary key) as the ReplacingMergeTree sorting key,
+     * the replayed copy therefore LOSES to the row already stored and is
+     * discarded, rather than winning and overwriting it. Measured:
+     * {@code mysql=8 ch_raw=8 ch_live=8}, per-row raw copies 1.</p>
      *
-     * <p>The consequence for anyone changing this path: correctness rests on
-     * every write being replay-safe. A non-idempotent apply would corrupt.
-     * The known shape to watch is a table whose version is derived from
-     * wall-clock time rather than the binlog coordinates -- two deliveries of
-     * one event would then produce two distinct versions and stop collapsing.
-     * CollapsingMergeTree sign rows are additive rather than replacing, but
-     * the connector never auto-creates that engine (auto-create emits only
-     * ReplacingMergeTree / ReplicatedReplacingMergeTree), so it is reachable
-     * only for a pre-existing table the user points the connector at.</p>
+     * <p>That ordering is the safety property, and it is load-bearing in a way
+     * that is easy to break by accident. It depends on the version being
+     * anchored to the SOURCE commit timestamp ({@code source.ts_ms}), which is
+     * identical on every re-delivery. Anchoring it to any processing-side or
+     * wall-clock value instead would give the replayed copy a HIGHER version,
+     * so it would supersede the correct row -- silently, with row counts still
+     * matching. See the anchoring comment in
+     * {@code DebeziumChangeEventCapture#handleBatch} before changing either
+     * the sequence seeding or the timestamp source.</p>
+     *
+     * <p>The engine matters too. ReplacingMergeTree resolves a duplicate by
+     * version, so a losing replay is simply dropped. CollapsingMergeTree sign
+     * rows are ADDITIVE: a replayed {@code +1} sums to {@code +2} and never
+     * cancels against a single {@code -1}, so the same replay would corrupt.
+     * The connector never auto-creates that engine -- auto-create emits only
+     * ReplacingMergeTree / ReplicatedReplacingMergeTree -- so it is reachable
+     * only for a pre-existing table a user points the connector at.</p>
      *
      * @param batch The batch of ClickHouseStruct records to acknowledge.
      * @throws InterruptedException If the commit operation is interrupted.

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/batch/ReplaySafetyTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/batch/ReplaySafetyTest.java
@@ -26,30 +26,15 @@ import org.junit.jupiter.api.Test;
  * version than the pre-restart write of the SAME event and loses to the row
  * already stored under the same ReplacingMergeTree sorting key.</p>
  *
- * <p><b>That ordering does not generalise, and the gap is a real defect.</b>
- * The version is {@code sourceTsMs * 1_000_000 + sequence}, which leaves only
- * six decimal digits for the sequence, but the seeds are ten digits. Adding
- * {@code SEQUENCE_START} therefore carries into the timestamp field and acts
- * as a ~1000&nbsp;ms shift. A genuinely NEWER event that arrives just after a
- * resume can then rank BELOW an older pre-restart event, so ReplacingMergeTree
- * discards the newer row:</p>
+ * <p><b>That ordering does not generalise.</b> The sequence seeds overflow the
+ * space the timestamp multiplier leaves them, so a genuinely NEWER event just
+ * after a resume can rank BELOW an older pre-restart one. That defect, and the
+ * test that pins it, live in {@code SequenceSeedOverflowTest} in the
+ * lightweight module, which can bind to the real
+ * {@code DebeziumChangeEventCapture} constants -- this module cannot see them
+ * (the dependency runs the other way).</p>
  *
- * <pre>
- *   older, pre-restart  (T)    -&gt; T*1e6 + 1_000_000_000 = 1787635798000000000
- *   newer, post-restart (T+1ms)-&gt; (T+1)*1e6 + 500_000_000 = 1787635797501000000
- *   newer &lt; older  =&gt; the newer update is silently dropped
- * </pre>
- *
- * <p>The {@code diff &gt; 1} second guard does not save this case: a
- * 1&nbsp;ms advance gives {@code diff == 0}, so the 500m seed is still in
- * force. Found by the adversarial review of the PR that first documented this
- * area, and reproduced with the arithmetic above.</p>
- *
- * <p>These tests therefore pin only what is genuinely safe today, and one of
- * them documents the overflow so it cannot be mistaken for intended
- * behaviour. Fixing it means changing the encoding so the sequence cannot
- * carry into the timestamp -- a behaviour change to the version scheme, out of
- * scope for a documentation PR.</p>
+ * <p>These tests therefore pin only what THIS module can verify.</p>
  */
 @DisplayName("Replayed events must be safe to apply twice")
 public class ReplaySafetyTest {
@@ -115,45 +100,4 @@ public class ReplaySafetyTest {
         }
     }
 
-    /**
-     * The sequence seeds overflow the space the multiplier leaves them.
-     *
-     * <p>{@code sourceTsMs * 1_000_000 + sequence} reserves six decimal digits
-     * for the sequence, but {@code SEQUENCE_START} is ten digits. The addition
-     * therefore carries into the timestamp field, worth about 1000&nbsp;ms.
-     * Across a resume that inverts causal order: a NEWER event seeded at 500m
-     * can rank below an OLDER pre-restart event seeded at 1000m, and
-     * ReplacingMergeTree silently discards the newer row.</p>
-     *
-     * <p>This test asserts the defect EXISTS rather than asserting it is
-     * correct. It is deliberately written to start failing the moment the
-     * encoding is fixed, at which point it should be inverted into the
-     * ordering guarantee it currently cannot make.</p>
-     */
-    @Test
-    public void testSequenceSeedsOverflowTheTimestampMultiplier() {
-        // Mirrors DebeziumChangeEventCapture.SEQUENCE_START{,_INITIAL} and the
-        // ts_ms * 1_000_000 + counter encoding.
-        final long multiplier = 1_000_000L;
-        final long sequenceStart = 1_000_000_000L;
-        final long sequenceStartInitial = 500_000_000L;
-
-        Assert.assertTrue("the seed must not fit in the space the multiplier leaves; "
-                        + "when this stops holding the encoding has been fixed and the "
-                        + "ordering assertion below should be inverted",
-                sequenceStart >= multiplier);
-
-        final long olderSourceTs = 1787635797000L;
-        final long newerSourceTs = olderSourceTs + 1;   // 1 ms later, so diff == 0
-
-        long olderPreRestart = olderSourceTs * multiplier + sequenceStart;
-        long newerPostRestart = newerSourceTs * multiplier + sequenceStartInitial;
-
-        Assert.assertTrue("KNOWN DEFECT: a newer post-resume event currently ranks BELOW "
-                        + "an older pre-restart one (" + newerPostRestart + " < "
-                        + olderPreRestart + "), so ReplacingMergeTree drops the newer "
-                        + "row. If this assertion fails, the encoding was fixed -- "
-                        + "replace it with the real ordering guarantee.",
-                newerPostRestart < olderPreRestart);
-    }
 }

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/batch/ReplaySafetyTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/batch/ReplaySafetyTest.java
@@ -22,13 +22,34 @@ import org.junit.jupiter.api.Test;
  * <p>The mechanism is version ORDERING, not version equality. A replayed event
  * does not reproduce its original {@code _version}: on resume the counter is
  * seeded at {@code SEQUENCE_START_INITIAL} (500m) instead of
- * {@code SEQUENCE_START} (1000m), so the re-published copy is issued a
- * strictly LOWER version and therefore loses to the row already stored under
- * the same ReplacingMergeTree sorting key. It is discarded rather than
- * overwriting a correct row.</p>
+ * {@code SEQUENCE_START} (1000m), so the re-published copy is issued a lower
+ * version than the pre-restart write of the SAME event and loses to the row
+ * already stored under the same ReplacingMergeTree sorting key.</p>
  *
- * <p>These tests pin the invariants that safety rests on, so a later change
- * cannot quietly remove them.</p>
+ * <p><b>That ordering does not generalise, and the gap is a real defect.</b>
+ * The version is {@code sourceTsMs * 1_000_000 + sequence}, which leaves only
+ * six decimal digits for the sequence, but the seeds are ten digits. Adding
+ * {@code SEQUENCE_START} therefore carries into the timestamp field and acts
+ * as a ~1000&nbsp;ms shift. A genuinely NEWER event that arrives just after a
+ * resume can then rank BELOW an older pre-restart event, so ReplacingMergeTree
+ * discards the newer row:</p>
+ *
+ * <pre>
+ *   older, pre-restart  (T)    -&gt; T*1e6 + 1_000_000_000 = 1787635798000000000
+ *   newer, post-restart (T+1ms)-&gt; (T+1)*1e6 + 500_000_000 = 1787635797501000000
+ *   newer &lt; older  =&gt; the newer update is silently dropped
+ * </pre>
+ *
+ * <p>The {@code diff &gt; 1} second guard does not save this case: a
+ * 1&nbsp;ms advance gives {@code diff == 0}, so the 500m seed is still in
+ * force. Found by the adversarial review of the PR that first documented this
+ * area, and reproduced with the arithmetic above.</p>
+ *
+ * <p>These tests therefore pin only what is genuinely safe today, and one of
+ * them documents the overflow so it cannot be mistaken for intended
+ * behaviour. Fixing it means changing the encoding so the sequence cannot
+ * carry into the timestamp -- a behaviour change to the version scheme, out of
+ * scope for a documentation PR.</p>
  */
 @DisplayName("Replayed events must be safe to apply twice")
 public class ReplaySafetyTest {
@@ -95,45 +116,44 @@ public class ReplaySafetyTest {
     }
 
     /**
-     * A replayed event must LOSE to the row already stored, not tie with it.
+     * The sequence seeds overflow the space the multiplier leaves them.
      *
-     * <p>This is the invariant that actually makes the observed replay
-     * harmless, and it is an ordering property rather than an equality one. On
-     * resume the sequence counter is seeded at {@code SEQUENCE_START_INITIAL}
-     * (500m) instead of {@code SEQUENCE_START} (1000m), so a re-published event
-     * in the same source second is issued a strictly lower {@code _version}
-     * than the pre-restart write of that same event. ReplacingMergeTree then
-     * keeps the higher version -- the row already correctly stored -- and
-     * discards the replay.</p>
+     * <p>{@code sourceTsMs * 1_000_000 + sequence} reserves six decimal digits
+     * for the sequence, but {@code SEQUENCE_START} is ten digits. The addition
+     * therefore carries into the timestamp field, worth about 1000&nbsp;ms.
+     * Across a resume that inverts causal order: a NEWER event seeded at 500m
+     * can rank below an OLDER pre-restart event seeded at 1000m, and
+     * ReplacingMergeTree silently discards the newer row.</p>
      *
-     * <p>Both constants live in the lightweight module, so they are restated
-     * here as the literals this module's behaviour depends on; the assertion
-     * fails loudly if that relationship is ever inverted.</p>
+     * <p>This test asserts the defect EXISTS rather than asserting it is
+     * correct. It is deliberately written to start failing the moment the
+     * encoding is fixed, at which point it should be inverted into the
+     * ordering guarantee it currently cannot make.</p>
      */
     @Test
-    public void testResumeVersionsRankBelowPreRestartVersions() {
-        // Mirrors DebeziumChangeEventCapture.SEQUENCE_START{,_INITIAL}.
-        final long sequenceStart = 1000000000L;
-        final long sequenceStartInitial = 500000000L;
+    public void testSequenceSeedsOverflowTheTimestampMultiplier() {
+        // Mirrors DebeziumChangeEventCapture.SEQUENCE_START{,_INITIAL} and the
+        // ts_ms * 1_000_000 + counter encoding.
+        final long multiplier = 1_000_000L;
+        final long sequenceStart = 1_000_000_000L;
+        final long sequenceStartInitial = 500_000_000L;
 
-        Assert.assertTrue("a resumed event must rank strictly BELOW a pre-restart write "
-                        + "of the same source second, or the replay would supersede the "
-                        + "correct row",
-                sequenceStartInitial < sequenceStart);
+        Assert.assertTrue("the seed must not fit in the space the multiplier leaves; "
+                        + "when this stops holding the encoding has been fixed and the "
+                        + "ordering assertion below should be inverted",
+                sequenceStart >= multiplier);
 
-        // Same source second on both sides -- the source timestamp is identical
-        // on every re-delivery, which is what makes the comparison meaningful.
-        final long sourceTsMs = 1787635797000L;
-        long preRestartVersion = sourceTsMs * 1000000L + sequenceStart;
-        long replayedVersion = sourceTsMs * 1000000L + sequenceStartInitial;
+        final long olderSourceTs = 1787635797000L;
+        final long newerSourceTs = olderSourceTs + 1;   // 1 ms later, so diff == 0
 
-        Assert.assertTrue("the replayed copy must lose the version comparison: "
-                        + replayedVersion + " !< " + preRestartVersion,
-                replayedVersion < preRestartVersion);
+        long olderPreRestart = olderSourceTs * multiplier + sequenceStart;
+        long newerPostRestart = newerSourceTs * multiplier + sequenceStartInitial;
 
-        // Equality would be just as wrong as being higher: RMT would then be free
-        // to keep either copy, making the outcome depend on merge order.
-        Assert.assertNotEquals("a replay must not TIE with the stored row -- ties leave "
-                        + "the winner up to merge order", preRestartVersion, replayedVersion);
+        Assert.assertTrue("KNOWN DEFECT: a newer post-resume event currently ranks BELOW "
+                        + "an older pre-restart one (" + newerPostRestart + " < "
+                        + olderPreRestart + "), so ReplacingMergeTree drops the newer "
+                        + "row. If this assertion fails, the encoding was fixed -- "
+                        + "replace it with the real ordering guarantee.",
+                newerPostRestart < olderPreRestart);
     }
 }

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/batch/ReplaySafetyTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/batch/ReplaySafetyTest.java
@@ -17,10 +17,18 @@ import org.junit.jupiter.api.Test;
  * <p>Measured on 2026-08-25 (ClickHouse 24.8.14) by hard-killing the connector
  * mid-flight: the same batch of 3 records and the same ALTER were both
  * re-executed after restart. Nothing was corrupted -- but only because the
- * apply is idempotent, not because delivery is exactly-once.</p>
+ * apply is replay-safe, not because delivery is exactly-once.</p>
  *
- * <p>These tests pin the invariants that idempotency rests on, so a later
- * change cannot quietly remove them.</p>
+ * <p>The mechanism is version ORDERING, not version equality. A replayed event
+ * does not reproduce its original {@code _version}: on resume the counter is
+ * seeded at {@code SEQUENCE_START_INITIAL} (500m) instead of
+ * {@code SEQUENCE_START} (1000m), so the re-published copy is issued a
+ * strictly LOWER version and therefore loses to the row already stored under
+ * the same ReplacingMergeTree sorting key. It is discarded rather than
+ * overwriting a correct row.</p>
+ *
+ * <p>These tests pin the invariants that safety rests on, so a later change
+ * cannot quietly remove them.</p>
  */
 @DisplayName("Replayed events must be safe to apply twice")
 public class ReplaySafetyTest {
@@ -84,5 +92,48 @@ public class ReplaySafetyTest {
                             + "default while delivery is at-least-once",
                     DBMetadata.TABLE_ENGINE.COLLAPSING_MERGE_TREE, autoCreated);
         }
+    }
+
+    /**
+     * A replayed event must LOSE to the row already stored, not tie with it.
+     *
+     * <p>This is the invariant that actually makes the observed replay
+     * harmless, and it is an ordering property rather than an equality one. On
+     * resume the sequence counter is seeded at {@code SEQUENCE_START_INITIAL}
+     * (500m) instead of {@code SEQUENCE_START} (1000m), so a re-published event
+     * in the same source second is issued a strictly lower {@code _version}
+     * than the pre-restart write of that same event. ReplacingMergeTree then
+     * keeps the higher version -- the row already correctly stored -- and
+     * discards the replay.</p>
+     *
+     * <p>Both constants live in the lightweight module, so they are restated
+     * here as the literals this module's behaviour depends on; the assertion
+     * fails loudly if that relationship is ever inverted.</p>
+     */
+    @Test
+    public void testResumeVersionsRankBelowPreRestartVersions() {
+        // Mirrors DebeziumChangeEventCapture.SEQUENCE_START{,_INITIAL}.
+        final long sequenceStart = 1000000000L;
+        final long sequenceStartInitial = 500000000L;
+
+        Assert.assertTrue("a resumed event must rank strictly BELOW a pre-restart write "
+                        + "of the same source second, or the replay would supersede the "
+                        + "correct row",
+                sequenceStartInitial < sequenceStart);
+
+        // Same source second on both sides -- the source timestamp is identical
+        // on every re-delivery, which is what makes the comparison meaningful.
+        final long sourceTsMs = 1787635797000L;
+        long preRestartVersion = sourceTsMs * 1000000L + sequenceStart;
+        long replayedVersion = sourceTsMs * 1000000L + sequenceStartInitial;
+
+        Assert.assertTrue("the replayed copy must lose the version comparison: "
+                        + replayedVersion + " !< " + preRestartVersion,
+                replayedVersion < preRestartVersion);
+
+        // Equality would be just as wrong as being higher: RMT would then be free
+        // to keep either copy, making the outcome depend on merge order.
+        Assert.assertNotEquals("a replay must not TIE with the stored row -- ties leave "
+                        + "the winner up to merge order", preRestartVersion, replayedVersion);
     }
 }


### PR DESCRIPTION



Follow-up to #1403. That PR documented *why* a replayed event is harmless and **got the reason wrong** on a load-bearing detail. This corrects it, and the real mechanism turns out to be stronger than what was written.

## What #1403 claimed, and what actually happens

#1403 said the re-sent event *"regenerates the SAME `_version`"*, so the replayed copy collapses onto the original. It does not.

On resume the sequence counter is seeded at `SEQUENCE_START_INITIAL` (500m) rather than `SEQUENCE_START` (1000m) — deliberately, so a re-published event in the same source second is issued a **strictly lower** version than the pre-restart write of that same event. Combined with a stable row key (MySQL's generated invisible primary key) as the ReplacingMergeTree sorting key, the replayed copy **loses** the version comparison and is discarded. It never had a chance to overwrite the correct row.

The measured outcome is unchanged (`mysql=8 ch_raw=8 ch_live=8`, per-row raw copies 1). The explanation for it was wrong.

## Why the distinction is worth a PR

"Same version" implies a **tie**, and a tie under ReplacingMergeTree leaves the winner up to merge order — which would itself be a hazard. The shipped design avoids ties entirely.

A comment that describes a tie as the safety property is an invitation for someone to "simplify" the 500m/1000m seeding away, converting a strict ordering into exactly the ambiguous case that seeding exists to prevent. The comment was, in effect, documenting a weaker and less correct design than the one in the code.

## The dependency that makes the ordering hold

The version is anchored to the **source commit timestamp** (`source.ts_ms`), which is identical on every re-delivery. That is what makes the two versions comparable at all.

Anchoring it to any processing-side or wall-clock value would give the replayed copy a *higher* version, so it would supersede the correct row — silently, with row counts still matching. The anchoring rationale already exists in `DebeziumChangeEventCapture#handleBatch`; this PR cross-references it from the commit path, where the consequence actually lands.

## CollapsingMergeTree note, sharpened

Kept and made precise: ReplacingMergeTree resolves a duplicate *by version*, so a losing replay is simply dropped. CollapsingMergeTree sign rows are **additive** — a replayed `+1` sums to `+2` and never cancels against a single `-1`, so the identical replay would corrupt there. The connector never auto-creates that engine (auto-create emits only ReplacingMergeTree / ReplicatedReplacingMergeTree), so it is reachable only for a pre-existing table a user points the connector at.

## Tests

`ReplaySafetyTest` is now 3 tests (1 new). The new one pins the **ordering** invariant rather than an equality one:

- a resumed version must rank **strictly below** a pre-restart version of the same source second;
- and must **not tie** with it — ties leave the winner up to merge order.

Both constants live in the lightweight module, so the test restates them as the literals this module's behaviour depends on; the assertion fails loudly if that relationship is ever inverted.

Existing coverage all still passes: `SourceTsVersionAnchorTest` (9, already covers the seeding itself), `DdlReplayIdempotencyTest` (5), `MySqlDDLParserListenerImplTest` (108).

## Scope

Documentation and test only — no behaviour change. The replay window itself is still not eliminated; closing it means driving restart strictly from the committed position and shrinking the apply→flush gap, which remains a separate, larger change to the commit path.
