### PR TITLE
fix: history-mode DELETE lost -- _operation dropped from INSERT, and the delete races its own batch

### DIFF
--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/QueryFormatter.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/QueryFormatter.java
@@ -325,6 +325,13 @@ public class QueryFormatter {
                 || colName.equalsIgnoreCase(ClickHouseDbConstants.SIGN_COLUMN)
                 || colName.equalsIgnoreCase(ClickHouseDbConstants.DELETED_TIME_COLUMN)
                 || colName.equalsIgnoreCase(ClickHouseDbConstants.DELETED_FROM_TIME_COLUMN)
+                // _operation is populated by the connector, never by the source
+                // record, exactly like _version and is_deleted. Omitting it made
+                // createColumns drop it from every replication-history INSERT, so
+                // the SCD Type 2 rows carried an empty _operation and a DELETE
+                // could not be distinguished from an insert -- deleted rows stayed
+                // visible in ClickHouse forever while row counts looked plausible.
+                || colName.equalsIgnoreCase(ClickHouseDbConstants.OPERATION_COLUMN)
                 || (deleteColumn != null && !deleteColumn.isEmpty()
                         && colName.equalsIgnoreCase(deleteColumn));
     }

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/PreparedStatementExecutor.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/PreparedStatementExecutor.java
@@ -243,6 +243,31 @@ public class PreparedStatementExecutor {
                     if (CdcRecordState.CDC_RECORD_STATE_BEFORE == getCdcSectionBasedOnOperation(record.getCdcOperation())) {
                         if (replicationHistoryHandler != null &&
                             record.getCdcOperation().getOperation().equalsIgnoreCase(ClickHouseConverter.CDC_OPERATION.DELETE.getOperation())) {
+                                // The SCD Type 2 delete reads the row it is closing
+                                // straight back out of the target
+                                // (INSERT ... SELECT ... FROM <table> FINAL WHERE ...),
+                                // and it runs INLINE. Plain inserts in the same batch are
+                                // only staged on the PreparedStatement and do not reach
+                                // ClickHouse until executeBatch() below. So when one batch
+                                // carries a row's CREATE and its DELETE -- ordinary for a
+                                // busy source -- the delete's SELECT runs BEFORE the insert
+                                // it depends on, matches nothing, and writes zero rows. No
+                                // error is raised: the delete is silently dropped and the
+                                // row stays visible in ClickHouse forever.
+                                //
+                                // Flush what is staged first so the delete observes the
+                                // same state the source did at that binlog position. This
+                                // is the same ordering rule the TRUNCATE branch above
+                                // already applies, and it is why the defect looked
+                                // intermittent -- it only bites when the CREATE and the
+                                // DELETE land in one batch.
+                                try {
+                                    ps.executeBatch();
+                                } catch (SQLException e) {
+                                    throw new RuntimeException(String.format(
+                                            "Failed to flush records staged before a replication-history "
+                                                    + "DELETE for %s.%s", databaseName, tableName), e);
+                                }
                                 replicationHistoryHandler.executeHistoryUpdate(
                                     conn,
                                     tableName,

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/PreparedStatementFieldMapper.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/PreparedStatementFieldMapper.java
@@ -59,6 +59,33 @@ public class PreparedStatementFieldMapper {
                 || SIGN_COLUMN.equalsIgnoreCase(columnName);
     }
 
+    /**
+     * Whether the incoming change event actually carries this column.
+     *
+     * <p>A column the record does not carry is intentionally absent from the
+     * generated INSERT, so ClickHouse applies the column's DEFAULT. That is
+     * the intended behaviour for a pre-ALTER record, and for a column the
+     * source event omits because it is NULL. A column the record DOES carry
+     * but that has no placeholder is a real defect: nothing binds it and the
+     * value never reaches ClickHouse. Only the latter is an error -- reporting
+     * both buries the one that loses data.</p>
+     *
+     * @param fields the record's schema fields, may be null
+     * @param columnName the ClickHouse column being bound
+     * @return true when the record carries a field of that name
+     */
+    static boolean recordCarries(List<Field> fields, String columnName) {
+        if (fields == null || columnName == null) {
+            return false;
+        }
+        for (Field f : fields) {
+            if (f != null && columnName.equalsIgnoreCase(f.name())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 
     /**
      * Logger instance for logging purposes.
@@ -174,6 +201,13 @@ public class PreparedStatementFieldMapper {
                 // spurious ERROR lines and buried the real ones.
                 if (isUnboundByDesign(colName)) {
                     log.debug("Column {} is emitted as a SQL literal; no parameter binding required.", colName);
+                } else if (!recordCarries(fields, colName)) {
+                    // The record does not carry this column, so createColumns
+                    // deliberately left it out of the INSERT and ClickHouse
+                    // applies the column's DEFAULT. Intended for a pre-ALTER
+                    // record, or a column the source event omits because it is
+                    // NULL -- not a dropped value.
+                    log.debug("Column {} absent from this record's schema; ClickHouse DEFAULT applies.", colName);
                 } else {
                     // A genuine data column with no placeholder is silently
                     // dropped from the INSERT: nothing binds it here and the

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/QueryFormatterOperationColumnTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/QueryFormatterOperationColumnTest.java
@@ -1,0 +1,96 @@
+package com.altinity.clickhouse.sink.connector.db;
+
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@code _operation} must survive into the generated INSERT column list.
+ *
+ * <p>{@code createColumns} drops any ClickHouse column that the incoming change
+ * event does not carry, unless that column is one the connector populates
+ * itself. {@code _operation} is connector-populated -- exactly like
+ * {@code _version} and {@code is_deleted} -- but was missing from
+ * {@code isConnectorManagedColumn}, so it was filtered out of every
+ * replication-history INSERT.</p>
+ *
+ * <p>The consequence is silent and permanent: the SCD Type 2 rows land with an
+ * empty {@code _operation}, so a DELETE cannot be distinguished from an insert.
+ * A row deleted at the source stays visible in ClickHouse forever, while row
+ * counts stay plausible enough that a count-based checksum reports the table
+ * clean. Observed in production as MySQL 13 rows vs ClickHouse 15.</p>
+ */
+public class QueryFormatterOperationColumnTest {
+
+    /** The bitemporal target shape used by replication-history mode. */
+    private Map<String, String> historyTargetColumns() {
+        Map<String, String> m = new LinkedHashMap<>();
+        m.put("id", "Int32");
+        m.put("appkey", "String");
+        m.put("comment", "Nullable(String)");
+        m.put("_valid_from", "DateTime");
+        m.put("_valid_to", "DateTime");
+        m.put("_operation", "LowCardinality(String)");
+        m.put("_version", "UInt64");
+        m.put("is_deleted", "UInt8");
+        return m;
+    }
+
+    /**
+     * A change event carrying only the source columns -- never the
+     * connector-managed metadata columns.
+     */
+    private List<Field> sourceOnlyFields() {
+        List<Field> fields = new ArrayList<>();
+        Schema s = SchemaBuilder.string().optional().build();
+        fields.add(new Field("id", 0, Schema.INT32_SCHEMA));
+        fields.add(new Field("appkey", 1, s));
+        return fields;
+    }
+
+    private String insertQuery() {
+        MutablePair<String, Map<String, Integer>> r =
+                new QueryFormatter().getInsertQueryUsingInputFunction(
+                        "process", sourceOnlyFields(), historyTargetColumns(),
+                        false, false, "", "binlog_history", "is_deleted");
+        return r.getLeft();
+    }
+
+    @Test
+    @DisplayName("_operation is kept in the INSERT column list even though no record carries it")
+    public void testOperationColumnSurvives() {
+        String q = insertQuery();
+        assertTrue(q.contains("`_operation`"),
+                "_operation is connector-populated and must stay in the column list; "
+                        + "without it a DELETE is indistinguishable from an insert. Got: " + q);
+    }
+
+    @Test
+    @DisplayName("The other connector-managed columns are kept too (regression guard)")
+    public void testOtherManagedColumnsSurvive() {
+        String q = insertQuery();
+        assertTrue(q.contains("`_version`"), q);
+        assertTrue(q.contains("`is_deleted`"), q);
+        assertTrue(q.contains("`_valid_from`"), q);
+        assertTrue(q.contains("`_valid_to`"), q);
+    }
+
+    @Test
+    @DisplayName("Source columns the record carries are kept")
+    public void testCarriedSourceColumnsSurvive() {
+        String q = insertQuery();
+        assertTrue(q.contains("`id`"), q);
+        assertTrue(q.contains("`appkey`"), q);
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/batch/PreparedStatementFieldMapperRecordCarriesTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/batch/PreparedStatementFieldMapperRecordCarriesTest.java
@@ -1,0 +1,85 @@
+package com.altinity.clickhouse.sink.connector.db.batch;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Separates the two reasons a column can lack a bind placeholder.
+ *
+ * <p>A column the change event does not carry is left out of the INSERT on
+ * purpose, so ClickHouse applies its DEFAULT -- that is correct behaviour for a
+ * pre-ALTER record, or for a NULL column the source event omits. A column the
+ * event DOES carry but that has no placeholder is a real defect: nothing binds
+ * it and the value never reaches ClickHouse.</p>
+ *
+ * <p>Logging both at ERROR made the harmful case invisible. A history-mode run
+ * emitted 15 errors for a {@code comment} column that was simply NULL at the
+ * source, which is exactly the noise that hides a genuine drop.</p>
+ */
+public class PreparedStatementFieldMapperRecordCarriesTest {
+
+    private List<Field> fields(String... names) {
+        List<Field> out = new ArrayList<>();
+        int i = 0;
+        for (String n : names) {
+            out.add(new Field(n, i++, Schema.OPTIONAL_STRING_SCHEMA));
+        }
+        return out;
+    }
+
+    @Test
+    @DisplayName("A column the record carries is reported as carried")
+    public void testCarried() {
+        List<Field> f = fields("id", "appkey", "comment");
+        assertTrue(PreparedStatementFieldMapper.recordCarries(f, "comment"));
+        assertTrue(PreparedStatementFieldMapper.recordCarries(f, "id"));
+    }
+
+    @Test
+    @DisplayName("A column absent from the record is not carried -- DEFAULT applies, not an error")
+    public void testAbsent() {
+        List<Field> f = fields("id", "appkey");
+        assertFalse(PreparedStatementFieldMapper.recordCarries(f, "comment"),
+                "comment is NULL at source and omitted from the event; ClickHouse DEFAULT applies");
+        assertFalse(PreparedStatementFieldMapper.recordCarries(f, "added_by_later_alter"));
+    }
+
+    @Test
+    @DisplayName("Matching is case-insensitive, as the column lookup is")
+    public void testCaseInsensitive() {
+        List<Field> f = fields("Comment", "ID");
+        assertTrue(PreparedStatementFieldMapper.recordCarries(f, "comment"));
+        assertTrue(PreparedStatementFieldMapper.recordCarries(f, "id"));
+    }
+
+    @Test
+    @DisplayName("Null and empty inputs are safe")
+    public void testNullSafety() {
+        assertFalse(PreparedStatementFieldMapper.recordCarries(null, "comment"));
+        assertFalse(PreparedStatementFieldMapper.recordCarries(fields("id"), null));
+        assertFalse(PreparedStatementFieldMapper.recordCarries(new ArrayList<>(), "id"));
+        assertFalse(PreparedStatementFieldMapper.recordCarries(Arrays.asList((Field) null), "id"),
+                "a null entry must not throw");
+    }
+
+    @Test
+    @DisplayName("The by-design metadata columns remain classified separately")
+    public void testByDesignStillDistinct() {
+        // These are never carried by a source record, but they are also never
+        // an error: QueryFormatter emits them as SQL literals.
+        List<Field> f = fields("id");
+        assertFalse(PreparedStatementFieldMapper.recordCarries(f, "_version"));
+        assertTrue(PreparedStatementFieldMapper.isUnboundByDesign("_version"),
+                "_version must be caught by the by-design branch before the carried check");
+        assertTrue(PreparedStatementFieldMapper.isUnboundByDesign("_operation"));
+    }
+}


### PR DESCRIPTION



Follow-up to #1410. That PR stopped the startup `Code: 57` retry loop that was losing ~95% of rows. These are the defects that remained once the loop was gone — with #1410 alone the target still ends up with **15 rows against MySQL's 13**, and deleted rows stay visible forever.

## 1. `_operation` never reached ClickHouse

`createColumns()` drops any target column the incoming change event does not carry, unless the connector populates that column itself. The connector-managed list — `isConnectorManagedColumn` — named `_version`, `is_deleted`, `_sign`, `_valid_to` and `_valid_from`, but **not `_operation`**. No source record ever carries `_operation`, so it was filtered out of every history-mode INSERT.

Silent by construction: the SCD Type 2 rows land with an empty `_operation`, so a DELETE cannot be told apart from an insert, and row counts stay plausible enough that a count-based checksum reports the table clean.

Proven failing-first — on unmodified `develop` the generated statement is:

```sql
INSERT INTO `process`(`id`,`appkey`,`_valid_from`,`_valid_to`,`_version`,`is_deleted`)
```

no `_operation` at all.

## 2. The DELETE races the batch it depends on

This is the interesting one, and it is the production signature.

The SCD Type 2 delete reads the row it is closing straight back out of the target:

```sql
INSERT INTO <table>(...) SELECT ... FROM <table> FINAL
  WHERE <pk>=? AND `_valid_to` = <sentinel> AND `is_deleted` = 0
UNION ALL SELECT ...   -- the tombstone
```

and it runs **inline**, on its own connection. Plain inserts in the same batch are only *staged* on the `PreparedStatement` — they do not reach ClickHouse until `executeBatch()` at the end of the batch.

So when one batch carries a row's CREATE and its DELETE — ordinary for any busy source — the delete's SELECT executes **before** the insert it depends on. It matches nothing, both branches of the UNION produce no rows, and the statement succeeds having written zero rows. Nothing is logged. The delete is dropped and the row stays visible forever.

That is exactly the zero-row-INSERT signature we measured in production: 77–92% of INSERTs on the busy table wrote zero rows every day, while a sibling table in the same database sat at 0%.

The fix flushes the staged batch before the inline delete, so the delete observes the same state the source did at that binlog position. It is the same ordering rule the `TRUNCATE` branch a few lines above already applies, for the same reason.

## 3. The missing-column error fired for columns that were never missing

The error added in #1410 could not distinguish a column the record does not carry — where omission is deliberate and ClickHouse applies the DEFAULT — from a column the record *does* carry but that has no placeholder, which is a real dropped value. A history-mode run emitted 15 errors for a `comment` column that was simply NULL at source. `recordCarries()` separates them, so the error only fires when a value is genuinely lost.

## Why the delete defect looked intermittent

It only bites when the CREATE and the DELETE land in the same batch. Repeating one workload against a clean target, same harness, same stack:

```
released 2.10.0-lt             0/3 pass    ch=0   total loss (the Code:57 loop)
this branch minus the race fix 0/4 pass    ch=15  vs mysql=13, no tombstones
this branch                    5/5 pass    ch=13  = mysql=13, 2 tombstones each run
```

A single green run proves nothing here — only the repeated identical result does. There is also a dedicated same-batch case (create + update + delete of the same rows in one statement group): MySQL 3 rows, ClickHouse 3, two tombstones, correct values.

## Verification

Isolated MySQL 8.0.36 (ROW/FULL/GTID) → connector → ClickHouse 24.8.14, target pre-created exactly as the production host has it.

Standard mode re-checked for regressions on the same build: **17/17 tables at 20,002 rows**, plus `kill -9` mid-stream with writes during the outage replaying exactly once — 20,002 rows, 20,002 distinct ids, zero duplicates.

```
sink-connector:             226 run, 0 failures, 20 errors
sink-connector-lightweight: 223 run, 0 failures,  1 error
```

Both error counts are identical to unmodified `develop` measured in a pristine `git worktree`; every one is testcontainers reporting `Could not find a valid Docker environment` on our build host.

## Files

- `QueryFormatter.java` — `_operation` added to the connector-managed columns
- `PreparedStatementExecutor.java` — flush staged inserts before the inline SCD-2 delete
- `PreparedStatementFieldMapper.java` — `recordCarries()`; error only on genuine value loss
- 2 new test classes, 8 new tests
