### PR TITLE
fix: _version stores UInt64 max when the source has no GTID, permanently winning RMT dedup

### DIFF
--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/PreparedStatementFieldMapper.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/PreparedStatementFieldMapper.java
@@ -351,6 +351,7 @@ public class PreparedStatementFieldMapper {
                 record.calculateVersion(config.getBoolean(
                         ClickHouseSinkConnectorConfigVariables.SNOWFLAKE_ID.toString()));
             }
+            rejectUnderivableVersion(record);
             long tombstoneVersion = record.getVersion() > 0 ? record.getVersion() - 1 : record.getVersion();
             ps.setLong(columnNameToIndexMap.get(this.versionColumn), tombstoneVersion);
         }
@@ -480,6 +481,37 @@ public class PreparedStatementFieldMapper {
     }
 
     /**
+     * Refuses to bind a version that could not be derived (issue #1213).
+     *
+     * <p>{@code ClickHouseStruct.version} starts at the {@code -1} uninitialized
+     * sentinel. Binding it with {@code setLong} into the {@code UInt64}
+     * {@code _version} column stores 18446744073709551615 -- the maximum UInt64.
+     * Under ReplacingMergeTree that row then wins every future deduplication
+     * permanently, so every later UPDATE and DELETE for the same key is silently
+     * discarded on merge: unbounded, undetectable data loss. Failing the batch is
+     * strictly preferable, since the batch is retried or surfaced to the operator
+     * whereas the corrupt row is not recoverable once merged.</p>
+     *
+     * <p>After {@code calculateVersion()} this is only reachable when the record
+     * carries no ordering key AND no source commit timestamp, which indicates a
+     * malformed or unsupported change event rather than a normal GTID-less source.</p>
+     *
+     * @param record The CDC record whose version is about to be bound.
+     */
+    private static void rejectUnderivableVersion(ClickHouseStruct record) {
+        if (record.getVersion() == -1) {
+            throw new IllegalStateException(
+                    "Cannot derive a _version for record from topic '" + record.getTopic()
+                            + "' at kafka offset " + record.getKafkaOffset()
+                            + ": no GTID, sequence number, LSN or source timestamp is present. "
+                            + "Refusing to write the uninitialized sentinel, which is stored as "
+                            + "UInt64 18446744073709551615 and would win every ReplacingMergeTree "
+                            + "deduplication for this key permanently, silently discarding all "
+                            + "later updates and deletes.");
+        }
+    }
+
+    /**
      * Handles Version column for REPLACING_MERGE_TREE engines.
      * Uses the version already calculated and stored in the ClickHouseStruct.
      */
@@ -500,6 +532,7 @@ public class PreparedStatementFieldMapper {
                         boolean useSnowflakeId = config.getBoolean(ClickHouseSinkConnectorConfigVariables.SNOWFLAKE_ID.toString());
                         record.calculateVersion(useSnowflakeId);
                     }
+                    rejectUnderivableVersion(record);
                     ps.setLong(columnNameToIndexMap.get(versionColumn), record.getVersion());
                 }
             }

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/model/ClickHouseStruct.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/model/ClickHouseStruct.java
@@ -818,6 +818,29 @@ public class ClickHouseStruct {
      * Calculates and sets the version based on gtid, sequenceNumber, or lsn.
      * Uses SnowFlakeId algorithm if useSnowflakeId is true and gtid is available.
      *
+     * <p>When none of those three ordering keys is present, the version is derived
+     * from the source commit timestamp combined with the Kafka offset (issue #1213).
+     * A MySQL source with GTID disabled supplies no gtid, and the Kafka Connect path
+     * never assigns a sequence number (only the lightweight
+     * {@code DebeziumChangeEventCapture} does), so before this fallback existed the
+     * method returned with {@code version} still at {@link #UNINITIALIZED_VALUE}.
+     * That {@code -1} was then bound with {@code setLong} into the {@code UInt64}
+     * {@code _version} column and stored as 18446744073709551615 -- the maximum
+     * UInt64, a version no later row can ever supersede, so every subsequent UPDATE
+     * and DELETE for that key was silently discarded on ReplacingMergeTree merge.</p>
+     *
+     * <p>The fallback deliberately reuses the connector's existing SnowFlakeId
+     * formula, substituting the Kafka offset for the absent GTID: both are
+     * monotonically increasing per source, so the resulting versions order by commit
+     * time first and by offset within the same millisecond, exactly as the GTID form
+     * does. It is applied regardless of {@code useSnowflakeId}, because with no GTID
+     * there is no raw transaction id for the non-snowflake branch to use, and any
+     * derived version is strictly better than the corrupt sentinel.</p>
+     *
+     * <p>The version is left at the sentinel only when even the source timestamp is
+     * missing, i.e. when nothing at all can be derived. The bind sites reject such a
+     * record rather than write it.</p>
+     *
      * @param useSnowflakeId Whether to use SnowFlakeId algorithm for version generation
      */
     public void calculateVersion(boolean useSnowflakeId) {
@@ -831,6 +854,10 @@ public class ClickHouseStruct {
             this.version = this.sequenceNumber;
         } else if (this.lsn != UNINITIALIZED_VALUE) {
             this.version = this.lsn;
+        } else if (this.ts_ms > 0) {
+            // No ordering key from the source (e.g. MySQL with GTID disabled).
+            // Fall back to the source commit timestamp plus the Kafka offset.
+            this.version = SnowFlakeId.generate(this.ts_ms, this.kafkaOffset, false);
         }
     }
 }

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/batch/VersionFallbackWithoutGtidTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/batch/VersionFallbackWithoutGtidTest.java
@@ -1,0 +1,280 @@
+package com.altinity.clickhouse.sink.connector.db.batch;
+
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import com.altinity.clickhouse.sink.connector.common.SnowFlakeId;
+import com.altinity.clickhouse.sink.connector.db.DBMetadata;
+import com.altinity.clickhouse.sink.connector.model.ClickHouseStruct;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.PreparedStatement;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Issue #1213: the {@code _version} column is filled with an unreadable value
+ * on a MySQL source that has GTID disabled.
+ *
+ * <p>Chain: {@code ClickHouseStruct.version} is initialised to the
+ * {@code UNINITIALIZED_VALUE} sentinel {@code -1}. {@code calculateVersion()}
+ * only assigns a version from a GTID, a sequence number or an LSN; when a
+ * MySQL source runs without GTID none of the three is present on the Kafka
+ * Connect path (nothing in {@code sink-connector/src/main} ever calls
+ * {@code setSequenceNumber} -- only the lightweight
+ * {@code DebeziumChangeEventCapture} does), so the method falls through and
+ * leaves the sentinel in place. The bind site then executes
+ * {@code ps.setLong(index, -1)} into a {@code UInt64} column, which stores
+ * <b>18446744073709551615</b> -- the value the reporter sees, and the value
+ * the JDBC driver then refuses to read back
+ * ({@code ArithmeticException: integer overflow: 18446744073709551615 cannot
+ * be presented as long}).
+ *
+ * <p>The unreadable cell is only the visible symptom. UInt64 max is the
+ * largest representable version, so under ReplacingMergeTree such a row wins
+ * every future deduplication permanently: every later UPDATE and DELETE for
+ * that key is discarded on merge. That is silent, unrecoverable corruption,
+ * which is why a record that cannot produce a version must fail loudly rather
+ * than be written.
+ *
+ * <p>The fallback asserted here reuses the connector's existing, already
+ * shipping version formula: {@code SnowFlakeId.generate(ts_ms, ordering)},
+ * substituting the Kafka offset for the absent GTID. Both inputs ARE populated
+ * on the affected path -- {@code ts_ms} from {@code source.ts_ms} and the
+ * offset from {@code record.kafkaOffset()} -- so no new versioning scheme is
+ * invented and no working deployment changes: a source that supplies a GTID, a
+ * sequence number or an LSN still takes its existing branch, which the
+ * regression tests at the bottom of this class pin.
+ */
+public class VersionFallbackWithoutGtidTest {
+
+    private static final String VERSION_COLUMN = "_version";
+
+    /** What setLong(-1) actually stores in a UInt64 column. */
+    private static final String UINT64_MAX = "18446744073709551615";
+
+    /** A realistic MySQL source commit timestamp (2026-01-01T00:00:00Z). */
+    private static final long SOURCE_TS_MS = 1767225600000L;
+
+    private static PreparedStatementFieldMapper mapper() {
+        return new PreparedStatementFieldMapper(
+                "is_deleted", true, null, VERSION_COLUMN, "test_db", ZoneId.of("UTC"));
+    }
+
+    /**
+     * A PreparedStatement stand-in that records the value bound to the version
+     * column. Mockito is not on the test classpath, so this uses a JDK proxy in
+     * the same style as ClosedConnectionRefreshTest.
+     */
+    private static PreparedStatement recordingStatement(AtomicLong boundVersion) {
+        InvocationHandler h = (proxy, method, args) -> {
+            switch (method.getName()) {
+                case "setLong":
+                    boundVersion.set((Long) args[1]);
+                    return null;
+                case "toString":
+                    return "RecordingPreparedStatement";
+                case "hashCode":
+                    return System.identityHashCode(proxy);
+                case "equals":
+                    return proxy == args[0];
+                default:
+                    return null;
+            }
+        };
+        return (PreparedStatement) Proxy.newProxyInstance(
+                PreparedStatement.class.getClassLoader(),
+                new Class<?>[]{PreparedStatement.class}, h);
+    }
+
+    /**
+     * Drives the real bind path for the version column. handleVersionColumn is
+     * private, so it is reached reflectively -- the point of the test is to
+     * observe what actually reaches the driver, not to re-implement it.
+     */
+    private static void bindVersion(ClickHouseStruct record, PreparedStatement ps) throws Exception {
+        Map<String, Integer> columnNameToIndexMap = new HashMap<>();
+        columnNameToIndexMap.put(VERSION_COLUMN, 1);
+        Map<String, String> columnNameToDataTypeMap = new HashMap<>();
+        columnNameToDataTypeMap.put(VERSION_COLUMN, "UInt64");
+
+        Method method = PreparedStatementFieldMapper.class.getDeclaredMethod(
+                "handleVersionColumn",
+                Map.class, PreparedStatement.class, ClickHouseStruct.class,
+                ClickHouseSinkConnectorConfig.class, Map.class,
+                DBMetadata.TABLE_ENGINE.class);
+        method.setAccessible(true);
+        try {
+            method.invoke(mapper(), columnNameToIndexMap, ps, record,
+                    new ClickHouseSinkConnectorConfig(new HashMap<>()),
+                    columnNameToDataTypeMap,
+                    DBMetadata.TABLE_ENGINE.REPLACING_MERGE_TREE);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception) {
+                throw (Exception) cause;
+            }
+            throw e;
+        }
+    }
+
+    /** The exact record shape produced by MySQL-without-GTID on the Kafka Connect path. */
+    private static ClickHouseStruct mysqlRecordWithoutGtid(long kafkaOffset) {
+        ClickHouseStruct record = new ClickHouseStruct();
+        record.setTopic("SERVER5432.test.employees");
+        record.setKafkaOffset(kafkaOffset);
+        record.setTs_ms(SOURCE_TS_MS);
+        // No GTID (disabled on the source), no sequence number (never set on
+        // this path) and no LSN (not a Postgres source).
+        return record;
+    }
+
+    @Test
+    @DisplayName("#1213: a MySQL record without GTID must not leave the -1 sentinel as its version")
+    public void calculateVersionMustNotFallThroughToSentinel() {
+        ClickHouseStruct record = mysqlRecordWithoutGtid(300023L);
+
+        record.calculateVersion(true);
+
+        assertNotEquals(-1L, record.getVersion(),
+                "calculateVersion() fell through and left the uninitialized sentinel. "
+                        + "Bound with setLong into a UInt64 column that stores " + UINT64_MAX
+                        + ", which no later row can ever supersede under ReplacingMergeTree.");
+        assertTrue(record.getVersion() > 0,
+                "the derived version must be a usable positive ordering value; got "
+                        + record.getVersion());
+    }
+
+    @Test
+    @DisplayName("#1213: the value reaching the driver must not be UInt64 max")
+    public void bindMustNotWriteUint64Max() throws Exception {
+        AtomicLong bound = new AtomicLong(Long.MIN_VALUE);
+        bindVersion(mysqlRecordWithoutGtid(300023L), recordingStatement(bound));
+
+        assertNotEquals(Long.MIN_VALUE, bound.get(), "no version was bound at all");
+        assertNotEquals(UINT64_MAX, Long.toUnsignedString(bound.get()),
+                "the bind wrote the -1 sentinel, stored as UInt64 " + UINT64_MAX
+                        + " -- exactly the value reported in issue #1213, and a version "
+                        + "that permanently wins every ReplacingMergeTree merge");
+        assertTrue(bound.get() > 0,
+                "expected a positive version; got " + bound.get()
+                        + " (unsigned " + Long.toUnsignedString(bound.get()) + ")");
+    }
+
+    @Test
+    @DisplayName("#1213: the fallback reuses the existing SnowFlakeId formula with the Kafka offset")
+    public void fallbackUsesSnowflakeIdWithKafkaOffset() {
+        long kafkaOffset = 300023L;
+        ClickHouseStruct record = mysqlRecordWithoutGtid(kafkaOffset);
+
+        record.calculateVersion(true);
+
+        assertEquals(SnowFlakeId.generate(SOURCE_TS_MS, kafkaOffset, false), record.getVersion(),
+                "the fallback must substitute the Kafka offset into the connector's existing "
+                        + "SnowFlakeId(timestamp, ordering) formula rather than invent a scheme");
+    }
+
+    @Test
+    @DisplayName("#1213: versions stay strictly increasing with the Kafka offset")
+    public void fallbackVersionsAreMonotonicWithinASecond() {
+        ClickHouseStruct first = mysqlRecordWithoutGtid(300023L);
+        ClickHouseStruct second = mysqlRecordWithoutGtid(300024L);
+
+        first.calculateVersion(true);
+        second.calculateVersion(true);
+
+        assertTrue(second.getVersion() > first.getVersion(),
+                "two changes committed in the same millisecond must still be ordered by their "
+                        + "Kafka offset, otherwise ReplacingMergeTree picks between them arbitrarily; "
+                        + "got " + first.getVersion() + " then " + second.getVersion());
+    }
+
+    @Test
+    @DisplayName("#1213: a record with no derivable version at all fails loudly, it is never written")
+    public void unresolvableVersionThrowsInsteadOfBinding() {
+        // No ordering key AND no source timestamp: nothing can be derived.
+        ClickHouseStruct record = new ClickHouseStruct();
+        record.setTopic("SERVER5432.test.employees");
+        record.setKafkaOffset(4242L);
+
+        AtomicLong bound = new AtomicLong(Long.MIN_VALUE);
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                () -> bindVersion(record, recordingStatement(bound)),
+                "with no derivable version the batch must fail loudly; binding the sentinel "
+                        + "writes UInt64 " + UINT64_MAX + ", which is unrecoverable corruption");
+
+        assertEquals(Long.MIN_VALUE, bound.get(),
+                "nothing may be bound once the version is known to be underivable");
+        assertTrue(thrown.getMessage() != null && thrown.getMessage().contains(UINT64_MAX),
+                "the error must name the value that would have been stored so an operator can "
+                        + "recognise it in the table; got: " + thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("SERVER5432.test.employees"),
+                "the error must identify the offending record; got: " + thrown.getMessage());
+    }
+
+    // ---------------------------------------------------------------------
+    // Regression guards: existing, working deployments must be untouched.
+    // These pass both before and after the fix -- they pin that the new
+    // fallback is reachable ONLY from the branch that is currently corrupt.
+    // ---------------------------------------------------------------------
+
+    @Test
+    @DisplayName("a GTID source keeps its existing version, snowflake mode")
+    public void gtidSnowflakeVersionUnchanged() {
+        ClickHouseStruct record = mysqlRecordWithoutGtid(300023L);
+        record.setGtid(2179558590L);
+
+        record.calculateVersion(true);
+
+        assertEquals(SnowFlakeId.generate(SOURCE_TS_MS, 2179558590L, false), record.getVersion(),
+                "a GTID source must still take the GTID branch");
+    }
+
+    @Test
+    @DisplayName("a GTID source keeps its existing version, plain mode")
+    public void gtidPlainVersionUnchanged() {
+        ClickHouseStruct record = mysqlRecordWithoutGtid(300023L);
+        record.setGtid(2179558590L);
+
+        record.calculateVersion(false);
+
+        assertEquals(2179558590L, record.getVersion(),
+                "with snowflake.id disabled the raw GTID must still be used verbatim");
+    }
+
+    @Test
+    @DisplayName("the lightweight sequence-number path is bit-for-bit unchanged")
+    public void sequenceNumberVersionUnchanged() {
+        long sequenceNumber = SOURCE_TS_MS * 1_000_000L + 7L;
+        ClickHouseStruct record = mysqlRecordWithoutGtid(300023L);
+        record.setSequenceNumber(sequenceNumber);
+
+        record.calculateVersion(true);
+
+        assertEquals(sequenceNumber, record.getVersion(),
+                "the lightweight connector always sets a sequence number; its 2.8.0-compatible "
+                        + "version domain must not move");
+    }
+
+    @Test
+    @DisplayName("a Postgres LSN source is unchanged")
+    public void lsnVersionUnchanged() {
+        ClickHouseStruct record = mysqlRecordWithoutGtid(300023L);
+        record.setLsn(987654321L);
+
+        record.calculateVersion(true);
+
+        assertEquals(987654321L, record.getVersion(),
+                "an LSN source must still take the LSN branch");
+    }
+}


### PR DESCRIPTION
Fixes #1213.

## Root cause

`ClickHouseStruct.calculateVersion` has three branches and no `else`:

```java
if (this.gtid != UNINITIALIZED_VALUE) { ... }
else if (this.sequenceNumber != UNINITIALIZED_VALUE) { this.version = this.sequenceNumber; }
else if (this.lsn != UNINITIALIZED_VALUE) { this.version = this.lsn; }
```

When all three are absent, `version` stays at `UNINITIALIZED_VALUE = -1L` and is bound with `ps.setLong(...)` into a `UInt64` column — stored as **18446744073709551615**, exactly the value in the report.

That is worse than an error. `_version` drives ReplacingMergeTree deduplication, so a row carrying max-UInt64 wins every future dedup permanently: silent, unrecoverable corruption.

Why the source needs no GTID to trigger it: `setGtid` only fires when `source.gtid` splits into exactly two colon-separated segments. The lightweight path always calls `setSequenceNumber`, which masks the fall-through; the Kafka Connect path never does — `grep -rn "setSequenceNumber" sink-connector/src/main/java` returns nothing, the only callers are in the lightweight module.

## Fix

`calculateVersion` gains one final branch using the fallback the configuration already intends: `SnowFlakeId.generate(ts_ms, kafkaOffset, false)`.

This makes the *existing* mechanism work rather than inventing a scheme. `snowflake.id` already defaults to true and is documented as "SnowFlake ID(Timestamp + GTID)" — the formula was already the intended version source, it simply had no input when GTID was absent. Both substituted inputs are populated on precisely the broken path: `ts_ms` from `source.ts_ms`, offset from `record.kafkaOffset()`. Both are monotonic, so versions order by commit time then offset — the same shape the GTID form produces.

Both bind sites additionally call a new `rejectUnderivableVersion()` that throws `IllegalStateException` naming the topic, offset and the max-UInt64 value. Post-fix that is only reachable when even `ts_ms` is absent, i.e. a malformed event. Nothing is muted.

## Not changing existing behaviour

The new branch is last, reachable only where the old code fell through and produced corruption. Four regression guards in the test pass **both** before and after — GTID/snowflake, GTID/plain, sequence-number, and LSN — so the lightweight sequence-number domain and the PostgreSQL LSN domain are untouched. No deployment that works today changes value.

## Verification

Before the fix:

```
bindMustNotWriteUint64Max:165 the bind wrote the -1 sentinel, stored as UInt64
18446744073709551615 -- exactly the value reported in issue #1213
  ==> expected: not equal but was: <18446744073709551615>
calculateVersionMustNotFallThroughToSentinel:149 ==> expected: not equal but was: <-1>
fallbackUsesSnowflakeIdWithKafkaOffset:182 ==> expected: <2006515713438946295> but was: <-1>
unresolvableVersionThrowsInsteadOfBinding:211 Expected java.lang.IllegalStateException
  to be thrown, but nothing was thrown.
```

After: 9/9 pass. The test uses a recording JDBC proxy so it observes the value actually bound, not merely that the driver was reached. Module suite 226 to 235; docker-dependent error set compared by sorted name, identical.

## Follow-up

Container-backed e2e coverage for this one is still outstanding and is worth adding separately. It cannot use the lightweight IT harness: `DebeziumChangeEventCapture` unconditionally calls `setSequenceNumber` on every record, so `calculateVersion` always takes the sequence-number branch there and never reaches the sentinel regardless of GTID — a GTID-disabled MySQL container would produce a green test proving nothing. The defect is reachable only from the Kafka Connect sink path, which needs its own harness.
