### PR TITLE
fix: the DDL waiter parsed IF NOT EXISTS as the column name

### DIFF
--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DDLSchemaChangeWaiter.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DDLSchemaChangeWaiter.java
@@ -39,15 +39,27 @@ public class DDLSchemaChangeWaiter {
     /**
      * Regex to extract column names from ALTER TABLE ... ADD COLUMN statements.
      * Matches both backtick-quoted and unquoted column names.
+     *
+     * <p>The optional {@code IF NOT EXISTS} is consumed as part of the prefix,
+     * not captured as the column name. Without that, the generated DDL
+     * {@code ADD COLUMN IF NOT EXISTS ship_spec Nullable(String)} yields the
+     * literal column {@code IF}, which never appears in
+     * {@code system.columns} -- so the waiter polls a name that cannot exist
+     * until it times out, and the real column is never waited for at all.</p>
      */
-    private static final Pattern ADD_COLUMN_PATTERN = Pattern.compile(
-            "ADD\\s+COLUMN\\s+`?([^`\\s]+)`?",
+    static final Pattern ADD_COLUMN_PATTERN = Pattern.compile(
+            "ADD\\s+COLUMN\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?`?([^`\\s]+)`?",
             Pattern.CASE_INSENSITIVE
     );
 
-    /** Regex to extract column names from ALTER TABLE ... DROP COLUMN. */
-    private static final Pattern DROP_COLUMN_PATTERN = Pattern.compile(
-            "DROP\\s+COLUMN\\s+`?([^`\\s]+)`?",
+    /**
+     * Regex to extract column names from ALTER TABLE ... DROP COLUMN.
+     *
+     * <p>Consumes the optional {@code IF EXISTS} for the same reason as
+     * {@link #ADD_COLUMN_PATTERN}.</p>
+     */
+    static final Pattern DROP_COLUMN_PATTERN = Pattern.compile(
+            "DROP\\s+COLUMN\\s+(?:IF\\s+EXISTS\\s+)?`?([^`\\s]+)`?",
             Pattern.CASE_INSENSITIVE
     );
 
@@ -160,7 +172,9 @@ public class DDLSchemaChangeWaiter {
 
         if (!remaining.isEmpty()) {
             log.warn("Timeout ({}ms) waiting for columns to appear in {}.{}: {}. " +
-                            "Proceeding anyway -- data loss may occur for these columns.",
+                            "Proceeding anyway -- data loss may occur for these columns. "
+                            + "If a name here is a SQL keyword such as IF, the DDL was "
+                            + "misparsed and the real column was never waited for.",
                     timeoutMs, database, table, remaining);
         }
     }

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DDLSchemaChangeWaiterRaceConditionTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/DDLSchemaChangeWaiterRaceConditionTest.java
@@ -133,6 +133,64 @@ class DDLSchemaChangeWaiterRaceConditionTest {
         }
 
         @Test
+        @DisplayName("IF NOT EXISTS is not captured as the column name")
+        void addColumnIfNotExistsIsNotTheColumnName() {
+            // Verbatim from the failing CI run: the DDL the connector itself
+            // generates for `alter table ship_class add column ship_spec ...`.
+            String ddl = "ALTER TABLE employees.ship_class "
+                    + "ADD COLUMN IF NOT EXISTS ship_spec Nullable(String)  first, "
+                    + "ADD COLUMN IF NOT EXISTS somecol Nullable(Int32)  after start_build";
+
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(
+                    ddl, DDLSchemaChangeWaiter.ADD_COLUMN_PATTERN);
+
+            assertEquals(List.of("ship_spec", "somecol"), cols,
+                    "the guarded form must yield the real columns, not the keyword IF");
+        }
+
+        @Test
+        @DisplayName("IF EXISTS is not captured as the dropped column name")
+        void dropColumnIfExistsIsNotTheColumnName() {
+            // DESTRUCTIVE: nothing is destroyed. This string is regex input for
+            // extractColumnNames; no connection or execution is involved.
+            String ddl = "ALTER TABLE employees.ship_class DROP COLUMN IF EXISTS extra";
+
+            List<String> cols = DDLSchemaChangeWaiter.extractColumnNames(
+                    ddl, DDLSchemaChangeWaiter.DROP_COLUMN_PATTERN);
+
+            assertEquals(List.of("extra"), cols);
+        }
+
+        @Test
+        @DisplayName("The shipped patterns handle the unguarded form too")
+        void shippedPatternsHandleBothForms() {
+            // Asserted against the class's OWN patterns rather than a copy.
+            // Every other test in this class re-declares the regex inline, so
+            // they kept passing while the shipped pattern was broken -- which
+            // is precisely how this defect reached CI.
+            assertEquals(List.of("plain_col"), DDLSchemaChangeWaiter.extractColumnNames(
+                    "ALTER TABLE db.tbl ADD COLUMN plain_col String",
+                    DDLSchemaChangeWaiter.ADD_COLUMN_PATTERN));
+            assertEquals(List.of("quoted_col"), DDLSchemaChangeWaiter.extractColumnNames(
+                    "ALTER TABLE `db`.`tbl` ADD COLUMN `quoted_col` String",
+                    DDLSchemaChangeWaiter.ADD_COLUMN_PATTERN));
+            // DESTRUCTIVE: nothing is destroyed -- regex input only, never run.
+            assertEquals(List.of("gone"), DDLSchemaChangeWaiter.extractColumnNames(
+                    "ALTER TABLE db.tbl DROP COLUMN gone",
+                    DDLSchemaChangeWaiter.DROP_COLUMN_PATTERN));
+        }
+
+        @Test
+        @DisplayName("A column legitimately named `if` is still extracted")
+        void columnNamedIfStillWorks() {
+            // The guard consumes IF only when it introduces the EXISTS clause;
+            // a backticked column actually named `if` must survive.
+            assertEquals(List.of("if"), DDLSchemaChangeWaiter.extractColumnNames(
+                    "ALTER TABLE db.tbl ADD COLUMN `if` String",
+                    DDLSchemaChangeWaiter.ADD_COLUMN_PATTERN));
+        }
+
+        @Test
         @DisplayName("No match returns empty list")
         void noMatchReturnsEmpty() {
             String ddl = "ALTER TABLE db.tbl MODIFY COLUMN col1 String";


### PR DESCRIPTION


Fixes the `java-lightweight` failures in [run 32834092832](https://github.com/Altinity/clickhouse-sink-connector/actions/runs/32834092832) and the `JUnit Test Report` job that reports them.

The schema-change waiter extracted the **wrong column name** from every guarded ALTER, so it waited for a column that can never exist and never waited for the real one — reinstating the exact race (#1222) it was written to close.

```
ALTER TABLE employees.ship_class
  ADD COLUMN IF NOT EXISTS ship_spec Nullable(String) first,
  ADD COLUMN IF NOT EXISTS somecol Nullable(Int32) after start_build

Waiting for 2 column(s) to appear in employees.ship_class: [IF, IF]
```

`ADD_COLUMN_PATTERN` captured the first token after `ADD COLUMN`. That was correct until the generated DDL became guarded; the pattern predates the guards and was never updated, so it now returns the keyword `IF`. `DROP_COLUMN_PATTERN` has the same defect with `IF EXISTS`.

## Consequences, all observed in CI

- the waiter polls `system.columns` for a column named `IF` for the full 30 s timeout — ~600 polls per table — then gives up;
- **the real column is never waited for**, so the caller reads column metadata that may predate the ALTER — the stale-column-list race this class exists to prevent;
- the test then dereferences a column map that was never populated and dies with a `NullPointerException` far from the cause.

## Fix

Consume the optional guard in the prefix instead of capturing it. A column legitimately named `` `if` `` still extracts correctly, since the guard only matches when `IF` introduces the `EXISTS` clause.

The timeout warning now names the misparse too. A wrong column name degraded silently for the whole timeout and then surfaced as an unrelated NPE; the warning says so where the operator will see it.

## Why this passed CI before

Every test in the class **re-declared the regex inline** rather than using the shipped constant, so the copies stayed correct while the real pattern broke. The patterns are now package-private and the new tests assert against them directly.

## Tests — 25 in the class, 4 new

The verbatim failing-CI DDL, the guarded drop form, the unguarded form still working, and a column actually named `` `if` ``.

**Failing-first verified** — reverting the two patterns fails exactly the new tests:

```
addColumnIfNotExistsIsNotTheColumnName:147
  expected: <[ship_spec, somecol]> but was: <[IF, IF]>
dropColumnIfExistsIsNotTheColumnName:159
  expected: <[extra]> but was: <[IF]>
```

## Integration tests

Run locally against the suites that were failing at `aa00431a`, all now green:

```
AlterTableAddColumnIT        1/1
AlterTableAddColumnRaceIT    1/1
AlterTableDropColumnCacheIT  1/1
MySQLDemoIT                  6 run, 0 failures, 0 errors   (was 2 failures + 3 errors)
```

Base branch `2.10.0`.
