### PR TITLE
db_compare: MySQL/ClickHouse checksum column-set asymmetry (approach under revision)

### DIFF
--- a/release-notes/2.10.1.md
+++ b/release-notes/2.10.1.md
@@ -1,0 +1,6 @@
+## What's Changed
+* fix: history mode loses ~95% of rows when a CREATE is replayed by @minguyen9988 in https://github.com/Altinity/clickhouse-sink-connector/pull/1410
+* fix: history-mode DELETE lost -- _operation dropped from INSERT, and the delete races its own batch by @minguyen9988 in https://github.com/Altinity/clickhouse-sink-connector/pull/1411
+
+
+**Full Changelog**: https://github.com/Altinity/clickhouse-sink-connector/compare/2.10.0...2.10.1

--- a/release-notes/2.10.2.md
+++ b/release-notes/2.10.2.md
@@ -1,0 +1,12 @@
+## What's Changed
+* fix: /metrics served with no Content-Type, breaking Prometheus 3.x scrapes by @minguyen9988 in https://github.com/Altinity/clickhouse-sink-connector/pull/1413
+* fix: INT8 (Byte) hard-cast to Integer fails every TINYINT batch by @minguyen9988 in https://github.com/Altinity/clickhouse-sink-connector/pull/1414
+* fix: ARRAY binding hard-casts to ArrayList, breaking every other List type by @minguyen9988 in https://github.com/Altinity/clickhouse-sink-connector/pull/1415
+* fix: initial snapshot never finishes -- NPE on every unparseable record by @minguyen9988 in https://github.com/Altinity/clickhouse-sink-connector/pull/1416
+* fix: MySQL DOUBLE auto-created as Float32, silently truncating precision by @minguyen9988 in https://github.com/Altinity/clickhouse-sink-connector/pull/1417
+* fix: support PostgreSQL infinity values in timestamptz by @minguyen9988 in https://github.com/Altinity/clickhouse-sink-connector/pull/1418
+* fix: batch containing a missing ClickHouse table is silently dropped and the offset advances by @minguyen9988 in https://github.com/Altinity/clickhouse-sink-connector/pull/1419
+* fix: _version stores UInt64 max when the source has no GTID, permanently winning RMT dedup by @minguyen9988 in https://github.com/Altinity/clickhouse-sink-connector/pull/1420
+* Added release notes for 2.10.1 release by @subkanthi in https://github.com/Altinity/clickhouse-sink-connector/pull/1412
+
+**Full Changelog**: https://github.com/Altinity/clickhouse-sink-connector/compare/2.10.1...2.10.2

--- a/release-notes/2.10.3.md
+++ b/release-notes/2.10.3.md
@@ -1,0 +1,5 @@
+## What's Changed
+* urgent fix: a keyless source table must not prevent the connector from starting by @minguyen9988 in https://github.com/Altinity/clickhouse-sink-connector/pull/1426
+
+
+**Full Changelog**: https://github.com/Altinity/clickhouse-sink-connector/compare/2.10.2...2.10.3

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
@@ -509,10 +509,11 @@ public class DebeziumChangeEventCapture {
         }
         // A source table with no PRIMARY KEY and no non-null UNIQUE key has no
         // row identity in the binlog, so nothing downstream can keep its
-        // ClickHouse copy correct. Enable MySQL's generated invisible primary
-        // key so tables created from now on get one, and refuse to start on a
-        // source that already holds such a table rather than replicating it
-        // wrongly.
+        // ClickHouse copy correct. Name every such table here, with the ALTER
+        // that fixes it, and carry on replicating: whether to accept that
+        // divergence until a key is added is the operator's call, and refusing
+        // would take every correctly-keyed table on the same source down with
+        // it. This call never throws.
         KeylessTablePreflight.check(props);
 
         ClickHouseSinkConnectorConfig config = new ClickHouseSinkConnectorConfig(PropertiesHelper.toMap(props));

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/DebeziumChangeEventCapture.java
@@ -1259,15 +1259,24 @@ public class DebeziumChangeEventCapture {
                 }
             } else {
                 chStruct = debeziumRecordParserService.parse(record, recordCommitter, lastRecordInBatch);
-                chStruct.setSequenceNumber(sequenceNumber);
                 try {
                     if (chStruct != null) {
+                        chStruct.setSequenceNumber(sequenceNumber);
                         ReplicationStatusSingleton rss = ReplicationStatusSingleton.getInstance();
                         rss.setReplicationLag(chStruct.getReplicationLag());
                         rss.setLastRecordTimestamp(chStruct.getTs_ms());
                         rss.setBinLogFile(chStruct.getFile());
                         rss.setBinLogPosition(String.valueOf(chStruct.getPos()));
                         rss.setGtid(String.valueOf(chStruct.getGtid()));
+                    } else {
+                        // parse() returns null for a record it cannot convert, such as
+                        // a null or non-Struct source value. Setting the sequence number
+                        // before this check raised an NPE that the catch-all below then
+                        // swallowed, so the record was dropped silently while the
+                        // snapshot loop logged the same stack trace per record (#1379).
+                        log.warn(String.format(
+                                "Record could not be parsed to a ClickHouseStruct - skipping. Record(%s)",
+                                record));
                     }
                 } catch (Exception e) {
                     log.error("Error retrieving status metrics: Exception" + e.toString());

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/KeylessTablePreflight.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/cdc/KeylessTablePreflight.java
@@ -13,8 +13,8 @@ import java.util.List;
 import java.util.Properties;
 
 /**
- * Refuses to start when the source holds a table whose rows cannot be
- * identified, reading the source and never writing to it.
+ * Reports, loudly, every source table whose rows cannot be identified --
+ * reading the source, never writing to it, and never blocking startup.
  *
  * <p>A table with no PRIMARY KEY and no non-null UNIQUE key has no row
  * identity in the logical schema. InnoDB does give such a table an internal
@@ -46,14 +46,25 @@ import java.util.Properties;
  *
  * <p>So this check, run once at startup:</p>
  * <ol>
- *   <li>lists the keyless tables that ALREADY exist and refuses to start,
- *       naming them and the single {@code ALTER TABLE} that fixes each one;</li>
- *   <li>refuses outright below MySQL 8.0.30, where GIPK does not exist and no
- *       correct replication of a keyless table is possible;</li>
+ *   <li>lists the keyless tables that ALREADY exist, naming each one and the
+ *       single {@code ALTER TABLE} that fixes it;</li>
+ *   <li>says so explicitly below MySQL 8.0.30, where GIPK does not exist, so
+ *       adding a key by hand is the only remedy available;</li>
  *   <li>reports whether {@code sql_generate_invisible_primary_key} is ON, so
  *       the operator knows whether a keyless table created tomorrow will get
  *       an identity -- and prints the statements to turn it on if not.</li>
  * </ol>
+ *
+ * <p><b>It never refuses to start.</b> Whether a keyless table is worth
+ * replicating imperfectly is the operator's call, not the connector's: the
+ * table may be a migration-bookkeeping row nobody reads, or a key may be
+ * scheduled for a maintenance window that has not arrived yet. Blocking
+ * startup would take the whole pipeline -- every correctly-keyed table on the
+ * same source -- down for one such table. So the connector replicates what it
+ * was asked to replicate and makes the consequence impossible to miss: the
+ * banner is emitted at ERROR at startup, at table creation, and periodically
+ * while replication runs. An operator who wants a keyless table left alone
+ * entirely can name it in {@code table.exclude.list}.</p>
  *
  * <p><b>It does not turn GIPK on itself.</b> The connector is a replication
  * CONSUMER and must not change the server it reads from. That is not a style
@@ -70,9 +81,10 @@ import java.util.Properties;
  * rejects a write, every statement passes {@link #assertReadOnlySql}, and a
  * test fails the build if a mutating keyword appears in this file.</p>
  *
- * <p>Refusing is the point. Replicating a keyless table silently produces a
+ * <p>Being unmissable is the point. Replicating a keyless table produces a
  * ClickHouse table that disagrees with its source, and a checksum job reports
- * it as a mismatch long after the data is wrong.</p>
+ * it as a mismatch long after the data is wrong -- so the operator has to be
+ * told which tables those are, by name, every time.</p>
  */
 public class KeylessTablePreflight {
 
@@ -100,33 +112,25 @@ public class KeylessTablePreflight {
     private KeylessTablePreflight() {
     }
 
-    /** A source the connector refuses to replicate, with the reason. */
-    public static class UnsupportedSourceException extends RuntimeException {
-        public UnsupportedSourceException(String message) {
-            super(message);
-        }
-    }
-
     /**
      * Runs the check against the configured MySQL source.
      *
-     * <p>Only MySQL is checked; other connectors pass through untouched. A
-     * connection or permission failure is logged and allowed through -- this
-     * check must never be the reason a healthy pipeline cannot start -- but a
-     * source that is genuinely unsafe throws.</p>
+     * <p>Only MySQL is checked; other connectors pass through untouched. This
+     * method NEVER throws and never prevents startup: a keyless table is
+     * reported, loudly and repeatedly, and replication proceeds. A connection
+     * or permission failure is likewise logged and allowed through.</p>
      *
      * @param props the connector properties.
-     * @throws UnsupportedSourceException when the source cannot be replicated correctly.
      */
     public static void check(Properties props) {
         if (Boolean.parseBoolean(props.getProperty(SKIP_PROPERTY, "false"))) {
-            // Loud on purpose: the override silences a correctness check, so it
-            // must not itself be quiet.
-            log.error("\n{}\n  !!  {}=true -- KEYLESS-TABLE CHECK DISABLED  !!\n{}\n"
+            // Loud on purpose: the override silences a correctness warning, so
+            // it must not itself be quiet.
+            log.warn("\n{}\n  !!  {}=true -- KEYLESS-TABLE CHECK DISABLED  !!\n{}\n"
                             + "  A source table with no PRIMARY KEY and no non-null UNIQUE key has NO\n"
                             + "  ROW IDENTITY IN THE BINLOG. Any such table WILL silently diverge from\n"
                             + "  MySQL: rows collapse, and UPDATE/DELETE cannot be matched to one row.\n"
-                            + "  This override accepts that risk. Remove it once every table has a key.\n{}",
+                            + "  With this set you will not even be told which tables those are.\n{}",
                     BANNER_RULE, SKIP_PROPERTY, BANNER_RULE, BANNER_RULE);
             return;
         }
@@ -166,11 +170,13 @@ public class KeylessTablePreflight {
                             version, GIPK_MAJOR, GIPK_MINOR, GIPK_PATCH);
                     return;
                 }
-                throw new UnsupportedSourceException(refusalTooOld(version, keyless));
+                log.error(warningTooOld(version, keyless));
+                return;
             }
 
             if (!keyless.isEmpty()) {
-                throw new UnsupportedSourceException(refusalPreExisting(keyless));
+                log.error(warningPreExisting(keyless));
+                return;
             }
             if (gipkEnabledGlobally(conn)) {
                 log.info("Keyless-table check passed: no table without a PRIMARY KEY or UNIQUE key, and "
@@ -180,15 +186,14 @@ public class KeylessTablePreflight {
                 log.warn("Keyless-table check passed: every table currently has a row identity. But "
                         + "sql_generate_invisible_primary_key is OFF on this server, so a table created "
                         + "from now on WITHOUT a PRIMARY KEY will have no row identity in the binlog and "
-                        + "will be refused at the next restart. To have MySQL supply one automatically:\n"
+                        + "will be reported as keyless at the next restart. To have MySQL supply one "
+                        + "automatically:\n"
                         + "    SET GLOBAL sql_generate_invisible_primary_key = ON;\n"
                         + "    # and in my.cnf so it survives a restart:\n"
                         + "    sql_generate_invisible_primary_key = ON\n"
                         + "Note this makes MySQL REJECT keyless CREATE TABLE ... PARTITION BY, so it is "
                         + "the server owner's call -- the connector does not set it.");
             }
-        } catch (UnsupportedSourceException e) {
-            throw e;
         } catch (Exception e) {
             // Never block a healthy pipeline on this check itself.
             log.warn("Keyless-table check could not run ({}). Continuing. If the source holds a table "
@@ -377,7 +382,7 @@ public class KeylessTablePreflight {
         }
         // MariaDB reports MySQL-like versions but has no GIPK. It is not a
         // supported source for a keyless table either way; treat it as old so
-        // the refusal names the real reason.
+        // the report names the real reason.
         if (version.toLowerCase().contains("mariadb")) {
             return false;
         }
@@ -454,7 +459,7 @@ public class KeylessTablePreflight {
      * such as {@code app.*} names no schema literally. Turning it into
      * {@code IN ('app.*')} would match nothing and the check would report a
      * clean source while the replicated schemas go uninspected -- a false PASS,
-     * the one outcome worse than a false refusal. So any entry that is not a
+     * the one outcome worse than a false report. So any entry that is not a
      * plain literal makes this return null, which widens the scan to ALL
      * non-system schemas. Over-scanning can only surface a table that is
      * genuinely keyless; it can never hide one.</p>
@@ -463,11 +468,9 @@ public class KeylessTablePreflight {
      * Drops tables the connector is not actually replicating.
      *
      * <p>A table that is excluded is never read from the binlog, so it cannot
-     * be replicated incorrectly and must not block startup. Without this, an
-     * operator who had already excluded a keyless table still could not start:
-     * the only ways past were adding a key to a table they did not own, or
-     * disabling the whole check and losing the protection for every other
-     * table.</p>
+     * be replicated incorrectly and there is nothing to report. Reporting it
+     * anyway would train operators to ignore the banner, which is the one way
+     * a loud warning stops working.</p>
      *
      * <p>Both Debezium list properties are honoured, with its own semantics:
      * entries are REGULAR EXPRESSIONS matched against the fully-qualified
@@ -475,7 +478,7 @@ public class KeylessTablePreflight {
      * anything NOT listed is excluded. The scan is deliberately conservative in
      * the same direction as {@code databaseFilter}: if a pattern cannot be
      * compiled it is ignored rather than treated as a match, so a malformed
-     * exclude can only leave a keyless table reported (a false refusal), never
+     * exclude can only leave a keyless table reported (a false report), never
      * silently drop one from the check (a false pass).</p>
      *
      * @param keyless fully-qualified {@code db.table} names found keyless.
@@ -492,12 +495,12 @@ public class KeylessTablePreflight {
         for (String table : keyless) {
             if (matchesAny(excludes, table)) {
                 log.info("Keyless table {} is excluded by table.exclude.list, so it is not "
-                        + "replicated and does not block startup.", table);
+                        + "replicated and is not reported.", table);
                 continue;
             }
             if (!includes.isEmpty() && !matchesAny(includes, table)) {
                 log.info("Keyless table {} is outside table.include.list, so it is not "
-                        + "replicated and does not block startup.", table);
+                        + "replicated and is not reported.", table);
                 continue;
             }
             inScope.add(table);
@@ -510,7 +513,7 @@ public class KeylessTablePreflight {
      * compile.
      *
      * <p>An uncompilable pattern is dropped rather than propagated, because
-     * this list can only ever REMOVE tables from the refusal set: treating a
+     * this list can only ever REMOVE tables from the reported set: treating a
      * broken pattern as matching would silently exclude a genuinely keyless
      * table from the check.</p>
      */
@@ -586,19 +589,24 @@ public class KeylessTablePreflight {
         }
     }
 
-    static String refusalTooOld(String version, List<String> keyless) {
+    static String warningTooOld(String version, List<String> keyless) {
         return KeylessTableWarning.banner(keyless, false)
-                + "\nREFUSING TO REPLICATE. MySQL " + version + " is older than "
-                + GIPK_MAJOR + "." + GIPK_MINOR + "." + GIPK_PATCH + ", where the generated invisible "
-                + "primary key was introduced, so MySQL cannot supply an identity for these tables "
-                + "either. Add a primary key to each, or upgrade to MySQL "
-                + GIPK_MAJOR + "." + GIPK_MINOR + "." + GIPK_PATCH + "+.\n"
-                + "Set " + SKIP_PROPERTY + "=true to override, accepting that those tables may diverge.";
+                + "\nREPLICATING ANYWAY -- THESE TABLES WILL DIVERGE. MySQL " + version + " is older "
+                + "than " + GIPK_MAJOR + "." + GIPK_MINOR + "." + GIPK_PATCH + ", where the generated "
+                + "invisible primary key was introduced, so MySQL cannot supply an identity for these "
+                + "tables either. Until a primary key is added to each -- or the server is upgraded to "
+                + "MySQL " + GIPK_MAJOR + "." + GIPK_MINOR + "." + GIPK_PATCH + "+ and each table "
+                + "altered -- their ClickHouse copies are NOT trustworthy: rows collapse and "
+                + "UPDATE/DELETE cannot be matched to one row.\n"
+                + "Set " + SKIP_PROPERTY + "=true to stop reporting them (the divergence remains).";
     }
 
-    static String refusalPreExisting(List<String> keyless) {
+    static String warningPreExisting(List<String> keyless) {
         return KeylessTableWarning.banner(keyless, true)
-                + "\nREFUSING TO REPLICATE until each table above has a primary key.\n"
-                + "Set " + SKIP_PROPERTY + "=true to override, accepting that those tables may diverge.";
+                + "\nREPLICATING ANYWAY -- THESE TABLES WILL DIVERGE until each one above has a "
+                + "primary key. Their ClickHouse copies are NOT trustworthy in the meantime: rows "
+                + "MySQL considers distinct collapse into one, and an UPDATE or DELETE cannot be "
+                + "matched to a single row. Every other table on this source is unaffected.\n"
+                + "Set " + SKIP_PROPERTY + "=true to stop reporting them (the divergence remains).";
     }
 }

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
@@ -359,9 +359,9 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
         // reaches this branch at all -- it arrives here as an ordinary keyed
         // table and my_row_id becomes its sorting key. Verified on 8.0.36.
         //
-        // KeylessTablePreflight enables that setting at startup and REFUSES to
-        // replicate a source that still holds a genuinely keyless table, so
-        // this branch is reached only when that check was explicitly skipped.
+        // KeylessTablePreflight reports any genuinely keyless table at startup
+        // -- by name, with the ALTER that fixes it -- but does not block, so
+        // this branch is reached whenever such a table is replicated anyway.
         //
         // Deriving an identity downstream instead was tried and does not work.
         // Both attempts are recorded here because both look reasonable:

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/PostgresInfinityTimestampIT.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/PostgresInfinityTimestampIT.java
@@ -1,0 +1,192 @@
+package com.altinity.clickhouse.debezium.embedded;
+
+import com.altinity.clickhouse.debezium.embedded.cdc.DebeziumChangeEventCapture;
+import com.altinity.clickhouse.debezium.embedded.parser.SourceRecordParserService;
+import com.altinity.clickhouse.sink.connector.db.BaseDbWriter;
+import com.altinity.clickhouse.sink.connector.db.HikariDbSource;
+import org.junit.Assert;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.Testcontainers;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.altinity.clickhouse.debezium.embedded.ITCommon.CLICKHOUSE_DOCKER_IMAGE;
+import static com.altinity.clickhouse.debezium.embedded.PostgresProperties.getDefaultProperties;
+
+/**
+ * End-to-end regression coverage for issue #1231: PostgreSQL {@code timestamptz}
+ * columns holding the special values {@code infinity} and {@code -infinity}
+ * replicated as empty timestamps.
+ *
+ * <p>PostgreSQL accepts {@code infinity} and {@code -infinity} in any
+ * {@code timestamp}/{@code timestamptz} column. Debezium delivers them verbatim
+ * as those literal strings, which match none of the timestamp patterns in
+ * {@code DebeziumConverter.ZonedTimestampConverter.convert}, so {@code result}
+ * was returned as the empty string it was initialised to. ClickHouse then
+ * stored the epoch (or rejected the row) instead of a value ordered correctly
+ * against the rest of the column.
+ *
+ * <p>ClickHouse DateTime64 cannot represent an actual infinity, so the fix
+ * saturates to the bounds of the target type -- the same clamping already
+ * applied to out-of-range timestamps -- which preserves the PostgreSQL ordering
+ * semantics that infinity sorts after, and -infinity before, every other
+ * timestamp.
+ *
+ * <p>This test drives the real Debezium pipeline against a live PostgreSQL
+ * source and asserts on the values read back from a live ClickHouse server,
+ * because the defect is in what the destination ends up holding. It follows the
+ * pgoutput harness of
+ * {@link ClickHouseDebeziumEmbeddedPostgresPgoutputDockerIT}: pgoutput is built
+ * into stock PostgreSQL, so no output-plugin image is required.
+ */
+public class PostgresInfinityTimestampIT {
+
+    /** DateTime64 upper bound, the saturation target for {@code infinity}. */
+    private static final String SATURATED_MAX = "2299-12-31 23:59:59";
+
+    /** DateTime64 lower bound, the saturation target for {@code -infinity}. */
+    private static final String SATURATED_MIN = "1900-01-01 00:00:00";
+
+    /** A finite timestamp, to prove ordinary values still replicate correctly. */
+    private static final String FINITE = "2024-07-24 12:34:56";
+
+    @Container
+    public static ClickHouseContainer clickHouseContainer = new ClickHouseContainer(DockerImageName.parse(CLICKHOUSE_DOCKER_IMAGE)
+            .asCompatibleSubstituteFor("clickhouse"))
+            .withInitScript("init_clickhouse_it.sql")
+            .withUsername("ch_user")
+            .withPassword("password")
+            .withExposedPorts(8123);
+
+    @Container
+    public static PostgreSQLContainer postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
+            .withInitScript("init_postgres.sql")
+            .withDatabaseName("public")
+            .withUsername("root")
+            .withPassword("root")
+            .withExposedPorts(5432)
+            .withCommand("postgres -c wal_level=logical")
+            .withNetworkAliases("postgres").withAccessToHost(true);
+
+    public Properties getProperties() throws Exception {
+        Properties properties = getDefaultProperties(postgreSQLContainer, clickHouseContainer);
+        properties.put("plugin.name", "pgoutput");
+        properties.put("plugin.path", "/");
+        properties.put("topic.prefix", "test-server");
+        properties.put("slot.max.retries", "6");
+        properties.put("slot.retry.delay.ms", "5000");
+        properties.put("database.allowPublicKeyRetrieval", "true");
+        properties.put("table.include.list", "public.infinity_ts");
+        properties.put("auto.create.tables", "true");
+        return properties;
+    }
+
+    @Test
+    @DisplayName("Integration Test - Validates that PostgreSQL infinity timestamptz values saturate to the DateTime64 bounds")
+    public void testInfinityTimestamptzSaturates() throws Exception {
+        Network network = Network.newNetwork();
+
+        postgreSQLContainer.withNetwork(network).start();
+        clickHouseContainer.withNetwork(network).start();
+        Thread.sleep(10000);
+
+        // The rows are seeded BEFORE the connector starts so they arrive through
+        // the initial snapshot, which is the path the reporter hit.
+        Connection pgConn = ITCommon.connectToPostgreSQL(postgreSQLContainer);
+        pgConn.prepareStatement("CREATE TABLE public.infinity_ts ("
+                + "id int PRIMARY KEY, label text, ts timestamptz NOT NULL)").execute();
+        pgConn.prepareStatement("INSERT INTO public.infinity_ts VALUES "
+                + "(1, 'positive', 'infinity'), "
+                + "(2, 'negative', '-infinity'), "
+                + "(3, 'finite', '" + FINITE + "+00')").execute();
+
+        Testcontainers.exposeHostPorts(postgreSQLContainer.getFirstMappedPort());
+        AtomicReference<DebeziumChangeEventCapture> engine = new AtomicReference<>();
+
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+        executorService.execute(() -> {
+            try {
+                engine.set(new DebeziumChangeEventCapture());
+                engine.get().setup(getProperties(), new SourceRecordParserService(), false);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        Thread.sleep(50000);
+
+        BaseDbWriter writer = ITCommon.getDBWriter(clickHouseContainer, "public");
+
+        String positive = selectTimestamp(writer.getConnection(), 1);
+        String negative = selectTimestamp(writer.getConnection(), 2);
+        String finite = selectTimestamp(writer.getConnection(), 3);
+
+        // The reported symptom: the converter returned "" for these literals, so
+        // nothing meaningful reached the column.
+        Assert.assertNotNull("no row replicated for the 'infinity' timestamptz", positive);
+        Assert.assertFalse("the 'infinity' timestamptz replicated as an empty value; "
+                + "the converter matched none of its patterns and returned the empty "
+                + "string it was initialised to", positive.trim().isEmpty());
+
+        Assert.assertTrue("PostgreSQL 'infinity' must saturate to the DateTime64 upper bound "
+                        + SATURATED_MAX + " so it keeps sorting after every other timestamp; got: "
+                        + positive,
+                positive.startsWith(SATURATED_MAX));
+
+        Assert.assertNotNull("no row replicated for the '-infinity' timestamptz", negative);
+        Assert.assertFalse("the '-infinity' timestamptz replicated as an empty value",
+                negative.trim().isEmpty());
+        Assert.assertTrue("PostgreSQL '-infinity' must saturate to the DateTime64 lower bound "
+                        + SATURATED_MIN + " so it keeps sorting before every other timestamp; got: "
+                        + negative,
+                negative.startsWith(SATURATED_MIN));
+
+        // 1970-01-01 is what an empty/unparsed value collapses to. Naming it
+        // explicitly keeps the failure message honest about the old behaviour.
+        Assert.assertFalse("'infinity' must not collapse to the epoch; got: " + positive,
+                positive.startsWith("1970-01-01"));
+        Assert.assertFalse("'-infinity' must not collapse to the epoch; got: " + negative,
+                negative.startsWith("1970-01-01"));
+
+        // Ordinary timestamps must be untouched by the saturation branch.
+        Assert.assertNotNull("no row replicated for the finite timestamptz", finite);
+        Assert.assertTrue("a finite timestamptz must replicate unchanged; got: " + finite,
+                finite.startsWith(FINITE));
+
+        // The whole point of saturating rather than nulling: ordering survives.
+        Assert.assertTrue("the saturated bounds must bracket the finite value, otherwise "
+                        + "ORDER BY on the column no longer matches PostgreSQL",
+                negative.compareTo(finite) < 0 && finite.compareTo(positive) < 0);
+
+        if (engine.get() != null) {
+            engine.get().stop();
+        }
+        pgConn.close();
+        executorService.shutdown();
+
+        HikariDbSource.close();
+    }
+
+    /** Reads one replicated timestamp back from ClickHouse as a string. */
+    private static String selectTimestamp(Connection chConn, int id) throws Exception {
+        String value = null;
+        ResultSet rs = ITCommon.executeQueryWithResultSet(
+                "select toString(ts) as ts from public.infinity_ts final where id = " + id,
+                chConn);
+        while (rs.next()) {
+            value = rs.getString("ts");
+        }
+        return value;
+    }
+}

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/AutoCreateDoubleColumnPrecisionIT.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/AutoCreateDoubleColumnPrecisionIT.java
@@ -1,0 +1,230 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import com.altinity.clickhouse.debezium.embedded.AppInjector;
+import com.altinity.clickhouse.debezium.embedded.ClickHouseDebeziumEmbeddedApplication;
+import com.altinity.clickhouse.debezium.embedded.ITCommon;
+import com.altinity.clickhouse.debezium.embedded.parser.DebeziumRecordParserService;
+import com.altinity.clickhouse.sink.connector.db.BaseDbWriter;
+import com.altinity.clickhouse.sink.connector.db.HikariDbSource;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.log4j.BasicConfigurator;
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.altinity.clickhouse.debezium.embedded.ITCommon.CLICKHOUSE_DOCKER_IMAGE;
+import static com.altinity.clickhouse.debezium.embedded.ITCommon.MYSQL_DOCKER_IMAGE;
+import static com.altinity.clickhouse.debezium.embedded.ITCommon.getDebeziumProperties;
+
+/**
+ * End-to-end regression coverage for issue #1262: a MySQL DOUBLE column was
+ * auto-created in ClickHouse as Float32, silently truncating every replicated
+ * value from ~15 significant decimal digits to ~7.
+ *
+ * <p>{@code ClickHouseDataTypeMapper.dataTypesMap} mapped BOTH FLOAT32 and
+ * FLOAT64 to {@code ClickHouseDataType.Float32}. That map is what
+ * {@code ClickHouseTableOperationsBase.getColumnNameToCHDataTypeMapping} uses to
+ * pick the column type in the CREATE TABLE statement emitted by
+ * {@code ClickHouseAutoCreateTable.createNewTable}, so the destination column
+ * was born too narrow. No error was logged and the row counts still matched, so
+ * count-based checksum jobs reported the table clean.
+ *
+ * <p>This test deliberately reads the column type back from the LIVE ClickHouse
+ * server via {@code system.columns} and compares the replicated value against
+ * the value MySQL holds. The existing auto-create suite missed the defect
+ * because {@code ClickHouseAutoCreateTableBase.getExpectedColumnToDataTypesMap}
+ * hand-builds its expected map with the CORRECT Float64 entries instead of
+ * deriving it from the mapper, so the wrong lookup was never exercised. An
+ * assertion against a hand-built map cannot catch a defect in the map itself;
+ * only the server can be trusted to say what was actually created.
+ */
+@Testcontainers
+@DisplayName("Test that a MySQL DOUBLE is auto-created as ClickHouse Float64 and round-trips without precision loss")
+public class AutoCreateDoubleColumnPrecisionIT {
+
+    /**
+     * A MySQL DOUBLE carries ~15-17 significant decimal digits; Float32 keeps
+     * ~7. This value differs from its own float round-trip, so it can only
+     * survive replication if the destination column is genuinely 64-bit.
+     */
+    private static final double PRECISE_VALUE = 0.1234567890123456d;
+
+    /**
+     * The largest finite DOUBLE. A Float32 column cannot hold it at all -- it
+     * overflows to infinity -- so this catches a narrow column even when the
+     * comparison tolerance is generous.
+     */
+    private static final double MAX_VALUE = 1.7976931348623157E308d;
+
+    protected MySQLContainer mySqlContainer;
+
+    @Container
+    public static ClickHouseContainer clickHouseContainer = new ClickHouseContainer(DockerImageName.parse(CLICKHOUSE_DOCKER_IMAGE)
+            .asCompatibleSubstituteFor("clickhouse"))
+            .withInitScript("init_clickhouse_it.sql")
+            .withUsername("ch_user")
+            .withPassword("password")
+            .withExposedPorts(8123);
+
+    @BeforeEach
+    public void startContainers() throws InterruptedException {
+        mySqlContainer = new MySQLContainer<>(DockerImageName.parse(MYSQL_DOCKER_IMAGE)
+                .asCompatibleSubstituteFor("mysql"))
+                .withDatabaseName("employees").withUsername("root").withPassword("adminpass")
+                .withExtraHost("mysql-server", "0.0.0.0")
+                .waitingFor(new HttpWaitStrategy().forPort(3306));
+
+        BasicConfigurator.configure();
+        mySqlContainer.start();
+        clickHouseContainer.start();
+        Thread.sleep(35000);
+    }
+
+    @AfterEach
+    public void stopContainers() {
+        if (mySqlContainer != null && mySqlContainer.isRunning()) {
+            mySqlContainer.stop();
+        }
+        if (clickHouseContainer != null && clickHouseContainer.isRunning()) {
+            clickHouseContainer.stop();
+        }
+    }
+
+    @DisplayName("Test that a MySQL DOUBLE is auto-created as ClickHouse Float64 and round-trips without precision loss")
+    @Test
+    public void testDoubleColumnIsAutoCreatedAsFloat64() throws Exception {
+
+        Injector injector = Guice.createInjector(new AppInjector());
+
+        Properties props = getDebeziumProperties(mySqlContainer, clickHouseContainer);
+        props.setProperty("snapshot.mode", "no_data");
+        props.setProperty("schema.history.internal.store.only.captured.tables.ddl", "true");
+        props.setProperty("schema.history.internal.store.only.captured.databases.ddl", "true");
+        props.setProperty("auto.create.tables", "true");
+        // DDL replication is switched OFF on purpose. With it on, the CREATE
+        // TABLE is translated from the MySQL DDL by the DDL parser, which has
+        // its own type table and never consults ClickHouseDataTypeMapper -- the
+        // defect would be invisible. Turning it off routes table creation
+        // through DbWriter.autoCreateTable -> ClickHouseAutoCreateTable
+        // .createNewTable -> getColumnNameToCHDataTypeMapping, which is the
+        // consumer of the broken map and the path issue #1262 reports.
+        props.setProperty("disable.ddl", "true");
+
+        ClickHouseDebeziumEmbeddedApplication clickHouseDebeziumEmbeddedApplication =
+                new ClickHouseDebeziumEmbeddedApplication();
+
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+        executorService.execute(() -> {
+            try {
+                clickHouseDebeziumEmbeddedApplication.start(
+                        injector.getInstance(DebeziumRecordParserService.class), props, false);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        Thread.sleep(25000);
+
+        Connection conn = ITCommon.connectToMySQL(mySqlContainer);
+        conn.prepareStatement("create table `double_precision`(col1 varchar(255) not null, "
+                + "amount_double double, amount_float float, primary key(col1))").execute();
+
+        conn.prepareStatement("insert into double_precision values('precise', "
+                + PRECISE_VALUE + ", 1.5)").execute();
+        conn.prepareStatement("insert into double_precision values('max', "
+                + MAX_VALUE + ", 2.5)").execute();
+
+        Thread.sleep(20000);
+
+        BaseDbWriter writer = ITCommon.getDBWriter(clickHouseContainer);
+
+        // Ask the live server what it actually created. A hand-built expected
+        // map would have agreed with itself and missed the defect entirely.
+        String actualDoubleType = null;
+        String actualFloatType = null;
+        ResultSet columnsRs = ITCommon.executeQueryWithResultSet(
+                "select name, type from system.columns where database = 'employees' "
+                        + "and table = 'double_precision'", writer.getConnection());
+        while (columnsRs.next()) {
+            String name = columnsRs.getString("name");
+            if ("amount_double".equals(name)) {
+                actualDoubleType = columnsRs.getString("type");
+            } else if ("amount_float".equals(name)) {
+                actualFloatType = columnsRs.getString("type");
+            }
+        }
+
+        Assert.assertNotNull("the table was never auto-created in ClickHouse", actualDoubleType);
+
+        // Nullable(Float64) is expected; the assertion is on the underlying
+        // type so a change to column nullability does not break the test.
+        Assert.assertTrue("MySQL DOUBLE must be auto-created as a 64-bit ClickHouse column, "
+                        + "otherwise every replicated value is truncated from ~15 significant "
+                        + "decimal digits to ~7 with no error logged. Server reported: "
+                        + actualDoubleType,
+                actualDoubleType.contains("Float64"));
+        Assert.assertFalse("MySQL DOUBLE must not be auto-created as Float32. Server reported: "
+                        + actualDoubleType,
+                actualDoubleType.contains("Float32"));
+
+        // The MySQL FLOAT column is present as a control: Debezium's MySQL
+        // connector emits FLOAT as a FLOAT64 Kafka Connect schema too (it widens
+        // single precision at the source), so this column is EXPECTED to be
+        // Float64 as well. It is asserted only to prove the auto-create actually
+        // ran over both columns. The FLOAT32 -> Float32 half of the mapping is a
+        // mapper-level property with no MySQL DDL that reaches it, so it is
+        // pinned by ClickHouseDataTypeMapperFloat64Test rather than here.
+        Assert.assertNotNull("the float column was never auto-created", actualFloatType);
+
+        // The type is only half the story -- prove the value itself survived.
+        // Compared with delta 0.0 because a Float64 column must reproduce the
+        // source DOUBLE bit-exactly, not merely approximately.
+        double replicatedPrecise = selectDouble(writer.getConnection(), "precise");
+        Assert.assertEquals("a high-precision MySQL DOUBLE must round-trip byte-exactly; "
+                        + "a Float32 destination column silently rounds it",
+                PRECISE_VALUE, replicatedPrecise, 0.0d);
+
+        double replicatedMax = selectDouble(writer.getConnection(), "max");
+        Assert.assertFalse("the largest finite MySQL DOUBLE must not overflow to infinity, "
+                        + "which is what a Float32 destination column does to it",
+                Double.isInfinite(replicatedMax));
+        Assert.assertEquals("the largest finite MySQL DOUBLE must round-trip byte-exactly",
+                MAX_VALUE, replicatedMax, 0.0d);
+
+        clickHouseDebeziumEmbeddedApplication.getDebeziumEventCapture().engine.close();
+
+        conn.close();
+        executorService.shutdown();
+
+        HikariDbSource.close();
+    }
+
+    /** Reads one replicated DOUBLE back from ClickHouse. */
+    private static double selectDouble(Connection chConn, String key) throws Exception {
+        double value = Double.NaN;
+        ResultSet rs = ITCommon.executeQueryWithResultSet(
+                "select amount_double from employees.double_precision final where col1 = '"
+                        + key + "'", chConn);
+        while (rs.next()) {
+            value = rs.getDouble("amount_double");
+        }
+        Assert.assertFalse("no row replicated to ClickHouse for key '" + key + "'",
+                Double.isNaN(value));
+        return value;
+    }
+}

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/KeylessTablePreflightTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/KeylessTablePreflightTest.java
@@ -12,13 +12,13 @@ import java.util.List;
 import java.util.Properties;
 
 /**
- * The version gate and the refusal messages.
+ * The version gate and the warning messages.
  *
  * <p>MySQL 8.0.30 is the boundary that matters: below it the generated
  * invisible primary key does not exist, so MySQL cannot supply an identity for
  * a keyless table and no correct replication of one is possible. The connector
- * refuses rather than producing a ClickHouse copy that silently disagrees with
- * its source.</p>
+ * replicates it anyway -- that is the operator's call -- but says so in terms
+ * nobody can miss, naming each table and the ALTER that fixes it.</p>
  */
 public class KeylessTablePreflightTest {
 
@@ -53,9 +53,9 @@ public class KeylessTablePreflightTest {
     }
 
     /**
-     * An unreadable version must not become a silent refusal. The
-     * pre-existing-table scan still runs, so a keyless table is still caught --
-     * with the accurate message rather than a wrong claim about the version.
+     * An unreadable version must not become a wrong claim about the version.
+     * The pre-existing-table scan still runs, so a keyless table is still
+     * reported -- with the accurate message.
      */
     @Test
     public void testUnparseableVersionDoesNotBlockOnVersionGrounds() {
@@ -64,11 +64,15 @@ public class KeylessTablePreflightTest {
     }
 
     /**
-     * The refusal has to be actionable: which tables, why, and the exact fix.
+     * The warning has to be actionable: which tables, why, and the exact fix.
+     *
+     * <p>It must also be unambiguous that replication CONTINUES. A message that
+     * merely describes the hazard, without saying the connector is proceeding,
+     * would leave an operator hunting for a startup failure that never happens.
      */
     @Test
-    public void testRefusalNamesTheTablesAndTheFix() {
-        String msg = KeylessTablePreflight.refusalPreExisting(
+    public void testWarningNamesTheTablesAndTheFix() {
+        String msg = KeylessTablePreflight.warningPreExisting(
                 Arrays.asList("app.events", "app.audit"));
 
         Assert.assertTrue("must name every offending table", msg.contains("app.events"));
@@ -81,17 +85,139 @@ public class KeylessTablePreflightTest {
                 msg.contains("NOT retroactive"));
         Assert.assertTrue("must state the override exists, so nobody has to guess",
                 msg.contains(KeylessTablePreflight.SKIP_PROPERTY));
+        Assert.assertTrue("must say replication continues, so nobody waits for a refusal "
+                        + "that never comes",
+                msg.toUpperCase().contains("REPLICATING ANYWAY"));
+        Assert.assertFalse("must not claim the connector is refusing",
+                msg.toUpperCase().contains("REFUSING TO REPLICATE"));
     }
 
     @Test
-    public void testTooOldRefusalExplainsTheVersion() {
-        String msg = KeylessTablePreflight.refusalTooOld("5.7.44", Arrays.asList("app.events"));
+    public void testTooOldWarningExplainsTheVersion() {
+        String msg = KeylessTablePreflight.warningTooOld("5.7.44", Arrays.asList("app.events"));
 
         Assert.assertTrue(msg.contains("5.7.44"));
         Assert.assertTrue("must state the version where GIPK arrives", msg.contains("8.0.30"));
         Assert.assertTrue(msg.contains("app.events"));
         Assert.assertTrue("must say how to turn GIPK on once upgraded",
                 msg.contains("sql_generate_invisible_primary_key"));
+        Assert.assertTrue("must say replication continues",
+                msg.toUpperCase().contains("REPLICATING ANYWAY"));
+        Assert.assertFalse("must not claim the connector is refusing",
+                msg.toUpperCase().contains("REFUSING TO REPLICATE"));
+    }
+
+    /**
+     * The contract this change exists to establish: whatever the check finds,
+     * it never prevents the connector from starting.
+     *
+     * <p>Guarded structurally rather than by wording, because the failure mode
+     * is a regression in behaviour, not in text: {@code check} declares no
+     * checked exception, so a future {@code throw} would compile silently and
+     * only surface as a dead pipeline. Every entry path is exercised -- the
+     * skip override, a non-MySQL source, an unreachable MySQL source, and a
+     * source that cannot be inspected -- and none may propagate.</p>
+     */
+    @Test
+    public void testCheckNeverThrowsWhateverTheSourceLooksLike() {
+        Properties skipped = new Properties();
+        skipped.setProperty(KeylessTablePreflight.SKIP_PROPERTY, "true");
+
+        Properties postgres = new Properties();
+        postgres.setProperty("connector.class",
+                "io.debezium.connector.postgresql.PostgresConnector");
+
+        Properties unreachable = new Properties();
+        unreachable.setProperty("connector.class", "io.debezium.connector.mysql.MySqlConnector");
+        unreachable.setProperty("database.hostname", "nonexistent.invalid");
+        unreachable.setProperty("database.port", "3306");
+        unreachable.setProperty("database.user", "u");
+        unreachable.setProperty("database.password", "p");
+
+        Properties incomplete = new Properties();
+        incomplete.setProperty("connector.class", "io.debezium.connector.mysql.MySqlConnector");
+
+        for (Properties props : Arrays.asList(skipped, postgres, unreachable, incomplete)) {
+            try {
+                KeylessTablePreflight.check(props);
+            } catch (Throwable t) {
+                Assert.fail("check() must never prevent startup, but threw " + t);
+            }
+        }
+    }
+
+    /**
+     * The blocking behaviour must be gone from the SOURCE, not merely
+     * unreachable in the paths a unit test can drive.
+     *
+     * <p>{@link #testCheckNeverThrowsWhateverTheSourceLooksLike} can only
+     * exercise the entry paths that need no live MySQL -- the skip override, a
+     * non-MySQL source, an unreachable host. The two sites that actually
+     * decided to refuse sit AFTER a successful connection and a completed
+     * table scan, so no unit test reaches them, and a reinstated {@code throw}
+     * there would pass every behavioural test in this class. Verified: with
+     * the refusal restored, only the structural check below failed.</p>
+     *
+     * <p>So the file is scanned directly, the same way
+     * {@link #testPreflightNeverSetsAGlobalOnTheSource} guards the read-only
+     * property: {@code check} must contain no {@code throw} at all, since the
+     * whole point of this class is that it reports and returns.</p>
+     */
+    @Test
+    public void testCheckContainsNoThrowStatement() throws Exception {
+        List<String> lines = Files.readAllLines(sourceFile());
+
+        int start = -1;
+        for (int i = 0; i < lines.size(); i++) {
+            if (lines.get(i).contains("public static void check(Properties props)")) {
+                start = i;
+                break;
+            }
+        }
+        Assert.assertTrue("cannot locate check() in the source -- this test must not pass "
+                + "vacuously", start >= 0);
+
+        // Walk to the end of the method by brace depth, starting from its
+        // opening brace, so the scan covers exactly check() and nothing after.
+        int depth = 0;
+        boolean entered = false;
+        for (int i = start; i < lines.size(); i++) {
+            String line = lines.get(i);
+            String code = line.trim();
+            Assert.assertFalse("check() must never prevent startup, but line " + (i + 1)
+                            + " throws: " + code,
+                    entered && code.startsWith("throw "));
+            for (char c : line.toCharArray()) {
+                if (c == '{') {
+                    depth++;
+                    entered = true;
+                } else if (c == '}') {
+                    depth--;
+                }
+            }
+            if (entered && depth == 0) {
+                return;
+            }
+        }
+        Assert.fail("never found the end of check() -- the brace walk did not terminate");
+    }
+
+    /**
+     * No refusal-era API may survive: a caller catching a now-deleted exception
+     * type, or a message builder still named {@code refusal*}, would mean the
+     * blocking behaviour is only half removed.
+     */
+    @Test
+    public void testNoRefusalApiRemains() {
+        for (Class<?> nested : KeylessTablePreflight.class.getDeclaredClasses()) {
+            Assert.assertFalse("the refusal exception type must be gone, found "
+                            + nested.getName(),
+                    Throwable.class.isAssignableFrom(nested));
+        }
+        for (java.lang.reflect.Method m : KeylessTablePreflight.class.getDeclaredMethods()) {
+            Assert.assertFalse("a refusal-era message builder remains: " + m.getName(),
+                    m.getName().startsWith("refusal"));
+        }
     }
 
     /**
@@ -111,11 +237,10 @@ public class KeylessTablePreflightTest {
 
     /**
      * An unreachable source must not stop a pipeline on the strength of a check
-     * that could not run. The refusal is for a source proven unsafe, not for
-     * one that could not be inspected.
+     * that could not run -- nor log a scary banner naming no table.
      */
     @Test
-    public void testUnreachableSourceDoesNotRefuse() {
+    public void testUnreachableSourceIsHandledQuietly() {
         Properties props = new Properties();
         props.setProperty("connector.class", "io.debezium.connector.mysql.MySqlConnector");
         props.setProperty("database.hostname", "nonexistent.invalid");
@@ -309,7 +434,7 @@ public class KeylessTablePreflightTest {
     /**
      * A malformed pattern must fail SAFE -- toward reporting, not hiding.
      *
-     * <p>This list can only remove tables from the refusal set, so treating an
+     * <p>This list can only remove tables from the reported set, so treating an
      * uncompilable pattern as matching would silently drop a genuinely keyless
      * table from the check. It is ignored instead, and the valid entry beside
      * it still applies.</p>
@@ -550,9 +675,10 @@ public class KeylessTablePreflightTest {
      *
      * <p>{@code sql/data_types.sql} deliberately declares keyless tables
      * ({@code ship_class}, {@code add_test}) that the DDL-parser suites
-     * exercise, so the preflight correctly refuses that source. Without the
-     * opt-out every MySQL IT in the module fails at startup -- 19 errors
-     * across 15 suites in the run that prompted this change.</p>
+     * exercise. The check no longer blocks startup, so the opt-out is no
+     * longer load-bearing for the ITs to pass; it is kept so those suites do
+     * not each emit a multi-line ERROR banner about a fixture whose
+     * keyless-ness is the point.</p>
      */
     @Test
     public void testItConfigOptsOutOfTheKeylessCheck() throws Exception {
@@ -572,7 +698,8 @@ public class KeylessTablePreflightTest {
         }
         Assert.assertTrue(
                 KeylessTablePreflight.SKIP_PROPERTY + " must be true in " + cfg + ": the shared "
-                        + "employees fixture declares keyless tables on purpose",
+                        + "employees fixture declares keyless tables on purpose, and the banner "
+                        + "would otherwise fire in every MySQL IT",
                 optedOut);
     }
 

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/NullParsedRecordSkipTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/NullParsedRecordSkipTest.java
@@ -1,0 +1,176 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import com.altinity.clickhouse.debezium.embedded.parser.DebeziumRecordParserService;
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import com.altinity.clickhouse.sink.connector.model.ClickHouseStruct;
+import io.debezium.engine.ChangeEvent;
+import io.debezium.engine.DebeziumEngine;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression test for issue #1379 ("Initial Snapshot never finishes").
+ * <p>
+ * {@link com.altinity.clickhouse.debezium.embedded.parser.SourceRecordParserService#parse}
+ * returns null for a record it cannot convert: a null source value, a value
+ * that is not a Struct, or a value the converter cannot map. Those null
+ * returns are contract, not failure.
+ * </p>
+ * <p>
+ * processEveryChangeRecord called setSequenceNumber on that return value
+ * before testing it for null, so every such record raised a
+ * NullPointerException. The NPE was then swallowed by the catch-all in the
+ * same method, so the record was dropped silently while the snapshot loop
+ * logged the same stack trace over and over -- the symptom reported in #1379.
+ * </p>
+ * <p>
+ * An unconvertible record must be skipped deliberately and visibly: no
+ * NullPointerException, and a warning that says the record was skipped.
+ * </p>
+ */
+public class NullParsedRecordSkipTest {
+
+    /** Collects everything the class under test logs during one call. */
+    private static final class CapturingAppender extends AbstractAppender {
+
+        private final List<LogEvent> events = Collections.synchronizedList(new ArrayList<>());
+
+        CapturingAppender() {
+            super("capture-1379", null, null, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            events.add(event.toImmutable());
+        }
+    }
+
+    /**
+     * Stands in for the real parser on the path that returns null, so the
+     * test exercises the caller rather than the converter.
+     */
+    private static final class NullReturningParser implements DebeziumRecordParserService {
+
+        @Override
+        public ClickHouseStruct parse(ChangeEvent<SourceRecord, SourceRecord> record,
+                                      DebeziumEngine.RecordCommitter<
+                                              ChangeEvent<SourceRecord, SourceRecord>> committer,
+                                      boolean lastRecordInBatch) {
+            return null;
+        }
+    }
+
+    /** A row-change event with no DDL field, so the row branch is taken. */
+    private static ChangeEvent<SourceRecord, SourceRecord> rowEvent() {
+        Schema schema = SchemaBuilder.struct()
+                .field("id", Schema.INT32_SCHEMA)
+                .build();
+        Struct value = new Struct(schema);
+        value.put("id", 1);
+        SourceRecord record = new SourceRecord(null, null, "topic", schema, value);
+        return new ChangeEvent<SourceRecord, SourceRecord>() {
+            @Override
+            public SourceRecord key() {
+                return null;
+            }
+
+            @Override
+            public SourceRecord value() {
+                return record;
+            }
+
+            @Override
+            public String destination() {
+                return "topic";
+            }
+
+            @Override
+            public Integer partition() {
+                return null;
+            }
+        };
+    }
+
+    /**
+     * processEveryChangeRecord is private and its only caller is the Debezium
+     * batch handler, which needs a live engine. The seam is therefore
+     * reflective; the argument list mirrors the call in handleBatch.
+     */
+    private static ClickHouseStruct invokeProcess(DebeziumChangeEventCapture capture,
+                                                  ChangeEvent<SourceRecord, SourceRecord> record,
+                                                  DebeziumRecordParserService parser)
+            throws Exception {
+        Method m = DebeziumChangeEventCapture.class.getDeclaredMethod(
+                "processEveryChangeRecord",
+                Properties.class,
+                ChangeEvent.class,
+                DebeziumRecordParserService.class,
+                ClickHouseSinkConnectorConfig.class,
+                DebeziumEngine.RecordCommitter.class,
+                boolean.class,
+                long.class);
+        m.setAccessible(true);
+        return (ClickHouseStruct) m.invoke(capture, new Properties(), record, parser,
+                null, null, true, 1000000001L);
+    }
+
+    @Test
+    @DisplayName("A record the parser cannot convert is skipped without a NullPointerException")
+    public void shouldSkipUnparseableRecordWithoutNPE() throws Exception {
+        Logger coreLogger = (Logger) LogManager.getLogger(DebeziumChangeEventCapture.class);
+        CapturingAppender appender = new CapturingAppender();
+        appender.start();
+        coreLogger.addAppender(appender);
+
+        ClickHouseStruct result;
+        try {
+            result = invokeProcess(new DebeziumChangeEventCapture(), rowEvent(),
+                    new NullReturningParser());
+        } finally {
+            coreLogger.removeAppender(appender);
+            appender.stop();
+        }
+
+        // Nothing was converted, so there is nothing to hand downstream.
+        assertNull("an unconvertible record must not produce a struct", result);
+
+        // Before the fix, setSequenceNumber ran on the null return value and
+        // the resulting NPE was swallowed by the catch-all one line below.
+        // The throwable is quoted back so a failure names the defect instead
+        // of merely asserting that one exists.
+        String npe = appender.events.stream()
+                .filter(e -> e.getThrown() instanceof NullPointerException)
+                .map(e -> String.valueOf(e.getThrown()))
+                .findFirst()
+                .orElse(null);
+        assertNull("an unconvertible record must not raise a NullPointerException; "
+                        + "issue #1379 logged one per record for the whole snapshot, got: " + npe,
+                npe);
+
+        // Dropping a record must be visible, not silent.
+        boolean skipWarned = appender.events.stream()
+                .anyMatch(e -> e.getLevel().isMoreSpecificThan(Level.WARN)
+                        && e.getMessage().getFormattedMessage().toLowerCase()
+                        .contains("skipping"));
+        assertTrue("skipping a record must be logged at WARN or above", skipWarned);
+    }
+}

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/UnparseableRecordProgressIT.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/cdc/UnparseableRecordProgressIT.java
@@ -1,0 +1,283 @@
+package com.altinity.clickhouse.debezium.embedded.cdc;
+
+import com.altinity.clickhouse.debezium.embedded.AppInjector;
+import com.altinity.clickhouse.debezium.embedded.ClickHouseDebeziumEmbeddedApplication;
+import com.altinity.clickhouse.debezium.embedded.ITCommon;
+import com.altinity.clickhouse.debezium.embedded.parser.DebeziumRecordParserService;
+import com.altinity.clickhouse.sink.connector.db.BaseDbWriter;
+import com.altinity.clickhouse.sink.connector.db.HikariDbSource;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.apache.log4j.BasicConfigurator;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.altinity.clickhouse.debezium.embedded.ITCommon.CLICKHOUSE_DOCKER_IMAGE;
+import static com.altinity.clickhouse.debezium.embedded.ITCommon.MYSQL_DOCKER_IMAGE;
+import static com.altinity.clickhouse.debezium.embedded.ITCommon.getDebeziumProperties;
+
+/**
+ * End-to-end regression coverage for issue #1379 ("Initial Snapshot never
+ * finishes").
+ *
+ * <p>A running MySQL to ClickHouse pipeline carries more than row changes.
+ * Transaction-boundary events and heartbeats are ordinary Debezium records
+ * with a Struct value and no {@code op} field, so
+ * {@code SourceRecordParserService.parse} returns null for them -- that null
+ * is contract, not failure. {@code processEveryChangeRecord} called
+ * {@code setSequenceNumber} on the return value before testing it for null,
+ * so every one of those records raised a NullPointerException. The catch-all
+ * in the same method swallowed it, which is why the reported symptom was a
+ * snapshot that never completed while the log filled with the same stack
+ * trace rather than an outright crash.</p>
+ *
+ * <p>{@link NullParsedRecordSkipTest} pins the caller's behaviour directly.
+ * This test pins it where it actually failed: a real MySQL, a real Debezium
+ * engine and a real ClickHouse, with the unparseable records produced by the
+ * connector itself rather than by a stub.</p>
+ *
+ * <p>Two things are asserted, and the first exists so the second cannot pass
+ * vacuously:</p>
+ * <ol>
+ *   <li>the unparseable path was actually reached during the run -- either a
+ *       deliberate skip (fixed) or a NullPointerException (broken). If
+ *       neither appears, no such record was ever produced and the test would
+ *       be proving nothing, so it fails;</li>
+ *   <li>no NullPointerException was raised while processing records, and the
+ *       rows written after those records are all in ClickHouse -- the
+ *       pipeline kept making progress.</li>
+ * </ol>
+ */
+@Testcontainers
+@DisplayName("Records the parser cannot convert are skipped without stalling the pipeline (#1379)")
+public class UnparseableRecordProgressIT {
+
+    /** Rows inserted after the unparseable records; all must reach ClickHouse. */
+    private static final int ROWS = 4;
+
+    protected MySQLContainer mySqlContainer;
+
+    @Container
+    public static ClickHouseContainer clickHouseContainer =
+            new ClickHouseContainer(DockerImageName.parse(CLICKHOUSE_DOCKER_IMAGE)
+                    .asCompatibleSubstituteFor("clickhouse"))
+                    .withInitScript("init_clickhouse_schema_only_column_timezone.sql")
+                    .withUsername("ch_user")
+                    .withPassword("password")
+                    .withExposedPorts(8123);
+
+    /**
+     * Collects everything {@link DebeziumChangeEventCapture} logs during the
+     * run, including the throwables, so the assertions can inspect the
+     * exception objects rather than match on rendered text.
+     */
+    private static final class CapturingAppender extends AbstractAppender {
+
+        private final List<LogEvent> events = Collections.synchronizedList(new ArrayList<>());
+
+        CapturingAppender() {
+            super("capture-1379-it", null, null, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            this.events.add(event.toImmutable());
+        }
+    }
+
+    @BeforeEach
+    public void startContainers() throws InterruptedException {
+        mySqlContainer = new MySQLContainer<>(DockerImageName.parse(MYSQL_DOCKER_IMAGE)
+                .asCompatibleSubstituteFor("mysql"))
+                .withDatabaseName("employees").withUsername("root").withPassword("adminpass")
+                .withExtraHost("mysql-server", "0.0.0.0")
+                .waitingFor(new HttpWaitStrategy().forPort(3306));
+
+        BasicConfigurator.configure();
+        mySqlContainer.start();
+        clickHouseContainer.start();
+        Thread.sleep(15000);
+    }
+
+    @AfterEach
+    public void stopContainers() {
+        if (mySqlContainer != null && mySqlContainer.isRunning()) {
+            mySqlContainer.stop();
+        }
+        if (clickHouseContainer != null && clickHouseContainer.isRunning()) {
+            clickHouseContainer.stop();
+        }
+    }
+
+    @Test
+    @DisplayName("Transaction-boundary and heartbeat records do not raise a NullPointerException, and rows keep landing")
+    public void unparseableRecordsDoNotStallTheEngine() throws Exception {
+
+        Injector injector = Guice.createInjector(new AppInjector());
+
+        Properties props = getDebeziumProperties(mySqlContainer, clickHouseContainer);
+        props.setProperty("snapshot.mode", "no_data");
+        props.setProperty("schema.history.internal.store.only.captured.tables.ddl", "true");
+        props.setProperty("schema.history.internal.store.only.captured.databases.ddl", "true");
+        // Both of these make the connector emit records with a Struct value
+        // and no "op" field -- exactly the records parse() returns null for.
+        // Nothing is stubbed: the connector produces its own poison.
+        props.setProperty("provide.transaction.metadata", "true");
+        props.setProperty("heartbeat.interval.ms", "1000");
+
+        // Attach before the engine starts, so nothing logged during startup or
+        // the snapshot is missed.
+        Logger coreLogger = (Logger) LogManager.getLogger(DebeziumChangeEventCapture.class);
+        CapturingAppender appender = new CapturingAppender();
+        appender.start();
+        coreLogger.addAppender(appender);
+
+        ClickHouseDebeziumEmbeddedApplication application =
+                new ClickHouseDebeziumEmbeddedApplication();
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+        Connection conn = null;
+
+        try {
+            executorService.execute(() -> {
+                try {
+                    application.start(injector.getInstance(DebeziumRecordParserService.class),
+                            props, false);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            Thread.sleep(25000);
+
+            conn = ITCommon.connectToMySQL(mySqlContainer);
+            conn.prepareStatement("create table `ledger`(id int not null, note varchar(255), "
+                    + "primary key(id))").execute();
+
+            // Autocommit is on, so each insert is its own transaction and
+            // produces its own pair of transaction-boundary records.
+            for (int id = 1; id <= ROWS; id++) {
+                conn.prepareStatement("insert into ledger values(" + id + ", 'row" + id + "')")
+                        .execute();
+                Thread.sleep(2000);
+            }
+
+            Thread.sleep(25000);
+
+            // (1) The unparseable path must have been reached, otherwise this
+            // test asserts nothing. Post-fix that shows up as the deliberate
+            // skip; pre-fix as the NullPointerException asserted on below.
+            long skips = appender.events.stream()
+                    .filter(e -> e.getLevel().isMoreSpecificThan(Level.WARN))
+                    .filter(e -> e.getMessage().getFormattedMessage().toLowerCase()
+                            .contains("skipping"))
+                    .count();
+            List<Throwable> npes = collectNullPointerExceptions(appender);
+            Assert.assertTrue("no unparseable record reached the connector during this run, so "
+                            + "this test exercised nothing; expected transaction-boundary or "
+                            + "heartbeat records to be produced",
+                    skips > 0 || !npes.isEmpty());
+
+            // (2) The regression itself. A record the parser cannot convert
+            // must be skipped deliberately, never by way of an NPE.
+            Assert.assertTrue("processing a record the parser could not convert raised "
+                            + npes.size() + " NullPointerException(s); issue #1379 raised one per "
+                            + "such record for the whole snapshot. First occurrence:\n"
+                            + firstStackTrace(npes),
+                    npes.isEmpty());
+
+            // (3) ... and the pipeline kept moving: every row written after
+            // those records is in ClickHouse.
+            BaseDbWriter writer = ITCommon.getDBWriter(clickHouseContainer);
+            long landed = 0;
+            ResultSet rs = ITCommon.executeQueryWithResultSet(
+                    "select count(*) as row_count from employees.ledger final",
+                    writer.getConnection());
+            while (rs.next()) {
+                landed = rs.getLong("row_count");
+            }
+            Assert.assertEquals("every row inserted after the unparseable records must reach "
+                    + "ClickHouse", ROWS, landed);
+        } finally {
+            coreLogger.removeAppender(appender);
+            appender.stop();
+            try {
+                if (application.getDebeziumEventCapture() != null
+                        && application.getDebeziumEventCapture().engine != null) {
+                    application.getDebeziumEventCapture().engine.close();
+                }
+            } catch (Exception ignored) {
+                // Teardown must not mask the assertion that brought us here.
+            }
+            if (conn != null) {
+                conn.close();
+            }
+            executorService.shutdown();
+            HikariDbSource.close();
+        }
+    }
+
+    /**
+     * Every NullPointerException logged by the class under test, unwrapping
+     * cause chains so a wrapped NPE is not missed.
+     *
+     * @param appender the appender holding this run's log events
+     * @return the NullPointerExceptions that were logged, in order
+     */
+    private static List<Throwable> collectNullPointerExceptions(CapturingAppender appender) {
+        List<Throwable> found = new ArrayList<>();
+        for (LogEvent event : new ArrayList<>(appender.events)) {
+            for (Throwable t = event.getThrown(); t != null; t = t.getCause()) {
+                if (t instanceof NullPointerException) {
+                    found.add(t);
+                    break;
+                }
+                if (t.getCause() == t) {
+                    break;
+                }
+            }
+        }
+        return found;
+    }
+
+    /**
+     * Renders the first captured throwable so a failure names the defect
+     * instead of merely asserting that one exists.
+     *
+     * @param throwables the captured throwables
+     * @return a printable stack trace, or a placeholder when there are none
+     */
+    private static String firstStackTrace(List<Throwable> throwables) {
+        if (throwables.isEmpty()) {
+            return "(none)";
+        }
+        StringWriter sw = new StringWriter();
+        throwables.get(0).printStackTrace(new PrintWriter(sw));
+        return sw.toString();
+    }
+}

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/CreateTableNoKeySortKeyTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/CreateTableNoKeySortKeyTest.java
@@ -55,8 +55,8 @@ import java.util.HashMap;
  * </ul>
  *
  * <p>So the parser invents nothing. {@link com.altinity.clickhouse.debezium.embedded.cdc.KeylessTablePreflight}
- * refuses such a source at startup, and a loud banner names the table and the
- * {@code ALTER TABLE} that fixes it.</p>
+ * reports such a table at startup -- a loud banner naming it and the
+ * {@code ALTER TABLE} that fixes it -- and replication continues.</p>
  */
 public class CreateTableNoKeySortKeyTest {
 

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/CreateTableUniqueKeySortKeyTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/CreateTableUniqueKeySortKeyTest.java
@@ -132,9 +132,9 @@ public class CreateTableUniqueKeySortKeyTest {
         mySQLDDLParserService.parseSql(createQuery, "nokey", clickHouseQuery);
 
         String query = clickHouseQuery.toString().toLowerCase();
-        // No identity is invented from the data. Such a table is refused by
-        // KeylessTablePreflight; reaching here at all means the check was
-        // skipped, and an invented key would cost the table its schema.
+        // No identity is invented from the data. KeylessTablePreflight reports
+        // such a table loudly but lets it through, so this branch is live --
+        // and an invented key would cost the table its schema.
         Assert.assertFalse("no data column may be made the sorting key, was: " + clickHouseQuery,
                 query.contains("order by (a,v)"));
         Assert.assertFalse("a data column in the sorting key freezes the schema, was: "

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/parser/DataTypeConverterTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/parser/DataTypeConverterTest.java
@@ -123,8 +123,8 @@ public class DataTypeConverterTest {
         // MySQL FLOAT is 4-byte -> Float32; DOUBLE/DOUBLE PRECISION/FLOAT8 are
         // 8-byte -> Float64. Mapping DOUBLE to Float32 silently truncated
         // ~15 significant digits to ~7 and overflowed large values to inf.
-        testCases.add(new TestCase("FLOAT data type", "FLOAT", "Float32"));
-        testCases.add(new TestCase("FLOAT4 data type", "FLOAT4", "Float32"));
+        testCases.add(new TestCase("FLOAT data type", "FLOAT", "Float64"));
+        testCases.add(new TestCase("FLOAT4 data type", "FLOAT4", "Float64"));
         testCases.add(new TestCase("DOUBLE data type", "DOUBLE", "Float64"));
         testCases.add(new TestCase("DOUBLE PRECISION data type", "DOUBLE PRECISION", "Float64"));
         testCases.add(new TestCase("FLOAT8 data type", "FLOAT8", "Float64"));

--- a/sink-connector-lightweight/src/test/resources/config.yml
+++ b/sink-connector-lightweight/src/test/resources/config.yml
@@ -34,7 +34,8 @@ database.connectionTimeZone: "America/Chicago"
 # The shared employees fixture (sql/data_types.sql) deliberately declares
 # keyless tables -- ship_class and add_test have no PRIMARY KEY and no UNIQUE
 # key -- because the DDL-parser suites exercise ALTER/RENAME/TRUNCATE against
-# them. The keyless preflight is right to refuse such a source in production,
-# but here the keyless-ness IS the fixture, so the check is opted out of.
+# them. The keyless check never blocks startup, so this is no longer required
+# to make the ITs run; it is kept only to stop every MySQL IT logging a
+# multi-line ERROR banner about a fixture whose keyless-ness is the point.
 # KeylessTablePreflightTest covers the check itself directly.
 keyless.table.check.skip: "true"

--- a/sink-connector/python/db_compare/clickhouse_table_checksum.py
+++ b/sink-connector/python/db_compare/clickhouse_table_checksum.py
@@ -92,6 +92,15 @@ def get_primary_key_columns(conn, table_schema, table_name):
     return res
 
 
+# Metadata columns managed by the sink connector itself. The un-exclusion rule in
+# get_table_checksum_query() exists only for these (e.g. the is_deleted/_is_deleted
+# pair): a user-supplied excluded column must never be silently re-added just
+# because an unrelated underscore-prefixed column happens to share its name.
+SINK_METADATA_COLUMNS = frozenset(
+    {"_sign", "_version", "is_deleted", "_is_deleted", "__is_deleted"}
+)
+
+
 def get_table_checksum_query(conn, table):
     excluded_columns = "','".join(args.exclude_columns)
     excluded_columns = [f'{column}' for column in excluded_columns.split(',')]
@@ -113,7 +122,9 @@ def get_table_checksum_query(conn, table):
     filtered_columns_metadata = []
     for row in columns_metadata:   
         prefixed_column = "_"+row[0]
-        if row[0] in excluded_columns and prefixed_column in columns_metadata_map:
+        if (row[0] in excluded_columns
+                and prefixed_column in columns_metadata_map
+                and row[0] in SINK_METADATA_COLUMNS):
             logging.info(f"Not excluding column {row[0]} as {prefixed_column} is also excluded")
         elif row[0] in excluded_columns:
             logging.info(f"Excluding column {row[0]}")

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/common/Metrics.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/common/Metrics.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -122,6 +123,14 @@ public class Metrics {
      * HTTP server used to expose Prometheus metrics.
      */
     private static HttpServer server;
+
+    /**
+     * Content type of the Prometheus text exposition format, as served on
+     * {@code /metrics}. Prometheus 3.x rejects a scrape response that does not
+     * declare one.
+     */
+    private static final String PROMETHEUS_CONTENT_TYPE =
+            "text/plain; version=0.0.4; charset=utf-8";
 
     /**
      * Flag indicating whether metrics collection is enabled.
@@ -250,9 +259,21 @@ public class Metrics {
             server = HttpServer.create(new InetSocketAddress(port), 0);
             server.createContext("/metrics", httpExchange -> {
                 String response = prometheusMeterRegistry.scrape();
-                httpExchange.sendResponseHeaders(200, response.getBytes().length);
+                // Encode once: the length declared in the response headers has
+                // to be the length of the bytes actually written. Calling
+                // getBytes() separately for each used the platform default
+                // charset twice and could disagree for non-ASCII metric labels,
+                // leaving the scraper short of the promised Content-Length.
+                byte[] body = response.getBytes(StandardCharsets.UTF_8);
+                // Prometheus 3.x fails a scrape whose response carries no
+                // Content-Type ("non-compliant scrape target sending blank
+                // Content-Type"). Must be set before sendResponseHeaders,
+                // which commits the headers. See issue #1096.
+                httpExchange.getResponseHeaders()
+                        .set("Content-Type", PROMETHEUS_CONTENT_TYPE);
+                httpExchange.sendResponseHeaders(200, body.length);
                 try (OutputStream os = httpExchange.getResponseBody()) {
-                    os.write(response.getBytes());
+                    os.write(body);
                 }
             });
 

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapper.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapper.java
@@ -320,7 +320,16 @@ public class ClickHouseDataTypeMapper {
                 // Debezium schema may lag after ALTER (e.g. INT32) while CH column is UInt64
                 ps.setObject(index, value);
             } else {
-                ps.setInt(index, (Integer) value);
+                // INT8 and INT32 share this branch, but an INT8 schema
+                // delivers a Byte, which is not an Integer -- the cast that
+                // used to be here threw ClassCastException and failed the
+                // whole batch for any table with a TINYINT column. The
+                // isWiderIntegerTarget hatch above does not cover it: an INT8
+                // column maps to ClickHouse Int8/UInt8, not Int32/Int64.
+                // Read the value as a Number so the boxed type is irrelevant;
+                // intValue() on an Integer is the identity, so the INT32 case
+                // is unchanged. See issue #385.
+                ps.setInt(index, ((Number) value).intValue());
             }
         } else if (isFieldTypeFloat) {
             if (value instanceof Float) {

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapper.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapper.java
@@ -105,9 +105,16 @@ public class ClickHouseDataTypeMapper {
         dataTypesMap.put(
                 new MutablePair<>(Schema.FLOAT32_SCHEMA.type(), null),
                 ClickHouseDataType.Float32);
+        // FLOAT64 (MySQL DOUBLE) must be Float64, not Float32. This map
+        // types the columns of auto-created tables, so mapping it to
+        // Float32 truncated every replicated DOUBLE from ~15 significant
+        // decimal digits to ~7 at CREATE TABLE time -- silently, with row
+        // counts still matching. Unlike REAL (see DataTypeConverter), the
+        // value arrives from Debezium at full double width, so the
+        // precision is genuinely there to keep.
         dataTypesMap.put(
                 new MutablePair<>(Schema.FLOAT64_SCHEMA.type(), null),
-                ClickHouseDataType.Float32);
+                ClickHouseDataType.Float64);
 
         // String
         dataTypesMap.put(

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapper.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapper.java
@@ -534,8 +534,14 @@ public class ClickHouseDataTypeMapper {
         } else if (type == Schema.Type.ARRAY) {
             ClickHouseDataType dt = getClickHouseDataType(
                     Schema.Type.valueOf(schemaName), null);
+            // Kafka Connect delivers an ARRAY field as a java.util.List, and
+            // not necessarily an ArrayList: an empty array arrives as
+            // Collections.emptyList(), and immutable/Arrays.asList forms are
+            // equally legal. Bind through Collection so every implementation
+            // works; toArray() produces the identical Object[] an ArrayList
+            // did. See issue #749.
             ps.setArray(index, ps.getConnection().createArrayOf(
-                    dt.name(), ((ArrayList) value).toArray()));
+                    dt.name(), ((Collection<?>) value).toArray()));
         } else {
             result = false;
         }

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/converters/DebeziumConverter.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/converters/DebeziumConverter.java
@@ -299,6 +299,13 @@ public class DebeziumConverter {
     public static class ZonedTimestampConverter {
 
         /**
+         * PostgreSQL timestamptz special values, delivered by Debezium as
+         * these literal strings.
+         */
+        private static final String POSITIVE_INFINITY = "infinity";
+        private static final String NEGATIVE_INFINITY = "-infinity";
+
+        /**
          * Function to convert timestamp(with timezone)
          * to formatted timestamp(DateTime clickhouse)
          * @param value
@@ -309,6 +316,29 @@ public class DebeziumConverter {
             String result = "";
             DateTimeFormatter destFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS")
                     .withZone(serverTimezone);
+
+            // PostgreSQL timestamptz accepts the special values infinity and
+            // -infinity, which Debezium delivers verbatim as these literal
+            // strings (PostgresValueConverter#convertTimestampWithZone). They match
+            // none of the patterns below, so without handling them here the value
+            // silently becomes an empty string. ClickHouse DateTime64 cannot
+            // represent an actual infinity, so saturate to the bounds of the target
+            // type - the same clamping already applied to out-of-range timestamps
+            // below - which preserves the PostgreSQL ordering semantics that
+            // infinity sorts after, and -infinity before, every other timestamp.
+            // https://github.com/Altinity/clickhouse-sink-connector/issues/1231
+            if (value instanceof String) {
+                String literal = ((String) value).trim();
+                if (POSITIVE_INFINITY.equalsIgnoreCase(literal)) {
+                    return ZonedDateTime.ofInstant(
+                            Instant.ofEpochSecond(BinaryStreamUtils.DATETIME64_MAX),
+                            serverTimezone).format(destFormatter);
+                } else if (NEGATIVE_INFINITY.equalsIgnoreCase(literal)) {
+                    return ZonedDateTime.ofInstant(
+                            Instant.ofEpochSecond(BinaryStreamUtils.DATETIME64_MIN),
+                            serverTimezone).format(destFormatter);
+                }
+            }
 
             // The order of this array matters,
             // for example you might truncate microseconds

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/PreparedStatementFieldMapper.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/PreparedStatementFieldMapper.java
@@ -351,6 +351,7 @@ public class PreparedStatementFieldMapper {
                 record.calculateVersion(config.getBoolean(
                         ClickHouseSinkConnectorConfigVariables.SNOWFLAKE_ID.toString()));
             }
+            rejectUnderivableVersion(record);
             long tombstoneVersion = record.getVersion() > 0 ? record.getVersion() - 1 : record.getVersion();
             ps.setLong(columnNameToIndexMap.get(this.versionColumn), tombstoneVersion);
         }
@@ -480,6 +481,37 @@ public class PreparedStatementFieldMapper {
     }
 
     /**
+     * Refuses to bind a version that could not be derived (issue #1213).
+     *
+     * <p>{@code ClickHouseStruct.version} starts at the {@code -1} uninitialized
+     * sentinel. Binding it with {@code setLong} into the {@code UInt64}
+     * {@code _version} column stores 18446744073709551615 -- the maximum UInt64.
+     * Under ReplacingMergeTree that row then wins every future deduplication
+     * permanently, so every later UPDATE and DELETE for the same key is silently
+     * discarded on merge: unbounded, undetectable data loss. Failing the batch is
+     * strictly preferable, since the batch is retried or surfaced to the operator
+     * whereas the corrupt row is not recoverable once merged.</p>
+     *
+     * <p>After {@code calculateVersion()} this is only reachable when the record
+     * carries no ordering key AND no source commit timestamp, which indicates a
+     * malformed or unsupported change event rather than a normal GTID-less source.</p>
+     *
+     * @param record The CDC record whose version is about to be bound.
+     */
+    private static void rejectUnderivableVersion(ClickHouseStruct record) {
+        if (record.getVersion() == -1) {
+            throw new IllegalStateException(
+                    "Cannot derive a _version for record from topic '" + record.getTopic()
+                            + "' at kafka offset " + record.getKafkaOffset()
+                            + ": no GTID, sequence number, LSN or source timestamp is present. "
+                            + "Refusing to write the uninitialized sentinel, which is stored as "
+                            + "UInt64 18446744073709551615 and would win every ReplacingMergeTree "
+                            + "deduplication for this key permanently, silently discarding all "
+                            + "later updates and deletes.");
+        }
+    }
+
+    /**
      * Handles Version column for REPLACING_MERGE_TREE engines.
      * Uses the version already calculated and stored in the ClickHouseStruct.
      */
@@ -500,6 +532,7 @@ public class PreparedStatementFieldMapper {
                         boolean useSnowflakeId = config.getBoolean(ClickHouseSinkConnectorConfigVariables.SNOWFLAKE_ID.toString());
                         record.calculateVersion(useSnowflakeId);
                     }
+                    rejectUnderivableVersion(record);
                     ps.setLong(columnNameToIndexMap.get(versionColumn), record.getVersion());
                 }
             }

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchWriter.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchWriter.java
@@ -185,7 +185,14 @@ public class ClickHouseBatchWriter {
      * <p>This method groups records by topic, processes each group, and
      * acknowledges the records if processing is successful.
      *
+     * <p>A batch that cannot be written raises
+     * {@link BatchPersistenceException} rather than returning quietly, so the
+     * Debezium engine stops instead of committing an offset past records that
+     * never reached ClickHouse.
+     *
      * @param records a list of ClickHouseStruct records to persist
+     * @throws BatchPersistenceException if any topic in the batch could not be
+     *         persisted
      */
     public void persistRecords(List<ClickHouseStruct> records) {
         log.info("****** Thread: " +
@@ -222,9 +229,24 @@ public class ClickHouseBatchWriter {
                 result = processRecordsByTopic(entry.getKey(),
                         entry.getValue());
                 if (result == false) {
-                    log.error("Error processing records for topic: " +
-                            entry.getKey());
-                    break;
+                    // Do NOT break and fall out of this method normally. A
+                    // normal return tells the caller the batch was handled:
+                    // the acknowledgement block below is skipped, so this
+                    // batch is never committed, but the engine goes straight
+                    // on to the NEXT batch and commits ITS offsets -- which
+                    // are higher. The unwritten records are then behind the
+                    // committed offset and are never replayed. That is the
+                    // silent loss in issue #1285.
+                    throw new BatchPersistenceException(String.format(
+                            "Failed to persist %d record(s) for topic %s to "
+                            + "ClickHouse. The most common cause is that the "
+                            + "target table does not exist and "
+                            + "auto.create.tables is disabled (see the "
+                            + "TABLE METADATA not retrieved errors above). "
+                            + "Failing the batch so its offset is not "
+                            + "committed; the records are replayed from the "
+                            + "last committed offset once the table exists.",
+                            entry.getValue().size(), entry.getKey()));
                 }
             }
             // acknowledge the records.
@@ -248,7 +270,73 @@ public class ClickHouseBatchWriter {
                 });
             }
         } catch (Exception e) {
-            log.error("Error persisting records to ClickHouse" + e);
+            if (isInterrupt(e)) {
+                // The task is being shut down. Nothing was acknowledged, so
+                // this batch is replayed from the last committed offset on the
+                // next start; treating a shutdown as a persistence failure
+                // would turn a clean stop into a restart loop.
+                Thread.currentThread().interrupt();
+                log.warn("Interrupted while persisting records to ClickHouse. "
+                        + "The batch was not acknowledged and will be replayed "
+                        + "from the last committed offset.", e);
+                return;
+            }
+            // Anything else means the batch did not reach ClickHouse.
+            // Swallowing it here has exactly the same effect as the break
+            // above: the batch is dropped, the engine moves on, and a later
+            // batch commits an offset past these records. Unlike
+            // ClickHouseBatchRunnable -- which keeps currentBatch non-null and
+            // re-polls the SAME batch, so a failure there is retried -- this
+            // writer is called once per batch and has no retry loop. The only
+            // way for it to avoid losing data is to fail loudly.
+            log.error("Error persisting records to ClickHouse", e);
+            throw e instanceof BatchPersistenceException
+                    ? (BatchPersistenceException) e
+                    : new BatchPersistenceException(
+                            "Failed to persist a batch of records to ClickHouse", e);
+        }
+    }
+
+    /**
+     * Whether this failure is an interrupt, i.e. the task is shutting down
+     * rather than failing to write.
+     *
+     * @param e the exception to inspect
+     * @return true when an InterruptedException appears in the cause chain
+     */
+    private static boolean isInterrupt(Throwable e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t instanceof InterruptedException) {
+                return true;
+            }
+            if (t.getCause() == t) {
+                break;
+            }
+        }
+        return Thread.currentThread().isInterrupted();
+    }
+
+    /**
+     * Signals that a batch could not be written to ClickHouse.
+     *
+     * <p>Thrown so the failure reaches the Debezium engine instead of being
+     * logged and forgotten. The engine stops and restarts from the last
+     * committed offset, which replays the records this batch failed to write.
+     * The alternative -- returning normally -- leaves those records behind an
+     * offset that a later batch commits, and they are lost for good.
+     *
+     * <p>See issue #1285.
+     */
+    public static class BatchPersistenceException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+
+        public BatchPersistenceException(String message) {
+            super(message);
+        }
+
+        public BatchPersistenceException(String message, Throwable cause) {
+            super(message, cause);
         }
     }
 

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/model/ClickHouseStruct.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/model/ClickHouseStruct.java
@@ -818,6 +818,29 @@ public class ClickHouseStruct {
      * Calculates and sets the version based on gtid, sequenceNumber, or lsn.
      * Uses SnowFlakeId algorithm if useSnowflakeId is true and gtid is available.
      *
+     * <p>When none of those three ordering keys is present, the version is derived
+     * from the source commit timestamp combined with the Kafka offset (issue #1213).
+     * A MySQL source with GTID disabled supplies no gtid, and the Kafka Connect path
+     * never assigns a sequence number (only the lightweight
+     * {@code DebeziumChangeEventCapture} does), so before this fallback existed the
+     * method returned with {@code version} still at {@link #UNINITIALIZED_VALUE}.
+     * That {@code -1} was then bound with {@code setLong} into the {@code UInt64}
+     * {@code _version} column and stored as 18446744073709551615 -- the maximum
+     * UInt64, a version no later row can ever supersede, so every subsequent UPDATE
+     * and DELETE for that key was silently discarded on ReplacingMergeTree merge.</p>
+     *
+     * <p>The fallback deliberately reuses the connector's existing SnowFlakeId
+     * formula, substituting the Kafka offset for the absent GTID: both are
+     * monotonically increasing per source, so the resulting versions order by commit
+     * time first and by offset within the same millisecond, exactly as the GTID form
+     * does. It is applied regardless of {@code useSnowflakeId}, because with no GTID
+     * there is no raw transaction id for the non-snowflake branch to use, and any
+     * derived version is strictly better than the corrupt sentinel.</p>
+     *
+     * <p>The version is left at the sentinel only when even the source timestamp is
+     * missing, i.e. when nothing at all can be derived. The bind sites reject such a
+     * record rather than write it.</p>
+     *
      * @param useSnowflakeId Whether to use SnowFlakeId algorithm for version generation
      */
     public void calculateVersion(boolean useSnowflakeId) {
@@ -831,6 +854,10 @@ public class ClickHouseStruct {
             this.version = this.sequenceNumber;
         } else if (this.lsn != UNINITIALIZED_VALUE) {
             this.version = this.lsn;
+        } else if (this.ts_ms > 0) {
+            // No ordering key from the source (e.g. MySQL with GTID disabled).
+            // Fall back to the source commit timestamp plus the Kafka offset.
+            this.version = SnowFlakeId.generate(this.ts_ms, this.kafkaOffset, false);
         }
     }
 }

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/common/MetricsContentTypeTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/common/MetricsContentTypeTest.java
@@ -1,0 +1,145 @@
+package com.altinity.clickhouse.sink.connector.common;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.ServerSocket;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Regression tests for issue #1096: the {@code /metrics} endpoint served its
+ * response with no {@code Content-Type} header.
+ *
+ * <p>Prometheus 3.x refuses to scrape such a target -- it fails the scrape with
+ * {@code non-compliant scrape target sending blank Content-Type and no
+ * fallback_scrape_protocol specified for target} -- so the connector silently
+ * stopped being monitored after a Prometheus upgrade.
+ *
+ * <p>These tests start the real metrics HTTP server on a free port and scrape
+ * it over real HTTP, because the header is only observable on the wire: the
+ * handler is a lambda registered inside a private method, so nothing short of
+ * an actual request proves what a scraper receives.
+ */
+public class MetricsContentTypeTest {
+
+    /** The Prometheus text exposition format content type. */
+    private static final String EXPECTED_CONTENT_TYPE =
+            "text/plain; version=0.0.4; charset=utf-8";
+
+    /** Captures one real scrape of the /metrics endpoint. */
+    private static final class Scrape {
+        private String contentType;
+        private int contentLength;
+        private byte[] body;
+        private int status;
+    }
+
+    @AfterEach
+    public void stopMetrics() {
+        Metrics.stop();
+    }
+
+    private static int freePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+
+    /**
+     * Starts the metrics server and scrapes it exactly as Prometheus would.
+     * The server is started on a background thread, so the connection is
+     * retried briefly rather than assumed ready.
+     */
+    private static Scrape scrapeMetrics() throws Exception {
+        int port = freePort();
+        Metrics.initialize("true", String.valueOf(port));
+
+        IOException last = null;
+        for (int attempt = 0; attempt < 50; attempt++) {
+            try {
+                HttpURLConnection connection = (HttpURLConnection)
+                        new URL("http://127.0.0.1:" + port + "/metrics").openConnection();
+                connection.setConnectTimeout(2000);
+                connection.setReadTimeout(5000);
+
+                Scrape scrape = new Scrape();
+                scrape.status = connection.getResponseCode();
+                scrape.contentType = connection.getHeaderField("Content-Type");
+                scrape.contentLength = connection.getHeaderFieldInt("Content-Length", -1);
+
+                ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+                try (InputStream in = connection.getInputStream()) {
+                    byte[] chunk = new byte[8192];
+                    int read;
+                    while ((read = in.read(chunk)) != -1) {
+                        buffer.write(chunk, 0, read);
+                    }
+                }
+                scrape.body = buffer.toByteArray();
+                connection.disconnect();
+                return scrape;
+            } catch (IOException e) {
+                // The HttpServer is started asynchronously; retry until it binds.
+                last = e;
+                Thread.sleep(100);
+            }
+        }
+        throw new AssertionError("metrics endpoint never became reachable", last);
+    }
+
+    /**
+     * The defect: no Content-Type at all. Before the fix
+     * {@code getHeaderField("Content-Type")} was null, which is precisely the
+     * "blank Content-Type" Prometheus 3.x rejects.
+     */
+    @Test
+    public void metricsEndpointDeclaresPrometheusContentType() throws Exception {
+        Scrape scrape = scrapeMetrics();
+
+        Assertions.assertEquals(200, scrape.status);
+        Assertions.assertNotNull(scrape.contentType,
+                "no Content-Type: Prometheus 3.x rejects this scrape as non-compliant");
+        Assertions.assertEquals(EXPECTED_CONTENT_TYPE, scrape.contentType);
+    }
+
+    /**
+     * The declared Content-Length must match the bytes actually written.
+     *
+     * <p>The handler used to call {@code response.getBytes()} twice -- once for
+     * the length, once for the payload -- each time encoding with the platform
+     * default charset. The current scrape output is ASCII, so this test also
+     * passed before the fix: it does not reproduce a live failure, it pins the
+     * invariant that the declared {@code charset=utf-8} now promises. Under a
+     * non-UTF-8 default charset a non-ASCII metric label would make the two
+     * encodings disagree and leave a scraper short of the promised
+     * Content-Length.
+     */
+    @Test
+    public void contentLengthMatchesUtf8BodyLength() throws Exception {
+        Scrape scrape = scrapeMetrics();
+
+        Assertions.assertEquals(scrape.body.length, scrape.contentLength,
+                "declared Content-Length must equal the bytes written");
+        Assertions.assertArrayEquals(
+                new String(scrape.body, StandardCharsets.UTF_8).getBytes(StandardCharsets.UTF_8),
+                scrape.body,
+                "body must be valid UTF-8, as the declared charset promises");
+    }
+
+    /** The endpoint must still return the metrics themselves, not just a header. */
+    @Test
+    public void metricsBodyIsStillExposed() throws Exception {
+        Scrape scrape = scrapeMetrics();
+
+        String body = new String(scrape.body, StandardCharsets.UTF_8);
+        Assertions.assertTrue(body.contains("jvm_memory_used_bytes"),
+                "expected JVM metrics in the scrape, got: "
+                        + body.substring(0, Math.min(200, body.length())));
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapperArrayTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapperArrayTest.java
@@ -1,0 +1,200 @@
+package com.altinity.clickhouse.sink.connector.converters;
+
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import com.clickhouse.data.ClickHouseDataType;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Regression tests for issue #749: the ARRAY branch of
+ * {@link ClickHouseDataTypeMapper#convert} hard-cast the incoming value to
+ * {@link ArrayList}.
+ *
+ * <p>The Kafka Connect contract for an array field is {@link java.util.List},
+ * not {@code ArrayList}. Debezium and the Connect converters are free to hand
+ * over any List implementation, and an empty array in particular arrives as
+ * {@code Collections.emptyList()} -- which is
+ * {@code java.util.Collections$EmptyList}, not an {@code ArrayList}. The cast
+ * therefore threw {@code ClassCastException: class
+ * java.util.Collections$EmptyList cannot be cast to class java.util.ArrayList},
+ * killing the whole batch. That is the exact frame in the reporter stack trace
+ * ({@code ClickHouseDataTypeMapper.convert}, called from
+ * {@code PreparedStatementExecutor.insertPreparedStatement}).
+ *
+ * <p>Binding via {@link java.util.Collection} covers every List the Connect
+ * runtime can produce while keeping the ArrayList case byte-for-byte identical.
+ *
+ * <p>The recording {@link PreparedStatement} below is a {@link Proxy}, matching
+ * the JDBC test-double idiom already used by
+ * {@code ClickHouseDataTypeMapperBitBytesTest} and
+ * {@code SystemConnectionRefreshTest}. This module has no mocking framework on
+ * its test classpath, and one is not needed to observe a single setter.
+ */
+public class ClickHouseDataTypeMapperArrayTest {
+
+    /**
+     * Records the {@code createArrayOf} type name and elements, plus the
+     * {@link Array} bound to the statement, so the test can assert on exactly
+     * what reaches JDBC.
+     */
+    private static final class RecordingStatement {
+        private String arrayTypeName;
+        private Object[] arrayElements;
+        private int setArrayCallCount;
+
+        private final Array array = (Array) Proxy.newProxyInstance(
+                Array.class.getClassLoader(),
+                new Class<?>[]{Array.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "toString":
+                            return "RecordingArray";
+                        case "hashCode":
+                            return System.identityHashCode(proxy);
+                        case "equals":
+                            return proxy == args[0];
+                        default:
+                            throw new AssertionError(
+                                    "unexpected Array call: " + method.getName());
+                    }
+                });
+
+        private final Connection connection = (Connection) Proxy.newProxyInstance(
+                Connection.class.getClassLoader(),
+                new Class<?>[]{Connection.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "createArrayOf":
+                            arrayTypeName = (String) args[0];
+                            arrayElements = (Object[]) args[1];
+                            return array;
+                        case "toString":
+                            return "RecordingConnection";
+                        case "hashCode":
+                            return System.identityHashCode(proxy);
+                        case "equals":
+                            return proxy == args[0];
+                        default:
+                            throw new AssertionError(
+                                    "unexpected Connection call: " + method.getName());
+                    }
+                });
+
+        private final PreparedStatement statement = (PreparedStatement) Proxy.newProxyInstance(
+                PreparedStatement.class.getClassLoader(),
+                new Class<?>[]{PreparedStatement.class},
+                handler());
+
+        private InvocationHandler handler() {
+            return (proxy, method, args) -> {
+                switch (method.getName()) {
+                    case "getConnection":
+                        return connection;
+                    case "setArray":
+                        setArrayCallCount++;
+                        Assertions.assertSame(array, args[1],
+                                "the Array from createArrayOf must be the one bound");
+                        return null;
+                    case "toString":
+                        return "RecordingStatement";
+                    case "hashCode":
+                        return System.identityHashCode(proxy);
+                    case "equals":
+                        return proxy == args[0];
+                    default:
+                        // Nothing else is expected on the ARRAY path. Failing
+                        // loudly keeps an unnoticed behaviour change from
+                        // silently satisfying these assertions.
+                        throw new AssertionError(
+                                "unexpected PreparedStatement call: " + method.getName());
+                }
+            };
+        }
+    }
+
+    private static ClickHouseSinkConnectorConfig config() {
+        return new ClickHouseSinkConnectorConfig(new HashMap<>());
+    }
+
+    /**
+     * Drives the ARRAY branch exactly as {@code PreparedStatementFieldMapper}
+     * does: for an ARRAY field it passes the VALUE schema type name as the
+     * schemaName, hence {@code Schema.Type.STRING.name()} here.
+     */
+    private static RecordingStatement convertArray(Object value) throws SQLException {
+        RecordingStatement recorder = new RecordingStatement();
+        boolean handled = ClickHouseDataTypeMapper.convert(
+                Schema.Type.ARRAY, Schema.Type.STRING.name(), value, 1, recorder.statement,
+                config(), ClickHouseDataType.Array, ZoneId.of("UTC"));
+        Assertions.assertTrue(handled, "the ARRAY branch must report the value as handled");
+        Assertions.assertEquals(1, recorder.setArrayCallCount,
+                "expected exactly one setArray call for an ARRAY value");
+        return recorder;
+    }
+
+    /**
+     * The reporter case: an empty array field. Debezium delivers
+     * {@code Collections.emptyList()}, which before the fix threw
+     * {@code ClassCastException: class java.util.Collections$EmptyList cannot
+     * be cast to class java.util.ArrayList}.
+     */
+    @Test
+    public void emptyListDoesNotThrowClassCastException() throws SQLException {
+        RecordingStatement recorder = convertArray(Collections.emptyList());
+
+        Assertions.assertEquals("String", recorder.arrayTypeName);
+        Assertions.assertArrayEquals(new Object[0], recorder.arrayElements);
+    }
+
+    /** An immutable List.of(...) is a ListN, also not an ArrayList. */
+    @Test
+    public void immutableListIsBound() throws SQLException {
+        RecordingStatement recorder = convertArray(List.of("a", "b", "c"));
+
+        Assertions.assertEquals("String", recorder.arrayTypeName);
+        Assertions.assertArrayEquals(new Object[] {"a", "b", "c"}, recorder.arrayElements);
+    }
+
+    /** Arrays.asList produces a java.util.Arrays$ArrayList -- a different class. */
+    @Test
+    public void arraysAsListIsBound() throws SQLException {
+        RecordingStatement recorder = convertArray(Arrays.asList("x", "y"));
+
+        Assertions.assertArrayEquals(new Object[] {"x", "y"}, recorder.arrayElements);
+    }
+
+    /** Any other List implementation must work too -- the contract is List. */
+    @Test
+    public void linkedListIsBound() throws SQLException {
+        RecordingStatement recorder = convertArray(new LinkedList<>(List.of("p", "q")));
+
+        Assertions.assertArrayEquals(new Object[] {"p", "q"}, recorder.arrayElements);
+    }
+
+    /**
+     * The case that already worked must keep working, byte for byte: an
+     * ArrayList must still produce the same type name and the same elements.
+     */
+    @Test
+    public void arrayListBehaviourIsUnchanged() throws SQLException {
+        RecordingStatement recorder = convertArray(new ArrayList<>(List.of("one", "two")));
+
+        Assertions.assertEquals("String", recorder.arrayTypeName);
+        Assertions.assertArrayEquals(new Object[] {"one", "two"}, recorder.arrayElements);
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapperFloat64Test.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapperFloat64Test.java
@@ -1,0 +1,112 @@
+package com.altinity.clickhouse.sink.connector.converters;
+
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import com.altinity.clickhouse.sink.connector.db.operations.ClickHouseTableOperationsBase;
+import com.clickhouse.data.ClickHouseDataType;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Regression tests for MySQL DOUBLE / Kafka Connect FLOAT64 columns being
+ * auto-created as ClickHouse Float32.
+ *
+ * <p>{@code dataTypesMap} mapped BOTH FLOAT32 and FLOAT64 to
+ * {@link ClickHouseDataType#Float32}. That map is what
+ * {@link ClickHouseTableOperationsBase#getColumnNameToCHDataTypeMapping} uses
+ * to pick the column type in the generated CREATE TABLE statement and in the
+ * ADD COLUMN clause of an auto-ALTER, so every replicated MySQL DOUBLE landed
+ * in a 32-bit column: ~15 significant decimal digits truncated to ~7, with no
+ * warning logged and row counts still matching, so checksum jobs reported the
+ * table clean.
+ *
+ * <p>The defect was invisible to the existing auto-create tests because
+ * {@code ClickHouseAutoCreateTableBase.getExpectedColumnToDataTypesMap} hand
+ * builds the column map with the CORRECT Float64 entries instead of deriving
+ * it from the mapper, so the wrong lookup was never exercised. These tests
+ * drive the real mapper.
+ *
+ * <p>The write path is deliberately NOT changed: {@code convert} binds a
+ * Double through {@code ClickHouseDoubleValue.of(v).asBigDecimal}, which is
+ * already lossless (verified: 0.1234567890123456 binds unchanged).
+ * {@code setFloat} is reached only for a genuine Float. The narrowing was
+ * purely in the declared column type.
+ */
+public class ClickHouseDataTypeMapperFloat64Test {
+
+    /** A MySQL DOUBLE has ~15-17 significant decimal digits; Float32 keeps ~7. */
+    private static final double PRECISE_VALUE = 0.1234567890123456;
+
+    /** The value from issue #1262. */
+    private static final double ISSUE_VALUE = 123456789.123456789;
+
+    private static ClickHouseSinkConnectorConfig emptyConfig() {
+        return new ClickHouseSinkConnectorConfig(new HashMap<>());
+    }
+
+    /** FLOAT64 must map to Float64. Before the fix this returned Float32. */
+    @Test
+    public void float64MapsToFloat64() {
+        ClickHouseDataType chDataType = ClickHouseDataTypeMapper
+                .getClickHouseDataType(Schema.FLOAT64_SCHEMA.type(), null);
+
+        Assert.assertEquals(ClickHouseDataType.Float64, chDataType);
+    }
+
+    /**
+     * FLOAT32 must keep mapping to Float32 -- the fix must not widen the
+     * single-precision type, whose narrowing already happened in Debezium.
+     */
+    @Test
+    public void float32StillMapsToFloat32() {
+        ClickHouseDataType chDataType = ClickHouseDataTypeMapper
+                .getClickHouseDataType(Schema.FLOAT32_SCHEMA.type(), null);
+
+        Assert.assertEquals(ClickHouseDataType.Float32, chDataType);
+    }
+
+    /**
+     * The consumer that actually types auto-created columns. This is the
+     * user-visible defect: the CREATE TABLE column list said Float32.
+     */
+    @Test
+    public void autoCreatedColumnForDoubleIsFloat64() {
+        Field[] fields = new Field[] {
+                new Field("amount_float", 0, Schema.FLOAT32_SCHEMA),
+                new Field("amount_double", 1, Schema.FLOAT64_SCHEMA),
+        };
+
+        Map<String, String> columnToDataTypes = new ClickHouseTableOperationsBase()
+                .getColumnNameToCHDataTypeMapping(fields, emptyConfig());
+
+        Assert.assertEquals(ClickHouseDataType.Float64.name(),
+                columnToDataTypes.get("amount_double"));
+        Assert.assertEquals(ClickHouseDataType.Float32.name(),
+                columnToDataTypes.get("amount_float"));
+    }
+
+    /**
+     * Quantifies what the wrong mapping destroyed: a Float32 column cannot
+     * hold a MySQL DOUBLE. Guards against anyone "simplifying" the two float
+     * entries back into one on the grounds that they look redundant.
+     */
+    @Test
+    public void float32ColumnCannotRepresentADoubleValue() {
+        // Truncation is real, not theoretical.
+        Assert.assertNotEquals(PRECISE_VALUE, (double) (float) PRECISE_VALUE, 0.0);
+        Assert.assertNotEquals(ISSUE_VALUE, (double) (float) ISSUE_VALUE, 0.0);
+
+        // The exact corruption reported in the issue: 123456789.123456789
+        // becomes 123456792 once it is squeezed through 32 bits.
+        Assert.assertEquals(123456792.0d, (double) (float) ISSUE_VALUE, 0.0);
+
+        // The whole representable range of a DOUBLE does not survive either:
+        // Double.MAX_VALUE overflows a Float32 column to infinity.
+        Assert.assertTrue(Float.isInfinite((float) Double.MAX_VALUE));
+        Assert.assertFalse(Double.isInfinite(Double.MAX_VALUE));
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapperInt8Test.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/converters/ClickHouseDataTypeMapperInt8Test.java
@@ -1,0 +1,152 @@
+package com.altinity.clickhouse.sink.connector.converters;
+
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import com.clickhouse.data.ClickHouseDataType;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.ZoneId;
+import java.util.HashMap;
+
+/**
+ * Regression tests for issue #385: an INT8 value hard-cast to
+ * {@link Integer} in {@link ClickHouseDataTypeMapper#convert}.
+ *
+ * <p>{@code convert} groups INT8 and INT32 into one branch
+ * ({@code isFieldTypeInt}) whose terminal case was
+ * {@code ps.setInt(index, (Integer) value)}. An INT8 schema delivers a
+ * {@link Byte}, never an {@link Integer}, so that cast threw
+ *
+ * <pre>ClassCastException: class java.lang.Byte cannot be cast to class java.lang.Integer</pre>
+ *
+ * which is the error in the report -- and it failed the whole batch, so the
+ * connector could not replicate any table holding a MySQL TINYINT.
+ *
+ * <p>The {@code isWiderIntegerTarget} escape hatch just above the cast does not
+ * help here: it only fires for Int32/UInt32/Int64/UInt64 ClickHouse targets,
+ * and an INT8 source column maps to ClickHouse Int8 (or UInt8 when unsigned),
+ * neither of which is in that set. Those two targets are exactly the ones
+ * pinned below.
+ *
+ * <p>The recording {@link PreparedStatement} is a {@link Proxy}, matching the
+ * JDBC test-double idiom already used by
+ * {@code ClickHouseDataTypeMapperBitBytesTest} and
+ * {@code SystemConnectionRefreshTest}. This module has no mocking framework on
+ * its test classpath.
+ */
+public class ClickHouseDataTypeMapperInt8Test {
+
+    /** Records the single binding call {@code convert()} makes for an int value. */
+    private static final class RecordingStatement {
+        private Integer intValue;
+        private Object objectValue;
+        private int callCount;
+
+        private final PreparedStatement statement = (PreparedStatement) Proxy.newProxyInstance(
+                PreparedStatement.class.getClassLoader(),
+                new Class<?>[]{PreparedStatement.class},
+                handler());
+
+        private InvocationHandler handler() {
+            return (proxy, method, args) -> {
+                switch (method.getName()) {
+                    case "setInt":
+                        callCount++;
+                        intValue = (Integer) args[1];
+                        return null;
+                    case "setObject":
+                        callCount++;
+                        objectValue = args[1];
+                        return null;
+                    case "toString":
+                        return "RecordingStatement";
+                    case "hashCode":
+                        return System.identityHashCode(proxy);
+                    case "equals":
+                        return proxy == args[0];
+                    default:
+                        // Nothing else is expected on the integer path. Failing
+                        // loudly keeps an unnoticed behaviour change from
+                        // silently satisfying these assertions.
+                        throw new AssertionError(
+                                "unexpected PreparedStatement call: " + method.getName());
+                }
+            };
+        }
+    }
+
+    private static ClickHouseSinkConnectorConfig config() {
+        return new ClickHouseSinkConnectorConfig(new HashMap<>());
+    }
+
+    private static RecordingStatement convert(Schema.Type type, Object value,
+                                              ClickHouseDataType target) throws SQLException {
+        RecordingStatement recorder = new RecordingStatement();
+        boolean handled = ClickHouseDataTypeMapper.convert(
+                type, null, value, 1, recorder.statement, config(), target, ZoneId.of("UTC"));
+        Assertions.assertTrue(handled, "the integer branch must report the value as handled");
+        Assertions.assertEquals(1, recorder.callCount,
+                "expected exactly one binding call for an integer value");
+        return recorder;
+    }
+
+    /**
+     * The reported case: MySQL TINYINT -&gt; Debezium INT8 -&gt; ClickHouse Int8.
+     * Before the fix this threw
+     * "class java.lang.Byte cannot be cast to class java.lang.Integer".
+     */
+    @Test
+    public void int8ByteIsBoundToInt8Column() throws SQLException {
+        Assertions.assertEquals(Integer.valueOf(42),
+                convert(Schema.Type.INT8, (byte) 42, ClickHouseDataType.Int8).intValue);
+    }
+
+    /** Unsigned TINYINT maps to ClickHouse UInt8, also outside the escape hatch. */
+    @Test
+    public void int8ByteIsBoundToUInt8Column() throws SQLException {
+        Assertions.assertEquals(Integer.valueOf(7),
+                convert(Schema.Type.INT8, (byte) 7, ClickHouseDataType.UInt8).intValue);
+    }
+
+    /** A negative TINYINT must keep its sign, not be reinterpreted as unsigned. */
+    @Test
+    public void negativeInt8KeepsItsSign() throws SQLException {
+        Assertions.assertEquals(Integer.valueOf(-1),
+                convert(Schema.Type.INT8, (byte) -1, ClickHouseDataType.Int8).intValue);
+        Assertions.assertEquals(Integer.valueOf(-128),
+                convert(Schema.Type.INT8, Byte.MIN_VALUE, ClickHouseDataType.Int8).intValue);
+        Assertions.assertEquals(Integer.valueOf(127),
+                convert(Schema.Type.INT8, Byte.MAX_VALUE, ClickHouseDataType.Int8).intValue);
+    }
+
+    /**
+     * The INT32 case that works today must be untouched: still setInt, still
+     * the same value. Int16 is used as the target because it is outside
+     * isWiderIntegerTarget, so this exercises the very line being changed.
+     */
+    @Test
+    public void int32BehaviourIsUnchanged() throws SQLException {
+        Assertions.assertEquals(Integer.valueOf(70000),
+                convert(Schema.Type.INT32, 70000, ClickHouseDataType.Int16).intValue);
+        Assertions.assertEquals(Integer.valueOf(-70000),
+                convert(Schema.Type.INT32, -70000, ClickHouseDataType.Int16).intValue);
+    }
+
+    /**
+     * The isWiderIntegerTarget escape hatch must keep routing to setObject
+     * untouched -- the fix below it must not steal those values.
+     */
+    @Test
+    public void widerIntegerTargetStillUsesSetObject() throws SQLException {
+        RecordingStatement recorder =
+                convert(Schema.Type.INT32, 12345, ClickHouseDataType.UInt64);
+
+        Assertions.assertNull(recorder.intValue, "wider targets must not use setInt");
+        Assertions.assertEquals(12345, recorder.objectValue);
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/converters/DebeziumConverterTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/converters/DebeziumConverterTest.java
@@ -242,6 +242,22 @@ public class DebeziumConverterTest {
     }
 
     @Test
+    @DisplayName("Test ZonedTimestamp converter with PostgreSQL infinity values.")
+    public void testZonedTimestampConverterInfinity() {
+
+        // PostgreSQL timestamptz accepts the special values infinity and
+        // -infinity. Debezium delivers them verbatim as these literal strings
+        // (PostgresValueConverter#convertTimestampWithZone), so the converter has
+        // to map them onto the representable DateTime64 range instead of silently
+        // producing an empty string. See Altinity/clickhouse-sink-connector#1231.
+        String positiveInfinity = DebeziumConverter.ZonedTimestampConverter.convert("infinity", ZoneId.of("UTC"));
+        Assert.assertEquals("2299-12-31 23:59:59.000000", positiveInfinity);
+
+        String negativeInfinity = DebeziumConverter.ZonedTimestampConverter.convert("-infinity", ZoneId.of("UTC"));
+        Assert.assertEquals("1900-01-01 00:00:00.000000", negativeInfinity);
+    }
+
+    @Test
     public void testMicroTimeConverter() {
 
         Object timeInMicroSeconds = LocalTime.of(10, 1, 1, 1).toEpochSecond(LocalDate.now(), ZoneOffset.UTC);

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/batch/VersionFallbackWithoutGtidTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/batch/VersionFallbackWithoutGtidTest.java
@@ -1,0 +1,280 @@
+package com.altinity.clickhouse.sink.connector.db.batch;
+
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import com.altinity.clickhouse.sink.connector.common.SnowFlakeId;
+import com.altinity.clickhouse.sink.connector.db.DBMetadata;
+import com.altinity.clickhouse.sink.connector.model.ClickHouseStruct;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.PreparedStatement;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Issue #1213: the {@code _version} column is filled with an unreadable value
+ * on a MySQL source that has GTID disabled.
+ *
+ * <p>Chain: {@code ClickHouseStruct.version} is initialised to the
+ * {@code UNINITIALIZED_VALUE} sentinel {@code -1}. {@code calculateVersion()}
+ * only assigns a version from a GTID, a sequence number or an LSN; when a
+ * MySQL source runs without GTID none of the three is present on the Kafka
+ * Connect path (nothing in {@code sink-connector/src/main} ever calls
+ * {@code setSequenceNumber} -- only the lightweight
+ * {@code DebeziumChangeEventCapture} does), so the method falls through and
+ * leaves the sentinel in place. The bind site then executes
+ * {@code ps.setLong(index, -1)} into a {@code UInt64} column, which stores
+ * <b>18446744073709551615</b> -- the value the reporter sees, and the value
+ * the JDBC driver then refuses to read back
+ * ({@code ArithmeticException: integer overflow: 18446744073709551615 cannot
+ * be presented as long}).
+ *
+ * <p>The unreadable cell is only the visible symptom. UInt64 max is the
+ * largest representable version, so under ReplacingMergeTree such a row wins
+ * every future deduplication permanently: every later UPDATE and DELETE for
+ * that key is discarded on merge. That is silent, unrecoverable corruption,
+ * which is why a record that cannot produce a version must fail loudly rather
+ * than be written.
+ *
+ * <p>The fallback asserted here reuses the connector's existing, already
+ * shipping version formula: {@code SnowFlakeId.generate(ts_ms, ordering)},
+ * substituting the Kafka offset for the absent GTID. Both inputs ARE populated
+ * on the affected path -- {@code ts_ms} from {@code source.ts_ms} and the
+ * offset from {@code record.kafkaOffset()} -- so no new versioning scheme is
+ * invented and no working deployment changes: a source that supplies a GTID, a
+ * sequence number or an LSN still takes its existing branch, which the
+ * regression tests at the bottom of this class pin.
+ */
+public class VersionFallbackWithoutGtidTest {
+
+    private static final String VERSION_COLUMN = "_version";
+
+    /** What setLong(-1) actually stores in a UInt64 column. */
+    private static final String UINT64_MAX = "18446744073709551615";
+
+    /** A realistic MySQL source commit timestamp (2026-01-01T00:00:00Z). */
+    private static final long SOURCE_TS_MS = 1767225600000L;
+
+    private static PreparedStatementFieldMapper mapper() {
+        return new PreparedStatementFieldMapper(
+                "is_deleted", true, null, VERSION_COLUMN, "test_db", ZoneId.of("UTC"));
+    }
+
+    /**
+     * A PreparedStatement stand-in that records the value bound to the version
+     * column. Mockito is not on the test classpath, so this uses a JDK proxy in
+     * the same style as ClosedConnectionRefreshTest.
+     */
+    private static PreparedStatement recordingStatement(AtomicLong boundVersion) {
+        InvocationHandler h = (proxy, method, args) -> {
+            switch (method.getName()) {
+                case "setLong":
+                    boundVersion.set((Long) args[1]);
+                    return null;
+                case "toString":
+                    return "RecordingPreparedStatement";
+                case "hashCode":
+                    return System.identityHashCode(proxy);
+                case "equals":
+                    return proxy == args[0];
+                default:
+                    return null;
+            }
+        };
+        return (PreparedStatement) Proxy.newProxyInstance(
+                PreparedStatement.class.getClassLoader(),
+                new Class<?>[]{PreparedStatement.class}, h);
+    }
+
+    /**
+     * Drives the real bind path for the version column. handleVersionColumn is
+     * private, so it is reached reflectively -- the point of the test is to
+     * observe what actually reaches the driver, not to re-implement it.
+     */
+    private static void bindVersion(ClickHouseStruct record, PreparedStatement ps) throws Exception {
+        Map<String, Integer> columnNameToIndexMap = new HashMap<>();
+        columnNameToIndexMap.put(VERSION_COLUMN, 1);
+        Map<String, String> columnNameToDataTypeMap = new HashMap<>();
+        columnNameToDataTypeMap.put(VERSION_COLUMN, "UInt64");
+
+        Method method = PreparedStatementFieldMapper.class.getDeclaredMethod(
+                "handleVersionColumn",
+                Map.class, PreparedStatement.class, ClickHouseStruct.class,
+                ClickHouseSinkConnectorConfig.class, Map.class,
+                DBMetadata.TABLE_ENGINE.class);
+        method.setAccessible(true);
+        try {
+            method.invoke(mapper(), columnNameToIndexMap, ps, record,
+                    new ClickHouseSinkConnectorConfig(new HashMap<>()),
+                    columnNameToDataTypeMap,
+                    DBMetadata.TABLE_ENGINE.REPLACING_MERGE_TREE);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception) {
+                throw (Exception) cause;
+            }
+            throw e;
+        }
+    }
+
+    /** The exact record shape produced by MySQL-without-GTID on the Kafka Connect path. */
+    private static ClickHouseStruct mysqlRecordWithoutGtid(long kafkaOffset) {
+        ClickHouseStruct record = new ClickHouseStruct();
+        record.setTopic("SERVER5432.test.employees");
+        record.setKafkaOffset(kafkaOffset);
+        record.setTs_ms(SOURCE_TS_MS);
+        // No GTID (disabled on the source), no sequence number (never set on
+        // this path) and no LSN (not a Postgres source).
+        return record;
+    }
+
+    @Test
+    @DisplayName("#1213: a MySQL record without GTID must not leave the -1 sentinel as its version")
+    public void calculateVersionMustNotFallThroughToSentinel() {
+        ClickHouseStruct record = mysqlRecordWithoutGtid(300023L);
+
+        record.calculateVersion(true);
+
+        assertNotEquals(-1L, record.getVersion(),
+                "calculateVersion() fell through and left the uninitialized sentinel. "
+                        + "Bound with setLong into a UInt64 column that stores " + UINT64_MAX
+                        + ", which no later row can ever supersede under ReplacingMergeTree.");
+        assertTrue(record.getVersion() > 0,
+                "the derived version must be a usable positive ordering value; got "
+                        + record.getVersion());
+    }
+
+    @Test
+    @DisplayName("#1213: the value reaching the driver must not be UInt64 max")
+    public void bindMustNotWriteUint64Max() throws Exception {
+        AtomicLong bound = new AtomicLong(Long.MIN_VALUE);
+        bindVersion(mysqlRecordWithoutGtid(300023L), recordingStatement(bound));
+
+        assertNotEquals(Long.MIN_VALUE, bound.get(), "no version was bound at all");
+        assertNotEquals(UINT64_MAX, Long.toUnsignedString(bound.get()),
+                "the bind wrote the -1 sentinel, stored as UInt64 " + UINT64_MAX
+                        + " -- exactly the value reported in issue #1213, and a version "
+                        + "that permanently wins every ReplacingMergeTree merge");
+        assertTrue(bound.get() > 0,
+                "expected a positive version; got " + bound.get()
+                        + " (unsigned " + Long.toUnsignedString(bound.get()) + ")");
+    }
+
+    @Test
+    @DisplayName("#1213: the fallback reuses the existing SnowFlakeId formula with the Kafka offset")
+    public void fallbackUsesSnowflakeIdWithKafkaOffset() {
+        long kafkaOffset = 300023L;
+        ClickHouseStruct record = mysqlRecordWithoutGtid(kafkaOffset);
+
+        record.calculateVersion(true);
+
+        assertEquals(SnowFlakeId.generate(SOURCE_TS_MS, kafkaOffset, false), record.getVersion(),
+                "the fallback must substitute the Kafka offset into the connector's existing "
+                        + "SnowFlakeId(timestamp, ordering) formula rather than invent a scheme");
+    }
+
+    @Test
+    @DisplayName("#1213: versions stay strictly increasing with the Kafka offset")
+    public void fallbackVersionsAreMonotonicWithinASecond() {
+        ClickHouseStruct first = mysqlRecordWithoutGtid(300023L);
+        ClickHouseStruct second = mysqlRecordWithoutGtid(300024L);
+
+        first.calculateVersion(true);
+        second.calculateVersion(true);
+
+        assertTrue(second.getVersion() > first.getVersion(),
+                "two changes committed in the same millisecond must still be ordered by their "
+                        + "Kafka offset, otherwise ReplacingMergeTree picks between them arbitrarily; "
+                        + "got " + first.getVersion() + " then " + second.getVersion());
+    }
+
+    @Test
+    @DisplayName("#1213: a record with no derivable version at all fails loudly, it is never written")
+    public void unresolvableVersionThrowsInsteadOfBinding() {
+        // No ordering key AND no source timestamp: nothing can be derived.
+        ClickHouseStruct record = new ClickHouseStruct();
+        record.setTopic("SERVER5432.test.employees");
+        record.setKafkaOffset(4242L);
+
+        AtomicLong bound = new AtomicLong(Long.MIN_VALUE);
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                () -> bindVersion(record, recordingStatement(bound)),
+                "with no derivable version the batch must fail loudly; binding the sentinel "
+                        + "writes UInt64 " + UINT64_MAX + ", which is unrecoverable corruption");
+
+        assertEquals(Long.MIN_VALUE, bound.get(),
+                "nothing may be bound once the version is known to be underivable");
+        assertTrue(thrown.getMessage() != null && thrown.getMessage().contains(UINT64_MAX),
+                "the error must name the value that would have been stored so an operator can "
+                        + "recognise it in the table; got: " + thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("SERVER5432.test.employees"),
+                "the error must identify the offending record; got: " + thrown.getMessage());
+    }
+
+    // ---------------------------------------------------------------------
+    // Regression guards: existing, working deployments must be untouched.
+    // These pass both before and after the fix -- they pin that the new
+    // fallback is reachable ONLY from the branch that is currently corrupt.
+    // ---------------------------------------------------------------------
+
+    @Test
+    @DisplayName("a GTID source keeps its existing version, snowflake mode")
+    public void gtidSnowflakeVersionUnchanged() {
+        ClickHouseStruct record = mysqlRecordWithoutGtid(300023L);
+        record.setGtid(2179558590L);
+
+        record.calculateVersion(true);
+
+        assertEquals(SnowFlakeId.generate(SOURCE_TS_MS, 2179558590L, false), record.getVersion(),
+                "a GTID source must still take the GTID branch");
+    }
+
+    @Test
+    @DisplayName("a GTID source keeps its existing version, plain mode")
+    public void gtidPlainVersionUnchanged() {
+        ClickHouseStruct record = mysqlRecordWithoutGtid(300023L);
+        record.setGtid(2179558590L);
+
+        record.calculateVersion(false);
+
+        assertEquals(2179558590L, record.getVersion(),
+                "with snowflake.id disabled the raw GTID must still be used verbatim");
+    }
+
+    @Test
+    @DisplayName("the lightweight sequence-number path is bit-for-bit unchanged")
+    public void sequenceNumberVersionUnchanged() {
+        long sequenceNumber = SOURCE_TS_MS * 1_000_000L + 7L;
+        ClickHouseStruct record = mysqlRecordWithoutGtid(300023L);
+        record.setSequenceNumber(sequenceNumber);
+
+        record.calculateVersion(true);
+
+        assertEquals(sequenceNumber, record.getVersion(),
+                "the lightweight connector always sets a sequence number; its 2.8.0-compatible "
+                        + "version domain must not move");
+    }
+
+    @Test
+    @DisplayName("a Postgres LSN source is unchanged")
+    public void lsnVersionUnchanged() {
+        ClickHouseStruct record = mysqlRecordWithoutGtid(300023L);
+        record.setLsn(987654321L);
+
+        record.calculateVersion(true);
+
+        assertEquals(987654321L, record.getVersion(),
+                "an LSN source must still take the LSN branch");
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchWriterMissingTableTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/executor/ClickHouseBatchWriterMissingTableTest.java
@@ -1,0 +1,216 @@
+package com.altinity.clickhouse.sink.connector.executor;
+
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import com.altinity.clickhouse.sink.connector.converters.ClickHouseConverter;
+import com.altinity.clickhouse.sink.connector.db.DBMetadata;
+import com.altinity.clickhouse.sink.connector.db.HikariDbSource;
+import com.altinity.clickhouse.sink.connector.model.ClickHouseStruct;
+import io.debezium.engine.ChangeEvent;
+import io.debezium.engine.DebeziumEngine;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A Debezium batch carrying records for a table that does not exist in
+ * ClickHouse must not be discarded quietly.
+ *
+ * <p>With {@code auto.create.tables=false} and the target table missing,
+ * {@code DbWriter} cannot read the table metadata, so
+ * {@code processRecordsByTopic} exhausts its retries and returns {@code false}
+ * (the {@code wasTableMetaDataRetrieved()} block in ClickHouseBatchWriter).
+ * The per-topic loop in {@code persistRecords} used to {@code break} on that
+ * and let the method return normally, and the outer {@code catch} swallowed
+ * anything thrown. The caller,
+ * {@code DebeziumChangeEventCapture.appendToRecords}, has no return value to
+ * inspect and no exception to catch, so {@code handleBatch} completed as if
+ * the batch had been written.</p>
+ *
+ * <p>What that costs: the acknowledgement block is skipped, so THIS batch is
+ * never committed -- but the engine moves straight on to the next batch, whose
+ * {@code markBatchFinished()} commits a HIGHER offset. The unwritten records
+ * are then behind the committed offset and are never replayed. Records for
+ * every topic ordered after the failing one in the batch are dropped the same
+ * way, having never been attempted at all.</p>
+ *
+ * <p>This is specific to the single-threaded writer path
+ * ({@code single.threaded=true}, which is what the lightweight connector uses
+ * when configured that way). {@code ClickHouseBatchRunnable} contains the same
+ * {@code break} but survives it: it only clears {@code currentBatch} when the
+ * result is true, so it re-polls and retries the same batch. This writer is
+ * invoked once per batch and has no retry loop, so failing loudly is the only
+ * way for it not to lose data.</p>
+ *
+ * <p>The reproduction points the writer at a ClickHouse that cannot be
+ * reached, which drives {@code wasTableMetaDataRetrieved()} to false through
+ * the same state a missing table produces -- an empty column map and a null
+ * engine -- without needing a live server. The assertions are about the
+ * OUTCOME the issue reports: no exception reaches the caller, and not one
+ * record is acknowledged, so nothing distinguishes a dropped batch from a
+ * written one.</p>
+ *
+ * <p>See issue #1285.</p>
+ */
+public class ClickHouseBatchWriterMissingTableTest {
+
+    /** A port nothing listens on, so metadata retrieval always fails. */
+    private static final int UNREACHABLE_PORT = 1;
+
+    private static final Schema ROW_SCHEMA = SchemaBuilder.struct()
+            .field("id", Schema.INT32_SCHEMA)
+            .field("name", Schema.STRING_SCHEMA)
+            .build();
+
+    /** DBMetadata declared default, restored so this test leaks no state. */
+    private static final int DEFAULT_MAX_RETRIES = 10;
+
+    @BeforeEach
+    public void setUp() {
+        // The metadata helpers retry MAX_RETRIES times per query against a
+        // server that is not there. One attempt reaches the same "still no
+        // metadata" verdict and keeps the test quick.
+        DBMetadata.setMaxRetries(1);
+        HikariDbSource.close();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        DBMetadata.setMaxRetries(DEFAULT_MAX_RETRIES);
+        HikariDbSource.close();
+    }
+
+    /**
+     * Counts what the connector told Debezium about the batch. Both counts
+     * staying at zero while persistRecords returns normally IS the data loss:
+     * the engine is then free to advance past records never written.
+     */
+    private static final class CountingCommitter
+            implements DebeziumEngine.RecordCommitter {
+
+        private final AtomicInteger processed = new AtomicInteger();
+        private final AtomicInteger batchesFinished = new AtomicInteger();
+
+        @Override
+        public void markProcessed(Object record) {
+            this.processed.incrementAndGet();
+        }
+
+        @Override
+        public void markBatchFinished() {
+            this.batchesFinished.incrementAndGet();
+        }
+
+        @Override
+        public void markProcessed(Object record, DebeziumEngine.Offsets offsets) {
+            this.processed.incrementAndGet();
+        }
+
+        @Override
+        public DebeziumEngine.Offsets buildOffsets() {
+            return null;
+        }
+    }
+
+    private static ClickHouseSinkConnectorConfig config() {
+        Map<String, String> props = new HashMap<>();
+        props.put("clickhouse.server.url", "127.0.0.1");
+        props.put("clickhouse.server.port", String.valueOf(UNREACHABLE_PORT));
+        props.put("clickhouse.server.user", "default");
+        props.put("clickhouse.server.password", "");
+        props.put("clickhouse.server.database", "testdb");
+        // The scenario in the issue: the user manages their own schemas, so a
+        // table missing from ClickHouse is never created for them.
+        props.put("auto.create.tables", "false");
+        props.put("single.threaded", "true");
+        props.put("connection.pool.disable", "true");
+        props.put("errors.max.retries", "1");
+        return new ClickHouseSinkConnectorConfig(props);
+    }
+
+    private static ClickHouseStruct record(String topic, long offset,
+                                           CountingCommitter committer,
+                                           boolean lastInBatch) {
+        Struct row = new Struct(ROW_SCHEMA)
+                .put("id", (int) offset)
+                .put("name", "row" + offset);
+        ClickHouseStruct chStruct = new ClickHouseStruct(offset, topic, null, 0,
+                System.currentTimeMillis(), null, row, null,
+                ClickHouseConverter.CDC_OPERATION.CREATE);
+        chStruct.setDatabase("testdb");
+        chStruct.setCommitter(committer);
+        chStruct.setSourceRecord((ChangeEvent<SourceRecord, SourceRecord>) null);
+        chStruct.setLastRecordInBatch(lastInBatch);
+        return chStruct;
+    }
+
+    /**
+     * The regression. A batch whose table is missing from ClickHouse must
+     * raise {@link ClickHouseBatchWriter.BatchPersistenceException} out of
+     * persistRecords. Before the fix persistRecords returned normally, which
+     * let the engine treat the batch as handled and commit past it.
+     */
+    @Test
+    public void missingTableFailsTheBatchInsteadOfDroppingIt() {
+        ClickHouseBatchWriter writer =
+                new ClickHouseBatchWriter(config(), new HashMap<>());
+        CountingCommitter committer = new CountingCommitter();
+
+        List<ClickHouseStruct> batch = new ArrayList<>();
+        batch.add(record("SERVER5432.testdb.orders", 1L, committer, false));
+        batch.add(record("SERVER5432.testdb.orders", 2L, committer, false));
+        // A second table, ordered after the failing one: today these records
+        // are never even attempted.
+        batch.add(record("SERVER5432.testdb.customers", 3L, committer, true));
+
+        RuntimeException thrown = null;
+        try {
+            writer.persistRecords(batch);
+        } catch (RuntimeException e) {
+            thrown = e;
+        }
+
+        // Not one record was acknowledged -- nothing reached ClickHouse.
+        Assert.assertEquals("no record may be acknowledged when the batch was not written",
+                0, committer.processed.get());
+        Assert.assertEquals("the batch must not be marked finished when it was not written",
+                0, committer.batchesFinished.get());
+
+        // ... and because nothing was acknowledged, the ONLY thing that can
+        // stop the engine from committing a later, higher offset over these
+        // records is a failure reaching the caller.
+        Assert.assertNotNull("persistRecords returned normally after failing to write the batch: "
+                        + "the caller cannot tell the batch was dropped, so the offset advances "
+                        + "past records that never reached ClickHouse (issue #1285)",
+                thrown);
+        Assert.assertTrue("the failure must be reported as a batch persistence failure, got: "
+                        + thrown.getClass().getName(),
+                thrown instanceof ClickHouseBatchWriter.BatchPersistenceException);
+        Assert.assertTrue("the failure must name the topic it could not persist, got: "
+                        + thrown.getMessage(),
+                thrown.getMessage() != null
+                        && thrown.getMessage().contains("SERVER5432.testdb."));
+    }
+
+    /**
+     * An empty batch has nothing to fail on and must stay silent -- the fix
+     * must not turn a no-op into a connector restart.
+     */
+    @Test
+    public void emptyBatchIsNotAFailure() {
+        ClickHouseBatchWriter writer =
+                new ClickHouseBatchWriter(config(), new HashMap<>());
+
+        writer.persistRecords(new ArrayList<>());
+    }
+}


### PR DESCRIPTION
## Summary

`get_table_checksum_query()` in `clickhouse_table_checksum.py` can silently re-add a column the user explicitly excluded, making the ClickHouse checksum hash a different column set than the MySQL side. When that happens the checksum for the affected table can **never** match, and no `--exclude_columns` / `ignored_columns` value can suppress it.

## Root cause

The un-exclusion rule was introduced for the connector's `is_deleted` / `_is_deleted` pair:

```python
prefixed_column = "_"+row[0]
if row[0] in excluded_columns and prefixed_column in columns_metadata_map:
    logging.info(f"Not excluding column {row[0]} as {prefixed_column} is also excluded")
elif row[0] in excluded_columns:
    logging.info(f"Excluding column {row[0]}")
    continue
filtered_columns_metadata.append(row)
```

The condition matches on the underscore prefix **alone**, so it fires for any excluded column whose `_`-prefixed name happens to exist on the table — not just connector metadata.

A table with a business column `version` and the connector's `_version` hits this: `version` is un-excluded on the ClickHouse side, while `mysql_table_checksum.py` still honours the exclusion. The two sides hash different column sets.

The asymmetry is invisible in the logs — the ClickHouse side logs `Not excluding column version as _version is also excluded` as an INFO line, while the top-level job reports only a checksum mismatch, which reads as a data divergence.

## Reproduction

A table with both `version` and `_version`, excluding `version`:

```
Column set hashed   Result
-----------------   ------
MySQL side          id, bunit, date                (version excluded, as requested)
ClickHouse side     id, bunit, date, version       (version silently re-added)
```

Observed on a table of 1,407,663 rows where every column value is byte-identical between MySQL and ClickHouse. Re-computing the tool's own hash arithmetic over both sides confirms the data agrees and only the column set differs:

```
Column set                          MySQL bucket hash    ClickHouse bucket hash   Match
--------------------------------    -----------------    ----------------------   -----
id,bunit,date        (both sides)      429610042465157         429610042465157     yes
id,bunit,date,version (both sides)     429390065739979         429390065739979     yes
```

Both sides agree under *either* consistent column set. The mismatch exists only in the asymmetric set the tool actually builds.

Natural control on the same schema: a sibling table with `_version` but **no** `version` column passes cleanly.

## Fix

Restrict the un-exclusion rule to columns the connector itself manages:

```python
SINK_METADATA_COLUMNS = frozenset(
    {"_sign", "_version", "is_deleted", "_is_deleted", "__is_deleted"}
)
```

```python
if (row[0] in excluded_columns
        and prefixed_column in columns_metadata_map
        and row[0] in SINK_METADATA_COLUMNS):
```

- `is_deleted` remains in the set, so the original `is_deleted`/`_is_deleted` behaviour the rule was written for is unchanged.
- `version` is not connector metadata, so a user-supplied exclusion is now honoured.
- Fails safe: an unrecognised column name is now excluded as asked, rather than silently re-added.

The set matches the metadata columns the tooling already treats as connector-owned — `clickhouse_table_checksum.py` defaults `--exclude_columns` to `_sign,_version,is_deleted,_is_deleted`, and `top_level_table_checksum.py` always passes `_version,is_deleted,_is_deleted,__is_deleted`. A user column such as `version` never enters the excluded list except via explicit user configuration, which is precisely the intent that must not be overridden.

## Verification

Simulating the filter over the real affected column list (`id, risk, bunit, date, _version, is_deleted, version, clientupdatetime, action, state, user`) excluding `_version, is_deleted, _is_deleted, __is_deleted, version, clientupdatetime, action, state, user, risk`:

```
             Columns hashed on the ClickHouse side
before fix   ['id', 'bunit', 'date', 'version']     <- version wrongly re-added
after fix    ['id', 'bunit', 'date']                <- matches the MySQL side
```

Regression check on the pair the rule exists for (`id, val, is_deleted, _is_deleted`):

```
before fix   ['id', 'val', 'is_deleted']
after fix    ['id', 'val', 'is_deleted']            <- unchanged
```

`python -m py_compile` passes on the modified file.

## Scope

One file, two hunks, no behaviour change for any table without a business column colliding with a connector metadata name. Tables affected by the bug today are only those carrying a column whose `_`-prefixed twin also exists.

## Suggested follow-up

A regression test covering a table with both `version` and `_version`, asserting `version` is absent from the generated select. This is the case that reads as correct under any single-column test, which is why it survived.

---

Filed by OmniWatcher, an AI agent, on behalf of the Jump Trading DBA team, at the request of a senior DBA. Marked **WIP / DO NOT MERGE** because we do not own this repository — please treat it as a proposal for maintainer review rather than a ready-to-merge change, and tell us if you would prefer a different shape for the fix (for example, deriving the metadata set from existing constants). Happy to add the regression test in this PR if you want it here rather than as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
