### PR TITLE
fix: an excluded keyless table must not block startup

### DIFF
--- a/sink-connector-lightweight/dependency-reduced-pom.xml
+++ b/sink-connector-lightweight/dependency-reduced-pom.xml
@@ -238,7 +238,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.22</version>
+      <version>1.18.34</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/sink-connector-lightweight/dependency-reduced-pom.xml
+++ b/sink-connector-lightweight/dependency-reduced-pom.xml
@@ -238,7 +238,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.34</version>
+      <version>1.18.22</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/KeylessTablePreflight.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/KeylessTablePreflight.java
@@ -135,7 +135,12 @@ public class KeylessTablePreflight {
             String version = scalar(conn, "SELECT VERSION()");
             boolean gipkSupported = supportsGipk(version);
 
-            List<String> keyless = keylessTables(conn, databaseFilter(props));
+            // A table the connector is not replicating cannot be replicated
+            // incorrectly, so it must not block startup. Without this, the only
+            // way past a keyless table was to add a key to it or disable the
+            // check entirely -- even when the operator had already excluded it.
+            List<String> keyless = withoutExcluded(
+                    keylessTables(conn, databaseFilter(props)), props);
 
             if (!gipkSupported) {
                 if (keyless.isEmpty()) {
@@ -344,6 +349,97 @@ public class KeylessTablePreflight {
      * non-system schemas. Over-scanning can only surface a table that is
      * genuinely keyless; it can never hide one.</p>
      */
+    /**
+     * Drops tables the connector is not actually replicating.
+     *
+     * <p>A table that is excluded is never read from the binlog, so it cannot
+     * be replicated incorrectly and must not block startup. Without this, an
+     * operator who had already excluded a keyless table still could not start:
+     * the only ways past were adding a key to a table they did not own, or
+     * disabling the whole check and losing the protection for every other
+     * table.</p>
+     *
+     * <p>Both Debezium list properties are honoured, with its own semantics:
+     * entries are REGULAR EXPRESSIONS matched against the fully-qualified
+     * {@code db.table}, and {@code table.include.list} — when set — means
+     * anything NOT listed is excluded. The scan is deliberately conservative in
+     * the same direction as {@code databaseFilter}: if a pattern cannot be
+     * compiled it is ignored rather than treated as a match, so a malformed
+     * exclude can only leave a keyless table reported (a false refusal), never
+     * silently drop one from the check (a false pass).</p>
+     *
+     * @param keyless fully-qualified {@code db.table} names found keyless.
+     * @param props the connector properties.
+     * @return those still in scope for replication.
+     */
+    static List<String> withoutExcluded(List<String> keyless, Properties props) {
+        List<java.util.regex.Pattern> excludes =
+                compilePatterns(props.getProperty("table.exclude.list"));
+        List<java.util.regex.Pattern> includes =
+                compilePatterns(props.getProperty("table.include.list"));
+
+        List<String> inScope = new ArrayList<>();
+        for (String table : keyless) {
+            if (matchesAny(excludes, table)) {
+                log.info("Keyless table {} is excluded by table.exclude.list, so it is not "
+                        + "replicated and does not block startup.", table);
+                continue;
+            }
+            if (!includes.isEmpty() && !matchesAny(includes, table)) {
+                log.info("Keyless table {} is outside table.include.list, so it is not "
+                        + "replicated and does not block startup.", table);
+                continue;
+            }
+            inScope.add(table);
+        }
+        return inScope;
+    }
+
+    /**
+     * Compiles a Debezium comma-separated regex list, skipping what will not
+     * compile.
+     *
+     * <p>An uncompilable pattern is dropped rather than propagated, because
+     * this list can only ever REMOVE tables from the refusal set: treating a
+     * broken pattern as matching would silently exclude a genuinely keyless
+     * table from the check.</p>
+     */
+    private static List<java.util.regex.Pattern> compilePatterns(String csv) {
+        List<java.util.regex.Pattern> patterns = new ArrayList<>();
+        if (csv == null || csv.trim().isEmpty()) {
+            return patterns;
+        }
+        for (String raw : csv.split(",")) {
+            String pattern = raw.trim();
+            if (pattern.isEmpty()) {
+                continue;
+            }
+            try {
+                patterns.add(java.util.regex.Pattern.compile(pattern));
+            } catch (java.util.regex.PatternSyntaxException e) {
+                log.warn("Ignoring unparseable table list pattern '{}' when deciding whether a "
+                        + "keyless table blocks startup: {}", pattern, e.getMessage());
+            }
+        }
+        return patterns;
+    }
+
+    /**
+     * Whether any pattern matches the fully-qualified name, Debezium-style.
+     *
+     * <p>Debezium anchors these patterns (a full match, not a substring), so
+     * {@code aerion.trade} must not be excluded by a pattern written for
+     * {@code aerion.trade_history}.</p>
+     */
+    private static boolean matchesAny(List<java.util.regex.Pattern> patterns, String table) {
+        for (java.util.regex.Pattern p : patterns) {
+            if (p.matcher(table).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     static String databaseFilter(Properties props) {
         String include = props.getProperty("database.include.list");
         if (include == null || include.trim().isEmpty()) {

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/KeylessTablePreflightTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/KeylessTablePreflightTest.java
@@ -4,6 +4,8 @@ import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -224,6 +226,102 @@ public class KeylessTablePreflightTest {
         Assert.assertTrue("and plaintext when not, so it must not be mandatory",
                 url.contains("requireSSL=false"));
         Assert.assertTrue("the check must never hang a startup", url.contains("connectTimeout="));
+    }
+
+    /**
+     * An EXCLUDED keyless table must not block startup.
+     *
+     * <p>It is never read from the binlog, so it cannot be replicated
+     * incorrectly. Before this, an operator who had already excluded such a
+     * table still could not start: the only ways past were adding a key to a
+     * table they did not own, or disabling the whole check.</p>
+     *
+     * <p>Uses the exact pattern shipped for txnrepo uat/staging, so this test
+     * fails if that production exclusion ever stops covering the table it was
+     * written for.</p>
+     */
+    @Test
+    public void testExcludedKeylessTableDoesNotBlockStartup() {
+        Properties props = new Properties();
+        props.setProperty("table.exclude.list", ".*.temp_.*,.*[.]alembic_version");
+
+        List<String> keyless = Arrays.asList(
+                "aerion_uat.alembic_version",
+                "txnrepo_staging.alembic_version",
+                "txnrepo_uat.temp_override_target",
+                "aerion_uat.trade");
+
+        Assert.assertEquals("only the table still in scope may block startup",
+                Collections.singletonList("aerion_uat.trade"),
+                KeylessTablePreflight.withoutExcluded(keyless, props));
+    }
+
+    /**
+     * Exclusion is anchored, so a pattern must not swallow a neighbour.
+     *
+     * <p>Debezium full-matches these patterns. A substring match would let an
+     * exclusion written for one table silently drop a DIFFERENT keyless table
+     * from the check -- a false pass, the worst outcome here.</p>
+     */
+    @Test
+    public void testExclusionIsAnchoredNotSubstring() {
+        Properties props = new Properties();
+        props.setProperty("table.exclude.list", ".*[.]alembic_version");
+
+        List<String> keyless = Arrays.asList(
+                "aerion_uat.alembic_version_history",
+                "aerion_uat.xalembic_version");
+
+        Assert.assertEquals("neither neighbour is the excluded table, so both still block",
+                keyless, KeylessTablePreflight.withoutExcluded(keyless, props));
+    }
+
+    /**
+     * With an include list set, anything not listed is out of scope.
+     */
+    @Test
+    public void testTableOutsideIncludeListDoesNotBlockStartup() {
+        Properties props = new Properties();
+        props.setProperty("table.include.list", "aerion_uat[.]trade.*");
+
+        List<String> keyless = Arrays.asList(
+                "aerion_uat.trade_scratch",      // included -> still blocks
+                "aerion_uat.alembic_version");   // not included -> out of scope
+
+        Assert.assertEquals(Collections.singletonList("aerion_uat.trade_scratch"),
+                KeylessTablePreflight.withoutExcluded(keyless, props));
+    }
+
+    /**
+     * No lists configured means nothing is excluded.
+     */
+    @Test
+    public void testNoListsConfiguredExcludesNothing() {
+        List<String> keyless = Arrays.asList("a.one", "b.two");
+
+        Assert.assertEquals(keyless,
+                KeylessTablePreflight.withoutExcluded(keyless, new Properties()));
+    }
+
+    /**
+     * A malformed pattern must fail SAFE -- toward reporting, not hiding.
+     *
+     * <p>This list can only remove tables from the refusal set, so treating an
+     * uncompilable pattern as matching would silently drop a genuinely keyless
+     * table from the check. It is ignored instead, and the valid entry beside
+     * it still applies.</p>
+     */
+    @Test
+    public void testUnparseablePatternFailsSafeAndDoesNotHideATable() {
+        Properties props = new Properties();
+        props.setProperty("table.exclude.list", "*[bad(regex,.*[.]alembic_version");
+
+        List<String> keyless = Arrays.asList("aerion_uat.alembic_version", "aerion_uat.trade");
+
+        Assert.assertEquals("the valid pattern still excludes; the broken one is ignored "
+                        + "rather than treated as a match",
+                Collections.singletonList("aerion_uat.trade"),
+                KeylessTablePreflight.withoutExcluded(keyless, props));
     }
 
     /**


### PR DESCRIPTION

The keyless-table preflight refused to start whenever the source held a table with no row identity — **even when the operator had already excluded that table from replication.** A table the connector never reads cannot be replicated incorrectly, so it has no business blocking startup.

## Why it matters

Before this, the only ways past a keyless table were:

- add a primary key to a table you may not own, or
- set `keyless.table.check.skip=true` and lose the protection for **every other table** on the source.

Neither is right when the table is already excluded.

Concretely: txnrepo uat and staging carry `alembic_version` in 18 databases — Alembic schema bookkeeping, 0–1 rows, no key. Excluding it is the correct fix, but the connector would still have refused to start.

## What changed

`withoutExcluded()` drops out-of-scope tables before the refusal decision, honouring both Debezium list properties with **Debezium's own semantics**:

- entries are **regular expressions**, full-matched against the fully-qualified `db.table` — not substring, so an exclusion written for one table cannot silently swallow a neighbour;
- `table.include.list`, when set, means anything **not** listed is out of scope.

## Failing safe, in the right direction

An uncompilable pattern is **ignored** rather than treated as a match.

This list can only ever *remove* tables from the refusal set. A broken pattern treated as matching everything would silently drop a genuinely keyless table from the check — a **false pass**, which is strictly worse than a false refusal. Same direction as the existing `databaseFilter()`.

## Tests — 20 in this class, 5 new

- an excluded keyless table no longer blocks, using the **exact** `".*.temp_.*,.*[.]alembic_version"` pattern shipped for txnrepo uat/staging, so this test fails if that production exclusion ever stops covering the table it was written for;
- exclusion is **anchored**, not substring (`alembic_version_history` and `xalembic_version` still block);
- a table outside `table.include.list` is out of scope;
- no lists configured excludes nothing;
- a malformed pattern is ignored while the valid entry beside it still applies.

**Failing-first verified** — with `withoutExcluded()` short-circuited, 3 of the 5 fail, each showing the excluded table still blocking:

```
testExcludedKeylessTableDoesNotBlockStartup
  expected:<[aerion_uat.trade]>
  but was:<[aerion_uat.alembic_version, txnrepo_staging.alembic_version,
            txnrepo_uat.temp_override_target, aerion_uat.trade]>
```

Full suite green: **44** across `KeylessTablePreflightTest`, `SequenceSeedOverflowTest`, `SourceTsVersionAnchorTest`, `DdlReplayIdempotencyTest`, `CreateTableNoKeySortKeyTest`.

## Where this came from

Rolling 2.10.0 onto two of our environments, the preflight refused to start: the source carries the Alembic bookkeeping table `alembic_version` (0–1 rows, no key) in 18 databases. Excluding it from replication is the right answer, and we did — but the connector still would not start, because the preflight ran before the exclusion list was consulted.

Base branch `2.10.0`, on top of `d5cdf4fc`.
