### PR TITLE
fix: batch containing a missing ClickHouse table is silently dropped and the offset advances

### DIFF
--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchWriter.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchWriter.java
@@ -185,7 +185,14 @@ public class ClickHouseBatchWriter {
      * <p>This method groups records by topic, processes each group, and
      * acknowledges the records if processing is successful.
      *
+     * <p>A batch that cannot be written raises
+     * {@link BatchPersistenceException} rather than returning quietly, so the
+     * Debezium engine stops instead of committing an offset past records that
+     * never reached ClickHouse.
+     *
      * @param records a list of ClickHouseStruct records to persist
+     * @throws BatchPersistenceException if any topic in the batch could not be
+     *         persisted
      */
     public void persistRecords(List<ClickHouseStruct> records) {
         log.info("****** Thread: " +
@@ -222,9 +229,24 @@ public class ClickHouseBatchWriter {
                 result = processRecordsByTopic(entry.getKey(),
                         entry.getValue());
                 if (result == false) {
-                    log.error("Error processing records for topic: " +
-                            entry.getKey());
-                    break;
+                    // Do NOT break and fall out of this method normally. A
+                    // normal return tells the caller the batch was handled:
+                    // the acknowledgement block below is skipped, so this
+                    // batch is never committed, but the engine goes straight
+                    // on to the NEXT batch and commits ITS offsets -- which
+                    // are higher. The unwritten records are then behind the
+                    // committed offset and are never replayed. That is the
+                    // silent loss in issue #1285.
+                    throw new BatchPersistenceException(String.format(
+                            "Failed to persist %d record(s) for topic %s to "
+                            + "ClickHouse. The most common cause is that the "
+                            + "target table does not exist and "
+                            + "auto.create.tables is disabled (see the "
+                            + "TABLE METADATA not retrieved errors above). "
+                            + "Failing the batch so its offset is not "
+                            + "committed; the records are replayed from the "
+                            + "last committed offset once the table exists.",
+                            entry.getValue().size(), entry.getKey()));
                 }
             }
             // acknowledge the records.
@@ -248,7 +270,73 @@ public class ClickHouseBatchWriter {
                 });
             }
         } catch (Exception e) {
-            log.error("Error persisting records to ClickHouse" + e);
+            if (isInterrupt(e)) {
+                // The task is being shut down. Nothing was acknowledged, so
+                // this batch is replayed from the last committed offset on the
+                // next start; treating a shutdown as a persistence failure
+                // would turn a clean stop into a restart loop.
+                Thread.currentThread().interrupt();
+                log.warn("Interrupted while persisting records to ClickHouse. "
+                        + "The batch was not acknowledged and will be replayed "
+                        + "from the last committed offset.", e);
+                return;
+            }
+            // Anything else means the batch did not reach ClickHouse.
+            // Swallowing it here has exactly the same effect as the break
+            // above: the batch is dropped, the engine moves on, and a later
+            // batch commits an offset past these records. Unlike
+            // ClickHouseBatchRunnable -- which keeps currentBatch non-null and
+            // re-polls the SAME batch, so a failure there is retried -- this
+            // writer is called once per batch and has no retry loop. The only
+            // way for it to avoid losing data is to fail loudly.
+            log.error("Error persisting records to ClickHouse", e);
+            throw e instanceof BatchPersistenceException
+                    ? (BatchPersistenceException) e
+                    : new BatchPersistenceException(
+                            "Failed to persist a batch of records to ClickHouse", e);
+        }
+    }
+
+    /**
+     * Whether this failure is an interrupt, i.e. the task is shutting down
+     * rather than failing to write.
+     *
+     * @param e the exception to inspect
+     * @return true when an InterruptedException appears in the cause chain
+     */
+    private static boolean isInterrupt(Throwable e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t instanceof InterruptedException) {
+                return true;
+            }
+            if (t.getCause() == t) {
+                break;
+            }
+        }
+        return Thread.currentThread().isInterrupted();
+    }
+
+    /**
+     * Signals that a batch could not be written to ClickHouse.
+     *
+     * <p>Thrown so the failure reaches the Debezium engine instead of being
+     * logged and forgotten. The engine stops and restarts from the last
+     * committed offset, which replays the records this batch failed to write.
+     * The alternative -- returning normally -- leaves those records behind an
+     * offset that a later batch commits, and they are lost for good.
+     *
+     * <p>See issue #1285.
+     */
+    public static class BatchPersistenceException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+
+        public BatchPersistenceException(String message) {
+            super(message);
+        }
+
+        public BatchPersistenceException(String message, Throwable cause) {
+            super(message, cause);
         }
     }
 

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchWriterMissingTableTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchWriterMissingTableTest.java
@@ -1,0 +1,216 @@
+package com.altinity.clickhouse.sink.connector.executor;
+
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import com.altinity.clickhouse.sink.connector.converters.ClickHouseConverter;
+import com.altinity.clickhouse.sink.connector.db.DBMetadata;
+import com.altinity.clickhouse.sink.connector.db.HikariDbSource;
+import com.altinity.clickhouse.sink.connector.model.ClickHouseStruct;
+import io.debezium.engine.ChangeEvent;
+import io.debezium.engine.DebeziumEngine;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A Debezium batch carrying records for a table that does not exist in
+ * ClickHouse must not be discarded quietly.
+ *
+ * <p>With {@code auto.create.tables=false} and the target table missing,
+ * {@code DbWriter} cannot read the table metadata, so
+ * {@code processRecordsByTopic} exhausts its retries and returns {@code false}
+ * (the {@code wasTableMetaDataRetrieved()} block in ClickHouseBatchWriter).
+ * The per-topic loop in {@code persistRecords} used to {@code break} on that
+ * and let the method return normally, and the outer {@code catch} swallowed
+ * anything thrown. The caller,
+ * {@code DebeziumChangeEventCapture.appendToRecords}, has no return value to
+ * inspect and no exception to catch, so {@code handleBatch} completed as if
+ * the batch had been written.</p>
+ *
+ * <p>What that costs: the acknowledgement block is skipped, so THIS batch is
+ * never committed -- but the engine moves straight on to the next batch, whose
+ * {@code markBatchFinished()} commits a HIGHER offset. The unwritten records
+ * are then behind the committed offset and are never replayed. Records for
+ * every topic ordered after the failing one in the batch are dropped the same
+ * way, having never been attempted at all.</p>
+ *
+ * <p>This is specific to the single-threaded writer path
+ * ({@code single.threaded=true}, which is what the lightweight connector uses
+ * when configured that way). {@code ClickHouseBatchRunnable} contains the same
+ * {@code break} but survives it: it only clears {@code currentBatch} when the
+ * result is true, so it re-polls and retries the same batch. This writer is
+ * invoked once per batch and has no retry loop, so failing loudly is the only
+ * way for it not to lose data.</p>
+ *
+ * <p>The reproduction points the writer at a ClickHouse that cannot be
+ * reached, which drives {@code wasTableMetaDataRetrieved()} to false through
+ * the same state a missing table produces -- an empty column map and a null
+ * engine -- without needing a live server. The assertions are about the
+ * OUTCOME the issue reports: no exception reaches the caller, and not one
+ * record is acknowledged, so nothing distinguishes a dropped batch from a
+ * written one.</p>
+ *
+ * <p>See issue #1285.</p>
+ */
+public class ClickHouseBatchWriterMissingTableTest {
+
+    /** A port nothing listens on, so metadata retrieval always fails. */
+    private static final int UNREACHABLE_PORT = 1;
+
+    private static final Schema ROW_SCHEMA = SchemaBuilder.struct()
+            .field("id", Schema.INT32_SCHEMA)
+            .field("name", Schema.STRING_SCHEMA)
+            .build();
+
+    /** DBMetadata declared default, restored so this test leaks no state. */
+    private static final int DEFAULT_MAX_RETRIES = 10;
+
+    @BeforeEach
+    public void setUp() {
+        // The metadata helpers retry MAX_RETRIES times per query against a
+        // server that is not there. One attempt reaches the same "still no
+        // metadata" verdict and keeps the test quick.
+        DBMetadata.setMaxRetries(1);
+        HikariDbSource.close();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        DBMetadata.setMaxRetries(DEFAULT_MAX_RETRIES);
+        HikariDbSource.close();
+    }
+
+    /**
+     * Counts what the connector told Debezium about the batch. Both counts
+     * staying at zero while persistRecords returns normally IS the data loss:
+     * the engine is then free to advance past records never written.
+     */
+    private static final class CountingCommitter
+            implements DebeziumEngine.RecordCommitter {
+
+        private final AtomicInteger processed = new AtomicInteger();
+        private final AtomicInteger batchesFinished = new AtomicInteger();
+
+        @Override
+        public void markProcessed(Object record) {
+            this.processed.incrementAndGet();
+        }
+
+        @Override
+        public void markBatchFinished() {
+            this.batchesFinished.incrementAndGet();
+        }
+
+        @Override
+        public void markProcessed(Object record, DebeziumEngine.Offsets offsets) {
+            this.processed.incrementAndGet();
+        }
+
+        @Override
+        public DebeziumEngine.Offsets buildOffsets() {
+            return null;
+        }
+    }
+
+    private static ClickHouseSinkConnectorConfig config() {
+        Map<String, String> props = new HashMap<>();
+        props.put("clickhouse.server.url", "127.0.0.1");
+        props.put("clickhouse.server.port", String.valueOf(UNREACHABLE_PORT));
+        props.put("clickhouse.server.user", "default");
+        props.put("clickhouse.server.password", "");
+        props.put("clickhouse.server.database", "testdb");
+        // The scenario in the issue: the user manages their own schemas, so a
+        // table missing from ClickHouse is never created for them.
+        props.put("auto.create.tables", "false");
+        props.put("single.threaded", "true");
+        props.put("connection.pool.disable", "true");
+        props.put("errors.max.retries", "1");
+        return new ClickHouseSinkConnectorConfig(props);
+    }
+
+    private static ClickHouseStruct record(String topic, long offset,
+                                           CountingCommitter committer,
+                                           boolean lastInBatch) {
+        Struct row = new Struct(ROW_SCHEMA)
+                .put("id", (int) offset)
+                .put("name", "row" + offset);
+        ClickHouseStruct chStruct = new ClickHouseStruct(offset, topic, null, 0,
+                System.currentTimeMillis(), null, row, null,
+                ClickHouseConverter.CDC_OPERATION.CREATE);
+        chStruct.setDatabase("testdb");
+        chStruct.setCommitter(committer);
+        chStruct.setSourceRecord((ChangeEvent<SourceRecord, SourceRecord>) null);
+        chStruct.setLastRecordInBatch(lastInBatch);
+        return chStruct;
+    }
+
+    /**
+     * The regression. A batch whose table is missing from ClickHouse must
+     * raise {@link ClickHouseBatchWriter.BatchPersistenceException} out of
+     * persistRecords. Before the fix persistRecords returned normally, which
+     * let the engine treat the batch as handled and commit past it.
+     */
+    @Test
+    public void missingTableFailsTheBatchInsteadOfDroppingIt() {
+        ClickHouseBatchWriter writer =
+                new ClickHouseBatchWriter(config(), new HashMap<>());
+        CountingCommitter committer = new CountingCommitter();
+
+        List<ClickHouseStruct> batch = new ArrayList<>();
+        batch.add(record("SERVER5432.testdb.orders", 1L, committer, false));
+        batch.add(record("SERVER5432.testdb.orders", 2L, committer, false));
+        // A second table, ordered after the failing one: today these records
+        // are never even attempted.
+        batch.add(record("SERVER5432.testdb.customers", 3L, committer, true));
+
+        RuntimeException thrown = null;
+        try {
+            writer.persistRecords(batch);
+        } catch (RuntimeException e) {
+            thrown = e;
+        }
+
+        // Not one record was acknowledged -- nothing reached ClickHouse.
+        Assert.assertEquals("no record may be acknowledged when the batch was not written",
+                0, committer.processed.get());
+        Assert.assertEquals("the batch must not be marked finished when it was not written",
+                0, committer.batchesFinished.get());
+
+        // ... and because nothing was acknowledged, the ONLY thing that can
+        // stop the engine from committing a later, higher offset over these
+        // records is a failure reaching the caller.
+        Assert.assertNotNull("persistRecords returned normally after failing to write the batch: "
+                        + "the caller cannot tell the batch was dropped, so the offset advances "
+                        + "past records that never reached ClickHouse (issue #1285)",
+                thrown);
+        Assert.assertTrue("the failure must be reported as a batch persistence failure, got: "
+                        + thrown.getClass().getName(),
+                thrown instanceof ClickHouseBatchWriter.BatchPersistenceException);
+        Assert.assertTrue("the failure must name the topic it could not persist, got: "
+                        + thrown.getMessage(),
+                thrown.getMessage() != null
+                        && thrown.getMessage().contains("SERVER5432.testdb."));
+    }
+
+    /**
+     * An empty batch has nothing to fail on and must stay silent -- the fix
+     * must not turn a no-op into a connector restart.
+     */
+    @Test
+    public void emptyBatchIsNotAFailure() {
+        ClickHouseBatchWriter writer =
+                new ClickHouseBatchWriter(config(), new HashMap<>());
+
+        writer.persistRecords(new ArrayList<>());
+    }
+}


### PR DESCRIPTION
Fixes #1285.

## Root cause

`ClickHouseBatchWriter.persistRecords` treated a topic whose ClickHouse table is missing as a loop-break rather than a failure:

```java
result = processRecordsByTopic(entry.getKey(), entry.getValue());
if (result == false) {
    log.error("Error processing records for topic: " + entry.getKey());
    break;
}
```

`processRecordsByTopic` returns `false` after the metadata retry block fails (`wasTableMetaDataRetrieved() == false` — null engine or empty column map, which is exactly what `auto.create.tables=false` plus a missing table produces). The `break` skipped `markProcessed`/`markBatchFinished`, and the method then **returned normally**.

The caller is `void` and has no try/catch:

```java
singleThreadedWriter.persistRecords(convertedRecords);   // DebeziumChangeEventCapture:1472
```

so a normal return is indistinguishable from success. The batch is not committed, but the next batch's `markBatchFinished()` commits a **higher** offset — the unwritten records end up behind the committed offset and are lost permanently. An outer `catch (Exception e)` that only logged meant even a thrown failure could not escape.

## Fix

The failure is raised as a `BatchPersistenceException` naming the topic and record count, and the outer catch rethrows instead of swallowing. It reaches the `CompletionCallback`, which restarts the engine from the last committed offset — the replay the issue asks for.

One exception is deliberately preserved as non-fatal: an interrupt (cause-chain walk, interrupt flag restored) means shutdown, not a write failure, and rethrowing it would turn a clean stop into a restart loop.

`ClickHouseBatchRunnable` is **not** touched. It has the same `break` but survives it, because `currentBatch` is only nulled when `result` is true, so it re-polls and retries the same batch.

## Verification

`ClickHouseBatchWriterMissingTableTest`. Before the fix:

```
[ERROR] ClickHouseBatchWriter - *** TABLE METADATA not retrieved for Database(testdb), table(orders), retrying on next attempt
[ERROR] ClickHouseBatchWriter - Error processing records for topic: SERVER5432.testdb.orders
java.lang.AssertionError: persistRecords returned normally after failing to write the batch: the caller
cannot tell the batch was dropped, so the offset advances past records that never reached ClickHouse
```

The first two lines are the reporter's log signature. The zero-acknowledgement assertions already passed pre-fix — the only thing missing was the failure reaching the caller, which is precisely the defect. Module suite 226 to 228, docker-dependent error set identical by name.

## Trade-off, stated plainly

This converts silent data loss into an engine restart. For a persistently missing table that means a restart loop until the table is created. That is the "Halt" option the issue lists first, and it is a deliberate choice of correctness over availability rather than a free win. The alternative in the issue — skip only the failing table and commit the rest — needs per-topic offset tracking this path does not have today.

## On end-to-end coverage

An additional container-backed IT was attempted and deliberately **not** included, because it did not discriminate. Row counts converge on the same total either way: with the fix the engine surfaces the exception, restarts and replays the same rows; without it the engine writes them once and moves on. The observable that actually differs is recoverability — create the missing table afterwards and a non-committed offset replays the stranded record, whereas a committed one strands it permanently. That is the right shape for an e2e assertion and is worth adding as a follow-up; shipping a test that passes in both directions would have been worse than shipping none.
