### PR TITLE
fix: ARRAY binding hard-casts to ArrayList, breaking every other List type

### DIFF
--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapper.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapper.java
@@ -525,8 +525,14 @@ public class ClickHouseDataTypeMapper {
         } else if (type == Schema.Type.ARRAY) {
             ClickHouseDataType dt = getClickHouseDataType(
                     Schema.Type.valueOf(schemaName), null);
+            // Kafka Connect delivers an ARRAY field as a java.util.List, and
+            // not necessarily an ArrayList: an empty array arrives as
+            // Collections.emptyList(), and immutable/Arrays.asList forms are
+            // equally legal. Bind through Collection so every implementation
+            // works; toArray() produces the identical Object[] an ArrayList
+            // did. See issue #749.
             ps.setArray(index, ps.getConnection().createArrayOf(
-                    dt.name(), ((ArrayList) value).toArray()));
+                    dt.name(), ((Collection<?>) value).toArray()));
         } else {
             result = false;
         }

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapperArrayTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapperArrayTest.java
@@ -1,0 +1,200 @@
+package com.altinity.clickhouse.sink.connector.converters;
+
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import com.clickhouse.data.ClickHouseDataType;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Regression tests for issue #749: the ARRAY branch of
+ * {@link ClickHouseDataTypeMapper#convert} hard-cast the incoming value to
+ * {@link ArrayList}.
+ *
+ * <p>The Kafka Connect contract for an array field is {@link java.util.List},
+ * not {@code ArrayList}. Debezium and the Connect converters are free to hand
+ * over any List implementation, and an empty array in particular arrives as
+ * {@code Collections.emptyList()} -- which is
+ * {@code java.util.Collections$EmptyList}, not an {@code ArrayList}. The cast
+ * therefore threw {@code ClassCastException: class
+ * java.util.Collections$EmptyList cannot be cast to class java.util.ArrayList},
+ * killing the whole batch. That is the exact frame in the reporter stack trace
+ * ({@code ClickHouseDataTypeMapper.convert}, called from
+ * {@code PreparedStatementExecutor.insertPreparedStatement}).
+ *
+ * <p>Binding via {@link java.util.Collection} covers every List the Connect
+ * runtime can produce while keeping the ArrayList case byte-for-byte identical.
+ *
+ * <p>The recording {@link PreparedStatement} below is a {@link Proxy}, matching
+ * the JDBC test-double idiom already used by
+ * {@code ClickHouseDataTypeMapperBitBytesTest} and
+ * {@code SystemConnectionRefreshTest}. This module has no mocking framework on
+ * its test classpath, and one is not needed to observe a single setter.
+ */
+public class ClickHouseDataTypeMapperArrayTest {
+
+    /**
+     * Records the {@code createArrayOf} type name and elements, plus the
+     * {@link Array} bound to the statement, so the test can assert on exactly
+     * what reaches JDBC.
+     */
+    private static final class RecordingStatement {
+        private String arrayTypeName;
+        private Object[] arrayElements;
+        private int setArrayCallCount;
+
+        private final Array array = (Array) Proxy.newProxyInstance(
+                Array.class.getClassLoader(),
+                new Class<?>[]{Array.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "toString":
+                            return "RecordingArray";
+                        case "hashCode":
+                            return System.identityHashCode(proxy);
+                        case "equals":
+                            return proxy == args[0];
+                        default:
+                            throw new AssertionError(
+                                    "unexpected Array call: " + method.getName());
+                    }
+                });
+
+        private final Connection connection = (Connection) Proxy.newProxyInstance(
+                Connection.class.getClassLoader(),
+                new Class<?>[]{Connection.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "createArrayOf":
+                            arrayTypeName = (String) args[0];
+                            arrayElements = (Object[]) args[1];
+                            return array;
+                        case "toString":
+                            return "RecordingConnection";
+                        case "hashCode":
+                            return System.identityHashCode(proxy);
+                        case "equals":
+                            return proxy == args[0];
+                        default:
+                            throw new AssertionError(
+                                    "unexpected Connection call: " + method.getName());
+                    }
+                });
+
+        private final PreparedStatement statement = (PreparedStatement) Proxy.newProxyInstance(
+                PreparedStatement.class.getClassLoader(),
+                new Class<?>[]{PreparedStatement.class},
+                handler());
+
+        private InvocationHandler handler() {
+            return (proxy, method, args) -> {
+                switch (method.getName()) {
+                    case "getConnection":
+                        return connection;
+                    case "setArray":
+                        setArrayCallCount++;
+                        Assertions.assertSame(array, args[1],
+                                "the Array from createArrayOf must be the one bound");
+                        return null;
+                    case "toString":
+                        return "RecordingStatement";
+                    case "hashCode":
+                        return System.identityHashCode(proxy);
+                    case "equals":
+                        return proxy == args[0];
+                    default:
+                        // Nothing else is expected on the ARRAY path. Failing
+                        // loudly keeps an unnoticed behaviour change from
+                        // silently satisfying these assertions.
+                        throw new AssertionError(
+                                "unexpected PreparedStatement call: " + method.getName());
+                }
+            };
+        }
+    }
+
+    private static ClickHouseSinkConnectorConfig config() {
+        return new ClickHouseSinkConnectorConfig(new HashMap<>());
+    }
+
+    /**
+     * Drives the ARRAY branch exactly as {@code PreparedStatementFieldMapper}
+     * does: for an ARRAY field it passes the VALUE schema type name as the
+     * schemaName, hence {@code Schema.Type.STRING.name()} here.
+     */
+    private static RecordingStatement convertArray(Object value) throws SQLException {
+        RecordingStatement recorder = new RecordingStatement();
+        boolean handled = ClickHouseDataTypeMapper.convert(
+                Schema.Type.ARRAY, Schema.Type.STRING.name(), value, 1, recorder.statement,
+                config(), ClickHouseDataType.Array, ZoneId.of("UTC"));
+        Assertions.assertTrue(handled, "the ARRAY branch must report the value as handled");
+        Assertions.assertEquals(1, recorder.setArrayCallCount,
+                "expected exactly one setArray call for an ARRAY value");
+        return recorder;
+    }
+
+    /**
+     * The reporter case: an empty array field. Debezium delivers
+     * {@code Collections.emptyList()}, which before the fix threw
+     * {@code ClassCastException: class java.util.Collections$EmptyList cannot
+     * be cast to class java.util.ArrayList}.
+     */
+    @Test
+    public void emptyListDoesNotThrowClassCastException() throws SQLException {
+        RecordingStatement recorder = convertArray(Collections.emptyList());
+
+        Assertions.assertEquals("String", recorder.arrayTypeName);
+        Assertions.assertArrayEquals(new Object[0], recorder.arrayElements);
+    }
+
+    /** An immutable List.of(...) is a ListN, also not an ArrayList. */
+    @Test
+    public void immutableListIsBound() throws SQLException {
+        RecordingStatement recorder = convertArray(List.of("a", "b", "c"));
+
+        Assertions.assertEquals("String", recorder.arrayTypeName);
+        Assertions.assertArrayEquals(new Object[] {"a", "b", "c"}, recorder.arrayElements);
+    }
+
+    /** Arrays.asList produces a java.util.Arrays$ArrayList -- a different class. */
+    @Test
+    public void arraysAsListIsBound() throws SQLException {
+        RecordingStatement recorder = convertArray(Arrays.asList("x", "y"));
+
+        Assertions.assertArrayEquals(new Object[] {"x", "y"}, recorder.arrayElements);
+    }
+
+    /** Any other List implementation must work too -- the contract is List. */
+    @Test
+    public void linkedListIsBound() throws SQLException {
+        RecordingStatement recorder = convertArray(new LinkedList<>(List.of("p", "q")));
+
+        Assertions.assertArrayEquals(new Object[] {"p", "q"}, recorder.arrayElements);
+    }
+
+    /**
+     * The case that already worked must keep working, byte for byte: an
+     * ArrayList must still produce the same type name and the same elements.
+     */
+    @Test
+    public void arrayListBehaviourIsUnchanged() throws SQLException {
+        RecordingStatement recorder = convertArray(new ArrayList<>(List.of("one", "two")));
+
+        Assertions.assertEquals("String", recorder.arrayTypeName);
+        Assertions.assertArrayEquals(new Object[] {"one", "two"}, recorder.arrayElements);
+    }
+}


### PR DESCRIPTION
Fixes #749.

## Root cause

`ClickHouseDataTypeMapper` bound ARRAY values through a hard cast to the concrete implementation class:

```java
ps.setArray(index, ps.getConnection().createArrayOf(dt.name(), ((ArrayList) value).toArray()));
```

The Kafka Connect contract for an array field is `java.util.List`, not `ArrayList`. Any other List implementation throws — `List.of(...)`, `Arrays.asList(...)`, `Collections.emptyList()`, `LinkedList`, and every immutable list. This is the exact frame in the reported stack trace.

## Fix

Cast to `Collection<?>` instead. Safe because the only caller reaches this branch with `Schema.Type.ARRAY`, whose Connect value is always a List, and `Collection.toArray()` returns the identical `Object[]`. `java.util.*` was already imported.

## Verification

`ClickHouseDataTypeMapperArrayTest`, 5 tests. Before the fix, 4 error:

```
java.lang.ClassCastException: class java.util.Collections$EmptyList cannot be cast to class java.util.ArrayList
java.lang.ClassCastException: class java.util.ImmutableCollections$ListN cannot be cast to class java.util.ArrayList
java.lang.ClassCastException: class java.util.Arrays$ArrayList cannot be cast to class java.util.ArrayList
java.lang.ClassCastException: class java.util.LinkedList cannot be cast to class java.util.ArrayList
```

The first line is the reporter's verbatim exception. The `arrayListBehaviourIsUnchanged` control passed before the fix, so the reproduction isolates the defect rather than the surrounding code. After: 5/5 pass.

Module suite 226 to 231 across this and the sibling fixes; docker-dependent error set identical by name. This commit was also verified standalone by extracting it into a clean tree and running the full module suite.
