### PR TITLE
fix: initial snapshot never finishes -- NPE on every unparseable record

### DIFF
--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
@@ -1259,15 +1259,24 @@ public class DebeziumChangeEventCapture {
                 }
             } else {
                 chStruct = debeziumRecordParserService.parse(record, recordCommitter, lastRecordInBatch);
-                chStruct.setSequenceNumber(sequenceNumber);
                 try {
                     if (chStruct != null) {
+                        chStruct.setSequenceNumber(sequenceNumber);
                         ReplicationStatusSingleton rss = ReplicationStatusSingleton.getInstance();
                         rss.setReplicationLag(chStruct.getReplicationLag());
                         rss.setLastRecordTimestamp(chStruct.getTs_ms());
                         rss.setBinLogFile(chStruct.getFile());
                         rss.setBinLogPosition(String.valueOf(chStruct.getPos()));
                         rss.setGtid(String.valueOf(chStruct.getGtid()));
+                    } else {
+                        // parse() returns null for a record it cannot convert, such as
+                        // a null or non-Struct source value. Setting the sequence number
+                        // before this check raised an NPE that the catch-all below then
+                        // swallowed, so the record was dropped silently while the
+                        // snapshot loop logged the same stack trace per record (#1379).
+                        log.warn(String.format(
+                                "Record could not be parsed to a ClickHouseStruct - skipping. Record(%s)",
+                                record));
                     }
                 } catch (Exception e) {
                     log.error("Error retrieving status metrics: Exception" + e.toString());

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/NullParsedRecordSkipTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/NullParsedRecordSkipTest.java
@@ -1,0 +1,176 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import com.altinity.clickhouse.debezium.embedded.parser.DebeziumRecordParserService;
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import com.altinity.clickhouse.sink.connector.model.ClickHouseStruct;
+import io.debezium.engine.ChangeEvent;
+import io.debezium.engine.DebeziumEngine;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression test for issue #1379 ("Initial Snapshot never finishes").
+ * <p>
+ * {@link com.altinity.clickhouse.debezium.embedded.parser.SourceRecordParserService#parse}
+ * returns null for a record it cannot convert: a null source value, a value
+ * that is not a Struct, or a value the converter cannot map. Those null
+ * returns are contract, not failure.
+ * </p>
+ * <p>
+ * processEveryChangeRecord called setSequenceNumber on that return value
+ * before testing it for null, so every such record raised a
+ * NullPointerException. The NPE was then swallowed by the catch-all in the
+ * same method, so the record was dropped silently while the snapshot loop
+ * logged the same stack trace over and over -- the symptom reported in #1379.
+ * </p>
+ * <p>
+ * An unconvertible record must be skipped deliberately and visibly: no
+ * NullPointerException, and a warning that says the record was skipped.
+ * </p>
+ */
+public class NullParsedRecordSkipTest {
+
+    /** Collects everything the class under test logs during one call. */
+    private static final class CapturingAppender extends AbstractAppender {
+
+        private final List<LogEvent> events = Collections.synchronizedList(new ArrayList<>());
+
+        CapturingAppender() {
+            super("capture-1379", null, null, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            events.add(event.toImmutable());
+        }
+    }
+
+    /**
+     * Stands in for the real parser on the path that returns null, so the
+     * test exercises the caller rather than the converter.
+     */
+    private static final class NullReturningParser implements DebeziumRecordParserService {
+
+        @Override
+        public ClickHouseStruct parse(ChangeEvent<SourceRecord, SourceRecord> record,
+                                      DebeziumEngine.RecordCommitter<
+                                              ChangeEvent<SourceRecord, SourceRecord>> committer,
+                                      boolean lastRecordInBatch) {
+            return null;
+        }
+    }
+
+    /** A row-change event with no DDL field, so the row branch is taken. */
+    private static ChangeEvent<SourceRecord, SourceRecord> rowEvent() {
+        Schema schema = SchemaBuilder.struct()
+                .field("id", Schema.INT32_SCHEMA)
+                .build();
+        Struct value = new Struct(schema);
+        value.put("id", 1);
+        SourceRecord record = new SourceRecord(null, null, "topic", schema, value);
+        return new ChangeEvent<SourceRecord, SourceRecord>() {
+            @Override
+            public SourceRecord key() {
+                return null;
+            }
+
+            @Override
+            public SourceRecord value() {
+                return record;
+            }
+
+            @Override
+            public String destination() {
+                return "topic";
+            }
+
+            @Override
+            public Integer partition() {
+                return null;
+            }
+        };
+    }
+
+    /**
+     * processEveryChangeRecord is private and its only caller is the Debezium
+     * batch handler, which needs a live engine. The seam is therefore
+     * reflective; the argument list mirrors the call in handleBatch.
+     */
+    private static ClickHouseStruct invokeProcess(DebeziumChangeEventCapture capture,
+                                                  ChangeEvent<SourceRecord, SourceRecord> record,
+                                                  DebeziumRecordParserService parser)
+            throws Exception {
+        Method m = DebeziumChangeEventCapture.class.getDeclaredMethod(
+                "processEveryChangeRecord",
+                Properties.class,
+                ChangeEvent.class,
+                DebeziumRecordParserService.class,
+                ClickHouseSinkConnectorConfig.class,
+                DebeziumEngine.RecordCommitter.class,
+                boolean.class,
+                long.class);
+        m.setAccessible(true);
+        return (ClickHouseStruct) m.invoke(capture, new Properties(), record, parser,
+                null, null, true, 1000000001L);
+    }
+
+    @Test
+    @DisplayName("A record the parser cannot convert is skipped without a NullPointerException")
+    public void shouldSkipUnparseableRecordWithoutNPE() throws Exception {
+        Logger coreLogger = (Logger) LogManager.getLogger(DebeziumChangeEventCapture.class);
+        CapturingAppender appender = new CapturingAppender();
+        appender.start();
+        coreLogger.addAppender(appender);
+
+        ClickHouseStruct result;
+        try {
+            result = invokeProcess(new DebeziumChangeEventCapture(), rowEvent(),
+                    new NullReturningParser());
+        } finally {
+            coreLogger.removeAppender(appender);
+            appender.stop();
+        }
+
+        // Nothing was converted, so there is nothing to hand downstream.
+        assertNull("an unconvertible record must not produce a struct", result);
+
+        // Before the fix, setSequenceNumber ran on the null return value and
+        // the resulting NPE was swallowed by the catch-all one line below.
+        // The throwable is quoted back so a failure names the defect instead
+        // of merely asserting that one exists.
+        String npe = appender.events.stream()
+                .filter(e -> e.getThrown() instanceof NullPointerException)
+                .map(e -> String.valueOf(e.getThrown()))
+                .findFirst()
+                .orElse(null);
+        assertNull("an unconvertible record must not raise a NullPointerException; "
+                        + "issue #1379 logged one per record for the whole snapshot, got: " + npe,
+                npe);
+
+        // Dropping a record must be visible, not silent.
+        boolean skipWarned = appender.events.stream()
+                .anyMatch(e -> e.getLevel().isMoreSpecificThan(Level.WARN)
+                        && e.getMessage().getFormattedMessage().toLowerCase()
+                        .contains("skipping"));
+        assertTrue("skipping a record must be logged at WARN or above", skipWarned);
+    }
+}

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/UnparseableRecordProgressIT.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/UnparseableRecordProgressIT.java
@@ -1,0 +1,283 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import com.altinity.clickhouse.debezium.embedded.AppInjector;
+import com.altinity.clickhouse.debezium.embedded.ClickHouseDebeziumEmbeddedApplication;
+import com.altinity.clickhouse.debezium.embedded.ITCommon;
+import com.altinity.clickhouse.debezium.embedded.parser.DebeziumRecordParserService;
+import com.altinity.clickhouse.sink.connector.db.BaseDbWriter;
+import com.altinity.clickhouse.sink.connector.db.HikariDbSource;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.log4j.BasicConfigurator;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.altinity.clickhouse.debezium.embedded.ITCommon.CLICKHOUSE_DOCKER_IMAGE;
+import static com.altinity.clickhouse.debezium.embedded.ITCommon.MYSQL_DOCKER_IMAGE;
+import static com.altinity.clickhouse.debezium.embedded.ITCommon.getDebeziumProperties;
+
+/**
+ * End-to-end regression coverage for issue #1379 ("Initial Snapshot never
+ * finishes").
+ *
+ * <p>A running MySQL to ClickHouse pipeline carries more than row changes.
+ * Transaction-boundary events and heartbeats are ordinary Debezium records
+ * with a Struct value and no {@code op} field, so
+ * {@code SourceRecordParserService.parse} returns null for them -- that null
+ * is contract, not failure. {@code processEveryChangeRecord} called
+ * {@code setSequenceNumber} on the return value before testing it for null,
+ * so every one of those records raised a NullPointerException. The catch-all
+ * in the same method swallowed it, which is why the reported symptom was a
+ * snapshot that never completed while the log filled with the same stack
+ * trace rather than an outright crash.</p>
+ *
+ * <p>{@link NullParsedRecordSkipTest} pins the caller's behaviour directly.
+ * This test pins it where it actually failed: a real MySQL, a real Debezium
+ * engine and a real ClickHouse, with the unparseable records produced by the
+ * connector itself rather than by a stub.</p>
+ *
+ * <p>Two things are asserted, and the first exists so the second cannot pass
+ * vacuously:</p>
+ * <ol>
+ *   <li>the unparseable path was actually reached during the run -- either a
+ *       deliberate skip (fixed) or a NullPointerException (broken). If
+ *       neither appears, no such record was ever produced and the test would
+ *       be proving nothing, so it fails;</li>
+ *   <li>no NullPointerException was raised while processing records, and the
+ *       rows written after those records are all in ClickHouse -- the
+ *       pipeline kept making progress.</li>
+ * </ol>
+ */
+@Testcontainers
+@DisplayName("Records the parser cannot convert are skipped without stalling the pipeline (#1379)")
+public class UnparseableRecordProgressIT {
+
+    /** Rows inserted after the unparseable records; all must reach ClickHouse. */
+    private static final int ROWS = 4;
+
+    protected MySQLContainer mySqlContainer;
+
+    @Container
+    public static ClickHouseContainer clickHouseContainer =
+            new ClickHouseContainer(DockerImageName.parse(CLICKHOUSE_DOCKER_IMAGE)
+                    .asCompatibleSubstituteFor("clickhouse"))
+                    .withInitScript("init_clickhouse_schema_only_column_timezone.sql")
+                    .withUsername("ch_user")
+                    .withPassword("password")
+                    .withExposedPorts(8123);
+
+    /**
+     * Collects everything {@link DebeziumChangeEventCapture} logs during the
+     * run, including the throwables, so the assertions can inspect the
+     * exception objects rather than match on rendered text.
+     */
+    private static final class CapturingAppender extends AbstractAppender {
+
+        private final List<LogEvent> events = Collections.synchronizedList(new ArrayList<>());
+
+        CapturingAppender() {
+            super("capture-1379-it", null, null, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            this.events.add(event.toImmutable());
+        }
+    }
+
+    @BeforeEach
+    public void startContainers() throws InterruptedException {
+        mySqlContainer = new MySQLContainer<>(DockerImageName.parse(MYSQL_DOCKER_IMAGE)
+                .asCompatibleSubstituteFor("mysql"))
+                .withDatabaseName("employees").withUsername("root").withPassword("adminpass")
+                .withExtraHost("mysql-server", "0.0.0.0")
+                .waitingFor(new HttpWaitStrategy().forPort(3306));
+
+        BasicConfigurator.configure();
+        mySqlContainer.start();
+        clickHouseContainer.start();
+        Thread.sleep(15000);
+    }
+
+    @AfterEach
+    public void stopContainers() {
+        if (mySqlContainer != null && mySqlContainer.isRunning()) {
+            mySqlContainer.stop();
+        }
+        if (clickHouseContainer != null && clickHouseContainer.isRunning()) {
+            clickHouseContainer.stop();
+        }
+    }
+
+    @Test
+    @DisplayName("Transaction-boundary and heartbeat records do not raise a NullPointerException, and rows keep landing")
+    public void unparseableRecordsDoNotStallTheEngine() throws Exception {
+
+        Injector injector = Guice.createInjector(new AppInjector());
+
+        Properties props = getDebeziumProperties(mySqlContainer, clickHouseContainer);
+        props.setProperty("snapshot.mode", "no_data");
+        props.setProperty("schema.history.internal.store.only.captured.tables.ddl", "true");
+        props.setProperty("schema.history.internal.store.only.captured.databases.ddl", "true");
+        // Both of these make the connector emit records with a Struct value
+        // and no "op" field -- exactly the records parse() returns null for.
+        // Nothing is stubbed: the connector produces its own poison.
+        props.setProperty("provide.transaction.metadata", "true");
+        props.setProperty("heartbeat.interval.ms", "1000");
+
+        // Attach before the engine starts, so nothing logged during startup or
+        // the snapshot is missed.
+        Logger coreLogger = (Logger) LogManager.getLogger(DebeziumChangeEventCapture.class);
+        CapturingAppender appender = new CapturingAppender();
+        appender.start();
+        coreLogger.addAppender(appender);
+
+        ClickHouseDebeziumEmbeddedApplication application =
+                new ClickHouseDebeziumEmbeddedApplication();
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+        Connection conn = null;
+
+        try {
+            executorService.execute(() -> {
+                try {
+                    application.start(injector.getInstance(DebeziumRecordParserService.class),
+                            props, false);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            Thread.sleep(25000);
+
+            conn = ITCommon.connectToMySQL(mySqlContainer);
+            conn.prepareStatement("create table `ledger`(id int not null, note varchar(255), "
+                    + "primary key(id))").execute();
+
+            // Autocommit is on, so each insert is its own transaction and
+            // produces its own pair of transaction-boundary records.
+            for (int id = 1; id <= ROWS; id++) {
+                conn.prepareStatement("insert into ledger values(" + id + ", 'row" + id + "')")
+                        .execute();
+                Thread.sleep(2000);
+            }
+
+            Thread.sleep(25000);
+
+            // (1) The unparseable path must have been reached, otherwise this
+            // test asserts nothing. Post-fix that shows up as the deliberate
+            // skip; pre-fix as the NullPointerException asserted on below.
+            long skips = appender.events.stream()
+                    .filter(e -> e.getLevel().isMoreSpecificThan(Level.WARN))
+                    .filter(e -> e.getMessage().getFormattedMessage().toLowerCase()
+                            .contains("skipping"))
+                    .count();
+            List<Throwable> npes = collectNullPointerExceptions(appender);
+            Assert.assertTrue("no unparseable record reached the connector during this run, so "
+                            + "this test exercised nothing; expected transaction-boundary or "
+                            + "heartbeat records to be produced",
+                    skips > 0 || !npes.isEmpty());
+
+            // (2) The regression itself. A record the parser cannot convert
+            // must be skipped deliberately, never by way of an NPE.
+            Assert.assertTrue("processing a record the parser could not convert raised "
+                            + npes.size() + " NullPointerException(s); issue #1379 raised one per "
+                            + "such record for the whole snapshot. First occurrence:\n"
+                            + firstStackTrace(npes),
+                    npes.isEmpty());
+
+            // (3) ... and the pipeline kept moving: every row written after
+            // those records is in ClickHouse.
+            BaseDbWriter writer = ITCommon.getDBWriter(clickHouseContainer);
+            long landed = 0;
+            ResultSet rs = ITCommon.executeQueryWithResultSet(
+                    "select count(*) as row_count from employees.ledger final",
+                    writer.getConnection());
+            while (rs.next()) {
+                landed = rs.getLong("row_count");
+            }
+            Assert.assertEquals("every row inserted after the unparseable records must reach "
+                    + "ClickHouse", ROWS, landed);
+        } finally {
+            coreLogger.removeAppender(appender);
+            appender.stop();
+            try {
+                if (application.getDebeziumEventCapture() != null
+                        && application.getDebeziumEventCapture().engine != null) {
+                    application.getDebeziumEventCapture().engine.close();
+                }
+            } catch (Exception ignored) {
+                // Teardown must not mask the assertion that brought us here.
+            }
+            if (conn != null) {
+                conn.close();
+            }
+            executorService.shutdown();
+            HikariDbSource.close();
+        }
+    }
+
+    /**
+     * Every NullPointerException logged by the class under test, unwrapping
+     * cause chains so a wrapped NPE is not missed.
+     *
+     * @param appender the appender holding this run's log events
+     * @return the NullPointerExceptions that were logged, in order
+     */
+    private static List<Throwable> collectNullPointerExceptions(CapturingAppender appender) {
+        List<Throwable> found = new ArrayList<>();
+        for (LogEvent event : new ArrayList<>(appender.events)) {
+            for (Throwable t = event.getThrown(); t != null; t = t.getCause()) {
+                if (t instanceof NullPointerException) {
+                    found.add(t);
+                    break;
+                }
+                if (t.getCause() == t) {
+                    break;
+                }
+            }
+        }
+        return found;
+    }
+
+    /**
+     * Renders the first captured throwable so a failure names the defect
+     * instead of merely asserting that one exists.
+     *
+     * @param throwables the captured throwables
+     * @return a printable stack trace, or a placeholder when there are none
+     */
+    private static String firstStackTrace(List<Throwable> throwables) {
+        if (throwables.isEmpty()) {
+            return "(none)";
+        }
+        StringWriter sw = new StringWriter();
+        throwables.get(0).printStackTrace(new PrintWriter(sw));
+        return sw.toString();
+    }
+}


### PR DESCRIPTION
Fixes #1379.

## Root cause

`SourceRecordParserService.parse()` legitimately returns `null` — at lines 57 (null record or null value), 62 (value is not a `Struct`) and 85 (converter returned null). This became a documented return path in #1360.

`DebeziumChangeEventCapture.processEveryChangeRecord` dereferenced that result one line **before** its own null check:

```java
chStruct = debeziumRecordParserService.parse(record, recordCommitter, lastRecordInBatch);
chStruct.setSequenceNumber(sequenceNumber);   // NPE
try {
    if (chStruct != null) {                   // the check that proves null is expected
```

The NPE is caught by the outer `catch (Exception e)`, so the record is silently discarded and the loop logs one NPE per record — the reported "Initial Snapshot never finishes" with repeating NPE spam.

## Fix

`setSequenceNumber` moves inside the existing null check, and the null case is logged rather than swallowed silently. 10 insertions, 1 deletion, no reformatting.

## Verification

Unit test `NullParsedRecordSkipTest` reproduces the reported NPE string exactly. Before the fix:

```
java.lang.AssertionError: an unconvertible record must not raise a NullPointerException; got:
java.lang.NullPointerException: Cannot invoke
"com.altinity.clickhouse.sink.connector.model.ClickHouseStruct.setSequenceNumber(long)"
because "chStruct" is null
```

End-to-end test `UnparseableRecordProgressIT` drives a live MySQL to Debezium to ClickHouse pipeline with `provide.transaction.metadata=true` and `heartbeat.interval.ms=1000`, so the connector produces genuinely unparseable records itself — nothing is stubbed. With the production file reverted to develop:

```
UnparseableRecordProgressIT.unparseableRecordsDoNotStallTheEngine:208
processing a record the parser could not convert raised 13 NullPointerException(s)
	at DebeziumChangeEventCapture.processEveryChangeRecord(DebeziumChangeEventCapture.java:1262)
	at DebeziumChangeEventCapture$1.handleBatch(DebeziumChangeEventCapture.java:377)
```

With the fix restored, both pass. Module suite 288 to 289 tests, delta is exactly the new unit test; docker-dependent error set identical (compared by name, not count).

## Scope note

This stops the NPE and makes the drop observable. A record that cannot be parsed is still skipped — why a given source emits unparseable records is a separate question and is not addressed here.
