### PR TITLE
fix: the keyless preflight must not reconfigure the source server

### DIFF
--- a/sink-connector-lightweight/dependency-reduced-pom.xml
+++ b/sink-connector-lightweight/dependency-reduced-pom.xml
@@ -238,7 +238,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.22</version>
+      <version>1.18.34</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/sink-connector-lightweight/dependency-reduced-pom.xml
+++ b/sink-connector-lightweight/dependency-reduced-pom.xml
@@ -238,7 +238,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.34</version>
+      <version>1.18.22</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/KeylessTablePreflight.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/KeylessTablePreflight.java
@@ -277,9 +277,10 @@ public class KeylessTablePreflight {
      */
     private static boolean gipkEnabledGlobally(Connection conn) {
         try {
-            return "ON".equalsIgnoreCase(
-                    scalar(conn, "SELECT @@GLOBAL.sql_generate_invisible_primary_key"))
-                    || "1".equals(scalar(conn, "SELECT @@GLOBAL.sql_generate_invisible_primary_key"));
+            // One round trip: MySQL renders this as 1/0 or ON/OFF depending on
+            // version and client, so both spellings are accepted.
+            String value = scalar(conn, "SELECT @@GLOBAL.sql_generate_invisible_primary_key");
+            return "ON".equalsIgnoreCase(value) || "1".equals(value);
         } catch (Exception e) {
             log.debug("Could not read @@GLOBAL.sql_generate_invisible_primary_key: {}", e.toString());
             return false;

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/KeylessTablePreflight.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/KeylessTablePreflight.java
@@ -135,7 +135,12 @@ public class KeylessTablePreflight {
             String version = scalar(conn, "SELECT VERSION()");
             boolean gipkSupported = supportsGipk(version);
 
-            List<String> keyless = keylessTables(conn, databaseFilter(props));
+            // A table the connector is not replicating cannot be replicated
+            // incorrectly, so it must not block startup. Without this, the only
+            // way past a keyless table was to add a key to it or disable the
+            // check entirely -- even when the operator had already excluded it.
+            List<String> keyless = withoutExcluded(
+                    keylessTables(conn, databaseFilter(props)), props);
 
             if (!gipkSupported) {
                 if (keyless.isEmpty()) {
@@ -344,6 +349,97 @@ public class KeylessTablePreflight {
      * non-system schemas. Over-scanning can only surface a table that is
      * genuinely keyless; it can never hide one.</p>
      */
+    /**
+     * Drops tables the connector is not actually replicating.
+     *
+     * <p>A table that is excluded is never read from the binlog, so it cannot
+     * be replicated incorrectly and must not block startup. Without this, an
+     * operator who had already excluded a keyless table still could not start:
+     * the only ways past were adding a key to a table they did not own, or
+     * disabling the whole check and losing the protection for every other
+     * table.</p>
+     *
+     * <p>Both Debezium list properties are honoured, with its own semantics:
+     * entries are REGULAR EXPRESSIONS matched against the fully-qualified
+     * {@code db.table}, and {@code table.include.list} — when set — means
+     * anything NOT listed is excluded. The scan is deliberately conservative in
+     * the same direction as {@code databaseFilter}: if a pattern cannot be
+     * compiled it is ignored rather than treated as a match, so a malformed
+     * exclude can only leave a keyless table reported (a false refusal), never
+     * silently drop one from the check (a false pass).</p>
+     *
+     * @param keyless fully-qualified {@code db.table} names found keyless.
+     * @param props the connector properties.
+     * @return those still in scope for replication.
+     */
+    static List<String> withoutExcluded(List<String> keyless, Properties props) {
+        List<java.util.regex.Pattern> excludes =
+                compilePatterns(props.getProperty("table.exclude.list"));
+        List<java.util.regex.Pattern> includes =
+                compilePatterns(props.getProperty("table.include.list"));
+
+        List<String> inScope = new ArrayList<>();
+        for (String table : keyless) {
+            if (matchesAny(excludes, table)) {
+                log.info("Keyless table {} is excluded by table.exclude.list, so it is not "
+                        + "replicated and does not block startup.", table);
+                continue;
+            }
+            if (!includes.isEmpty() && !matchesAny(includes, table)) {
+                log.info("Keyless table {} is outside table.include.list, so it is not "
+                        + "replicated and does not block startup.", table);
+                continue;
+            }
+            inScope.add(table);
+        }
+        return inScope;
+    }
+
+    /**
+     * Compiles a Debezium comma-separated regex list, skipping what will not
+     * compile.
+     *
+     * <p>An uncompilable pattern is dropped rather than propagated, because
+     * this list can only ever REMOVE tables from the refusal set: treating a
+     * broken pattern as matching would silently exclude a genuinely keyless
+     * table from the check.</p>
+     */
+    private static List<java.util.regex.Pattern> compilePatterns(String csv) {
+        List<java.util.regex.Pattern> patterns = new ArrayList<>();
+        if (csv == null || csv.trim().isEmpty()) {
+            return patterns;
+        }
+        for (String raw : csv.split(",")) {
+            String pattern = raw.trim();
+            if (pattern.isEmpty()) {
+                continue;
+            }
+            try {
+                patterns.add(java.util.regex.Pattern.compile(pattern));
+            } catch (java.util.regex.PatternSyntaxException e) {
+                log.warn("Ignoring unparseable table list pattern '{}' when deciding whether a "
+                        + "keyless table blocks startup: {}", pattern, e.getMessage());
+            }
+        }
+        return patterns;
+    }
+
+    /**
+     * Whether any pattern matches the fully-qualified name, Debezium-style.
+     *
+     * <p>Debezium anchors these patterns (a full match, not a substring), so
+     * {@code aerion.trade} must not be excluded by a pattern written for
+     * {@code aerion.trade_history}.</p>
+     */
+    private static boolean matchesAny(List<java.util.regex.Pattern> patterns, String table) {
+        for (java.util.regex.Pattern p : patterns) {
+            if (p.matcher(table).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     static String databaseFilter(Properties props) {
         String include = props.getProperty("database.include.list");
         if (include == null || include.trim().isEmpty()) {

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/KeylessTablePreflight.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/KeylessTablePreflight.java
@@ -157,9 +157,21 @@ public class KeylessTablePreflight {
             if (!keyless.isEmpty()) {
                 throw new UnsupportedSourceException(refusalPreExisting(keyless));
             }
-            log.info("Keyless-table check passed: no table without a PRIMARY KEY or UNIQUE key, and "
-                    + "sql_generate_invisible_primary_key is ON so any created from now on will "
-                    + "receive one from MySQL.");
+            if (gipkEnabledGlobally(conn)) {
+                log.info("Keyless-table check passed: no table without a PRIMARY KEY or UNIQUE key, and "
+                        + "sql_generate_invisible_primary_key is ON so any created from now on will "
+                        + "receive one from MySQL.");
+            } else {
+                log.warn("Keyless-table check passed: every table currently has a row identity. But "
+                        + "sql_generate_invisible_primary_key is OFF on this server, so a table created "
+                        + "from now on WITHOUT a PRIMARY KEY will have no row identity in the binlog and "
+                        + "will be refused at the next restart. To have MySQL supply one automatically:\n"
+                        + "    SET GLOBAL sql_generate_invisible_primary_key = ON;\n"
+                        + "    # and in my.cnf so it survives a restart:\n"
+                        + "    sql_generate_invisible_primary_key = ON\n"
+                        + "Note this makes MySQL REJECT keyless CREATE TABLE ... PARTITION BY, so it is "
+                        + "the server owner's call -- the connector does not set it.");
+            }
         } catch (UnsupportedSourceException e) {
             throw e;
         } catch (Exception e) {
@@ -223,14 +235,29 @@ public class KeylessTablePreflight {
     }
 
     /**
-     * Turns GIPK on for this session, and globally when the account may.
+     * Turns GIPK on for the preflight's own session only.
      *
-     * <p>The session setting is what matters for correctness here: it is not
-     * replicated and applier threads ignore it, but the connector does not
-     * create source tables. Setting it globally is the useful part -- it makes
-     * MySQL give a key to keyless tables created by the application from now
-     * on. A missing SUPER/SYSTEM_VARIABLES_ADMIN grant is expected and is
-     * reported rather than treated as a failure.</p>
+     * <p>This deliberately does NOT write the global. A read-only replication
+     * consumer must not reconfigure the server it reads from, and this
+     * particular global is not inert: with
+     * {@code sql_generate_invisible_primary_key=ON}, MySQL REJECTS every
+     * subsequent keyless {@code CREATE TABLE ... PARTITION BY} on the whole
+     * server with</p>
+     *
+     * <pre>
+     *   ERROR 1235 (42000): This version of MySQL doesn't yet support
+     *   'generating invisible primary key for the partitioned tables'
+     * </pre>
+     *
+     * <p>So starting the connector would have broken partitioned-table DDL for
+     * every application sharing that MySQL -- an outage on the SOURCE caused by
+     * a consumer, persisting after the connector stopped, and surviving until
+     * someone found the global and reset it. Setting the global is the
+     * operator's decision to make, with their own knowledge of what else uses
+     * the server; the refusal message already spells out the exact statements.
+     *
+     * <p>The session setting is kept: it is harmless (the connector creates no
+     * source tables), and it makes the preflight's own behaviour explicit.</p>
      */
     private static void enableGipk(Connection conn) {
         try (Statement st = conn.createStatement()) {
@@ -238,20 +265,24 @@ public class KeylessTablePreflight {
         } catch (Exception e) {
             log.warn("Could not set sql_generate_invisible_primary_key for this session: {}", e.toString());
         }
-        try (Statement st = conn.createStatement()) {
-            st.execute("SET GLOBAL sql_generate_invisible_primary_key = ON");
-            log.info("Enabled sql_generate_invisible_primary_key globally: a table created without a "
-                    + "PRIMARY KEY from now on receives my_row_id from MySQL, which is carried by the "
-                    + "binlogged DDL and by every row image.");
+    }
+
+    /**
+     * Whether the server will give newly created keyless tables a key.
+     *
+     * @param conn an open connection to the source.
+     * @return true when the global {@code sql_generate_invisible_primary_key}
+     *         is ON. Unreadable is reported as false: the advice that follows
+     *         is then merely redundant, never wrongly reassuring.
+     */
+    private static boolean gipkEnabledGlobally(Connection conn) {
+        try {
+            return "ON".equalsIgnoreCase(
+                    scalar(conn, "SELECT @@GLOBAL.sql_generate_invisible_primary_key"))
+                    || "1".equals(scalar(conn, "SELECT @@GLOBAL.sql_generate_invisible_primary_key"));
         } catch (Exception e) {
-            log.warn("Could not enable sql_generate_invisible_primary_key globally ({}). Grant the "
-                            + "connector's account SYSTEM_VARIABLES_ADMIN, or set it on the server:\n"
-                            + "    SET GLOBAL sql_generate_invisible_primary_key = ON;\n"
-                            + "    # and in my.cnf so it survives a restart:\n"
-                            + "    sql_generate_invisible_primary_key = ON\n"
-                            + "Until then a newly created keyless table has no row identity in the "
-                            + "binlog and will be refused at the next restart.",
-                    e.toString());
+            log.debug("Could not read @@GLOBAL.sql_generate_invisible_primary_key: {}", e.toString());
+            return false;
         }
     }
 

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/KeylessTablePreflightTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/KeylessTablePreflightTest.java
@@ -4,6 +4,8 @@ import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -224,6 +226,102 @@ public class KeylessTablePreflightTest {
         Assert.assertTrue("and plaintext when not, so it must not be mandatory",
                 url.contains("requireSSL=false"));
         Assert.assertTrue("the check must never hang a startup", url.contains("connectTimeout="));
+    }
+
+    /**
+     * An EXCLUDED keyless table must not block startup.
+     *
+     * <p>It is never read from the binlog, so it cannot be replicated
+     * incorrectly. Before this, an operator who had already excluded such a
+     * table still could not start: the only ways past were adding a key to a
+     * table they did not own, or disabling the whole check.</p>
+     *
+     * <p>Uses the exact pattern shipped for txnrepo uat/staging, so this test
+     * fails if that production exclusion ever stops covering the table it was
+     * written for.</p>
+     */
+    @Test
+    public void testExcludedKeylessTableDoesNotBlockStartup() {
+        Properties props = new Properties();
+        props.setProperty("table.exclude.list", ".*.temp_.*,.*[.]alembic_version");
+
+        List<String> keyless = Arrays.asList(
+                "aerion_uat.alembic_version",
+                "txnrepo_staging.alembic_version",
+                "txnrepo_uat.temp_override_target",
+                "aerion_uat.trade");
+
+        Assert.assertEquals("only the table still in scope may block startup",
+                Collections.singletonList("aerion_uat.trade"),
+                KeylessTablePreflight.withoutExcluded(keyless, props));
+    }
+
+    /**
+     * Exclusion is anchored, so a pattern must not swallow a neighbour.
+     *
+     * <p>Debezium full-matches these patterns. A substring match would let an
+     * exclusion written for one table silently drop a DIFFERENT keyless table
+     * from the check -- a false pass, the worst outcome here.</p>
+     */
+    @Test
+    public void testExclusionIsAnchoredNotSubstring() {
+        Properties props = new Properties();
+        props.setProperty("table.exclude.list", ".*[.]alembic_version");
+
+        List<String> keyless = Arrays.asList(
+                "aerion_uat.alembic_version_history",
+                "aerion_uat.xalembic_version");
+
+        Assert.assertEquals("neither neighbour is the excluded table, so both still block",
+                keyless, KeylessTablePreflight.withoutExcluded(keyless, props));
+    }
+
+    /**
+     * With an include list set, anything not listed is out of scope.
+     */
+    @Test
+    public void testTableOutsideIncludeListDoesNotBlockStartup() {
+        Properties props = new Properties();
+        props.setProperty("table.include.list", "aerion_uat[.]trade.*");
+
+        List<String> keyless = Arrays.asList(
+                "aerion_uat.trade_scratch",      // included -> still blocks
+                "aerion_uat.alembic_version");   // not included -> out of scope
+
+        Assert.assertEquals(Collections.singletonList("aerion_uat.trade_scratch"),
+                KeylessTablePreflight.withoutExcluded(keyless, props));
+    }
+
+    /**
+     * No lists configured means nothing is excluded.
+     */
+    @Test
+    public void testNoListsConfiguredExcludesNothing() {
+        List<String> keyless = Arrays.asList("a.one", "b.two");
+
+        Assert.assertEquals(keyless,
+                KeylessTablePreflight.withoutExcluded(keyless, new Properties()));
+    }
+
+    /**
+     * A malformed pattern must fail SAFE -- toward reporting, not hiding.
+     *
+     * <p>This list can only remove tables from the refusal set, so treating an
+     * uncompilable pattern as matching would silently drop a genuinely keyless
+     * table from the check. It is ignored instead, and the valid entry beside
+     * it still applies.</p>
+     */
+    @Test
+    public void testUnparseablePatternFailsSafeAndDoesNotHideATable() {
+        Properties props = new Properties();
+        props.setProperty("table.exclude.list", "*[bad(regex,.*[.]alembic_version");
+
+        List<String> keyless = Arrays.asList("aerion_uat.alembic_version", "aerion_uat.trade");
+
+        Assert.assertEquals("the valid pattern still excludes; the broken one is ignored "
+                        + "rather than treated as a match",
+                Collections.singletonList("aerion_uat.trade"),
+                KeylessTablePreflight.withoutExcluded(keyless, props));
     }
 
     /**

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/KeylessTablePreflightTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/KeylessTablePreflightTest.java
@@ -3,6 +3,9 @@ package com.altinity.clickhouse.debezium.embedded.cdc;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -336,5 +339,102 @@ public class KeylessTablePreflightTest {
         props.setProperty(KeylessTablePreflight.SKIP_PROPERTY, "true");
 
         KeylessTablePreflight.check(props);
+    }
+
+    /**
+     * The preflight must never write a global on the source server.
+     *
+     * <p>Regression test for the defect this change fixes. Starting the
+     * connector used to run {@code SET GLOBAL
+     * sql_generate_invisible_primary_key = ON}, after which MySQL rejects
+     * every keyless {@code CREATE TABLE ... PARTITION BY} on the WHOLE server
+     * with ERROR 1235 -- a source-side DDL outage caused by a read-only
+     * consumer, persisting after the connector stopped.</p>
+     *
+     * <p>Asserted against the source text rather than a live server because
+     * the failure mode is the mere PRESENCE of the statement: any execution
+     * path reaching it is the bug, so no runtime scenario has to be guessed
+     * at. The file is located from the class itself, so the test fails loudly
+     * if it cannot be found rather than passing vacuously.</p>
+     */
+    @Test
+    public void testPreflightNeverSetsAGlobalOnTheSource() throws Exception {
+        Path src = sourceFile();
+        for (String line : Files.readAllLines(src)) {
+            String code = line.trim();
+            // Skip prose: the javadoc explains the defect and so necessarily
+            // quotes the statement it forbids.
+            if (code.startsWith("*") || code.startsWith("//") || code.startsWith("/*")) {
+                continue;
+            }
+            Assert.assertFalse(
+                    "the preflight must not execute SET GLOBAL on the source server: " + code,
+                    code.contains("SET GLOBAL") && code.contains("execute"));
+        }
+    }
+
+    /**
+     * The shared IT fixture must keep opting out of the check.
+     *
+     * <p>{@code sql/data_types.sql} deliberately declares keyless tables
+     * ({@code ship_class}, {@code add_test}) that the DDL-parser suites
+     * exercise, so the preflight correctly refuses that source. Without the
+     * opt-out every MySQL IT in the module fails at startup -- 19 errors
+     * across 15 suites in the run that prompted this change.</p>
+     */
+    @Test
+    public void testItConfigOptsOutOfTheKeylessCheck() throws Exception {
+        Path cfg = moduleRoot().resolve("src/test/resources/config.yml");
+        Assert.assertTrue("cannot locate the IT config at " + cfg
+                + " -- this test must not pass vacuously", Files.exists(cfg));
+
+        boolean optedOut = false;
+        for (String line : Files.readAllLines(cfg)) {
+            String code = line.trim();
+            if (code.startsWith("#")) {
+                continue;
+            }
+            if (code.startsWith(KeylessTablePreflight.SKIP_PROPERTY) && code.contains("true")) {
+                optedOut = true;
+            }
+        }
+        Assert.assertTrue(
+                KeylessTablePreflight.SKIP_PROPERTY + " must be true in " + cfg + ": the shared "
+                        + "employees fixture declares keyless tables on purpose",
+                optedOut);
+    }
+
+    /**
+     * The preflight's own source file, located from the compiled class.
+     *
+     * <p>Derived from the class location rather than assumed relative to the
+     * working directory, so the test behaves the same under maven, an IDE and
+     * a reactor build -- and fails rather than silently skipping if the layout
+     * ever changes.</p>
+     */
+    private static Path sourceFile() {
+        Path src = moduleRoot().resolve(
+                "src/main/java/" + KeylessTablePreflight.class.getName().replace('.', '/')
+                        + ".java");
+        Assert.assertTrue("cannot locate KeylessTablePreflight source at " + src
+                + " -- this test must not pass vacuously", Files.exists(src));
+        return src;
+    }
+
+    /** The sink-connector-lightweight module root, found from the class location. */
+    private static Path moduleRoot() {
+        Path p;
+        try {
+            p = Paths.get(KeylessTablePreflightTest.class.getProtectionDomain()
+                    .getCodeSource().getLocation().toURI());
+        } catch (Exception e) {
+            throw new AssertionError("cannot locate the test class on disk", e);
+        }
+        // .../<module>/target/test-classes -> .../<module>
+        while (p != null && !Files.exists(p.resolve("src/main/java"))) {
+            p = p.getParent();
+        }
+        Assert.assertNotNull("cannot locate the module root from the test class location", p);
+        return p;
     }
 }

--- a/sink-connector-lightweight/src/test/resources/config.yml
+++ b/sink-connector-lightweight/src/test/resources/config.yml
@@ -31,3 +31,10 @@ enable.snapshot.ddl: "true"
 auto.create.tables: "true"
 metrics.enable: "false"
 database.connectionTimeZone: "America/Chicago"
+# The shared employees fixture (sql/data_types.sql) deliberately declares
+# keyless tables -- ship_class and add_test have no PRIMARY KEY and no UNIQUE
+# key -- because the DDL-parser suites exercise ALTER/RENAME/TRUNCATE against
+# them. The keyless preflight is right to refuse such a source in production,
+# but here the keyless-ness IS the fixture, so the check is opted out of.
+# KeylessTablePreflightTest covers the check itself directly.
+keyless.table.check.skip: "true"


### PR DESCRIPTION


Fixes the `java-tests-lightweight` failure in [run 32819328349](https://github.com/Altinity/clickhouse-sink-connector/actions/runs/32819328349) — 278 tests, **3 failures + 19 errors across 15 suites**.

Two causes. One of them is a **real production defect**, not a test problem.

## 1. The preflight reconfigured the source server

`enableGipk()` ran:

```sql
SET GLOBAL sql_generate_invisible_primary_key = ON
```

With that global on, MySQL **rejects every subsequent keyless `CREATE TABLE ... PARTITION BY` on the whole server**:

```
ERROR 1235 (42000): This version of MySQL doesn't yet support
'generating invisible primary key for the partitioned tables'
```

So merely **starting the connector broke partitioned-table DDL for every application sharing that MySQL** — an outage on the *source*, caused by a read-only consumer, persisting after the connector stopped, and lasting until someone found the global and reset it.

`TableOperationsIT:111` is exactly that: a `CREATE TABLE ... PARTITION BY KEY(joined)` rejected on a server the connector had reconfigured. CI caught a genuine bug.

**Fix:** the global is never written. The session setting is kept — harmless, since the connector creates no source tables. When the global is OFF, the passing path logs a WARN with the exact statements *and* the partitioned-table consequence, so enabling it stays the server owner's decision, made with knowledge of what else uses that MySQL. The refusal message already carried the same advice.

## 2. The shared IT fixture is keyless on purpose

`sql/data_types.sql` declares `ship_class` and `add_test` with no PRIMARY KEY and no UNIQUE key, because the DDL-parser suites exercise ALTER/RENAME/TRUNCATE against them. The preflight is right to refuse such a source, so the ITs opt out via `keyless.table.check.skip` in `src/test/resources/config.yml`, with a comment explaining why.

The check itself stays covered directly by `KeylessTablePreflightTest`, which does not depend on that fixture.

## The other 17 errors are downstream

Once the connector refuses to start, the ITs' ClickHouse tables are never created, so the assertions fail with `UNKNOWN_TABLE` / `UNKNOWN_IDENTIFIER`, and one suite reports `Mapped port can only be obtained after the container is started` after its container teardown. No separate fix needed.

## Tests — 22 in the class, 2 new

- `testPreflightNeverSetsAGlobalOnTheSource` asserts against the **source text**, because the failure mode is the *presence* of the statement: any execution path reaching it is the bug, so no runtime scenario has to be guessed at.
- `testItConfigOptsOutOfTheKeylessCheck` pins the opt-out so a future edit cannot silently reintroduce a 19-error run.

Both locate their file from the compiled class location and fail loudly if it is missing, so neither can pass vacuously.

**Failing-first verified.** Restoring the `SET GLOBAL` call and removing the opt-out fails exactly the two new tests:

```
testPreflightNeverSetsAGlobalOnTheSource:370
  the preflight must not execute SET GLOBAL on the source server:
  st.execute("SET GLOBAL sql_generate_invisible_primary_key = ON");
testItConfigOptsOutOfTheKeylessCheck:401
  keyless.table.check.skip must be true in .../config.yml
```

Base branch `2.10.0`. Companion to #1405 (exclusion-aware preflight), which this branch sits on top of.

Full unit run green: **154** across `KeylessTablePreflightTest`, `SequenceSeedOverflowTest`, `SourceTsVersionAnchorTest`, `DdlReplayIdempotencyTest`, `CreateTableNoKeySortKeyTest`, `MySqlDDLParserListenerImplTest`.

The integration suites need Docker and were not run here; they are what CI will exercise on this branch.
