### PR TITLE
fix: MATERIALIZED column metadata storm, and report a shadowed source value

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,136 @@
+# AGENTS.md — read this before changing anything in this repository
+
+This file is the standing context for every agent (and every human) working
+on this codebase. Read it before proposing, writing, reviewing, or merging
+any change. It is not background reading — it is the rule that decides
+arguments.
+
+## ⛔ THE PRIME DIRECTIVE: MySQL is the source of truth
+
+**This project is a replication engine from a transactional source
+database (MySQL, PostgreSQL) into ClickHouse.**
+
+That single sentence settles most design questions in this repo, so state it
+plainly:
+
+1. **The source data is the truth, and the source is always correct.**
+   The source database defines what the data *is*. There is no scenario in
+   which this connector decides the source is wrong. (Throughout this file
+   "MySQL" stands for whichever source you are replicating; the rule is
+   identical for PostgreSQL.)
+2. **The ClickHouse side must CONFORM to MySQL.** ClickHouse is the replica.
+   Its schema, its column set, its values, and its types exist to reproduce
+   what MySQL holds.
+3. **Every mismatch is fixed by making ClickHouse match MySQL — always.**
+   A divergence is never resolved by adjusting, reinterpreting, or excusing
+   the MySQL side, and never by declaring the ClickHouse state acceptable.
+   The direction of the fix is fixed: ClickHouse moves to MySQL.
+
+### What this means when you are deciding something
+
+Any time you are weighing a design choice, a bug fix, a schema rule, a
+conflict-resolution policy, or a "which side is right?" question, resolve it
+with the prime directive:
+
+- If a value differs between MySQL and ClickHouse → **the MySQL value is
+  correct.** Write the MySQL value. Do not preserve, prefer, or defend the
+  ClickHouse value.
+- If a column exists in MySQL but not usefully in ClickHouse → **the
+  ClickHouse side is wrong or incomplete.** Fix the ClickHouse side.
+- If a type or precision cannot round-trip → that is a defect in the
+  ClickHouse mapping, not an acceptable loss. Report it loudly; never
+  silently narrow, truncate, or default the value.
+- If you are tempted to write "the connector correctly excludes X" — stop.
+  Verify against MySQL first. "Correct" is defined by the source, not by
+  what the current code happens to do.
+
+### Column-kind rules (ClickHouse side)
+
+These follow directly from the prime directive and are the specific rules
+that have caused real production incidents:
+
+| ClickHouse column kind | Rule |
+|---|---|
+| **ALIAS** | **Ignore it.** An ALIAS column is not stored and cannot be written. It is a query-time expression, never part of the replicated row. |
+| **MATERIALIZED** | **If MySQL defines a column of the same name, the MySQL value WINS and must be written.** A MATERIALIZED definition on the ClickHouse side must never silently shadow, override, or discard a value the source supplies. ClickHouse computing something locally does not make it the truth — MySQL is the truth. If a MATERIALIZED column blocks writing the source value, the MATERIALIZED definition is the thing that is wrong, and the fix is on the ClickHouse side. |
+| **DEFAULT / ordinary** | Normal replicated column. Bind the source value, including NULL. Never let a ClickHouse DEFAULT stand in for a value MySQL actually sent. |
+
+The trap: a column that is MATERIALIZED in ClickHouse *and* present in
+MySQL looks, to code that only inspects the ClickHouse catalog, like a
+column ClickHouse owns. It is not. If MySQL sends it, it belongs to MySQL.
+Any code path that decides column membership must therefore ask what MySQL
+sent, not only what the ClickHouse metadata says.
+
+### Failures this directive is meant to prevent
+
+Every one of these has actually happened in this codebase:
+
+- A NULL-valued source column being dropped from the INSERT, so ClickHouse
+  substituted a column DEFAULT (`0` / `''` / `1970-01-01`) instead of NULL.
+  Row counts matched; only a value-level checksum caught it.
+- A newly added source column being replicated as schema but never
+  backfilled, leaving a large historical range blank on the ClickHouse side
+  while MySQL held the values.
+- Treating a MATERIALIZED column as "correctly excluded" ClickHouse-owned
+  state, rather than asking whether MySQL defines it.
+- A per-record metadata re-read loop caused by mistaking a permanently
+  ClickHouse-computed column for a stale cache.
+
+The common shape: **the connector inferred correctness from the ClickHouse
+side alone.** Do not do that. Check the source.
+
+## Silence is the enemy
+
+Because MySQL is the truth, any divergence is a defect — so it must be
+loud:
+
+- **Never swallow, mute, or downgrade a replication error** to make a batch
+  succeed. A failed batch that retries is recoverable; a batch that writes
+  wrong data and reports success is not.
+- **Never let row counts stand in for correctness.** Every incident above
+  had matching row counts. Value-level comparison
+  (`db_compare/` checksum tooling) is the only proof of agreement.
+- **Never declare "in sync", "converged", or "false positive"** on a
+  checksum failure without comparing actual column VALUES against the MySQL
+  host the checksum job locked, and naming *why* the checksum differed in
+  the first place. "It just converged" is not an explanation.
+
+## Working rules for changes in this repo
+
+1. **Verify against the live source, not the code.** Reading a DDL file or
+   a config does not tell you what MySQL holds. Query it.
+2. **Trace the full path before changing a flag.** config → generator →
+   template → consumer → runtime effect. A flag whose mechanism does not
+   achieve the intent is not a fix.
+3. **Do not break existing behaviour to fix new behaviour.** Search for
+   consumers of anything you change; fix them in the same change or
+   abandon it.
+4. **Add a regression test that fails without your fix.** Mutation-check
+   it: break the fix, confirm the test goes red. A test that passes either
+   way protects nothing.
+5. **Schema-cache and metadata code is high-risk.** It decides INSERT
+   column membership, so a mistake there is silent data divergence, not a
+   crash. Changes here need value-level verification, not just green unit
+   tests.
+
+## Repository shape
+
+- `sink-connector/` — the Kafka Connect sink: batching, schema cache,
+  query construction, ClickHouse writes.
+- `sink-connector-lightweight/` — the standalone (embedded Debezium)
+  runtime.
+- `sink-connector-client/` — client/CLI.
+- `sink-connector/python/db_compare/` — source↔ClickHouse count and checksum
+  comparison tooling. This is the ground truth for "are the two sides
+  actually equal?".
+- `doc/` — feature matrix and reference docs.
+
+Build with JDK 17 and Maven; `mvn -o test` works offline once dependencies
+are cached.
+
+## If this file conflicts with something else
+
+The prime directive wins. If a comment, a doc, an old commit message, or
+your own reasoning suggests that the ClickHouse side should be preserved
+over the MySQL side, that source is wrong and should be corrected in the
+same change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,39 @@ plainly:
    A divergence is never resolved by adjusting, reinterpreting, or excusing
    the MySQL side, and never by declaring the ClickHouse state acceptable.
    The direction of the fix is fixed: ClickHouse moves to MySQL.
+4. **The connector is the ENFORCER of that rule, not a reporter of it.**
+   It does not merely detect divergence and describe it — it makes
+   ClickHouse correct according to MySQL. When the ClickHouse side is in a
+   shape that prevents the source value from being stored, the connector
+   changes the ClickHouse side so it can be stored. **Reporting is the
+   fallback for when enforcement genuinely fails, never the default.**
+
+### Enforcement, concretely
+
+Enforcement is an action, so it has a shape. Whenever you find the replica
+unable to hold what the source sent:
+
+- **Correct the ClickHouse side automatically** where a safe, bounded
+  operation exists. A MATERIALIZED column shadowing a source value is
+  fixed with `ALTER TABLE ... MODIFY COLUMN <col> <type>`, restating the
+  type with no default expression — metadata-only, no part rewrite, on the
+  same DDL path the connector already uses for schema evolution.
+- **Enforcement has two halves, and the second is easy to forget.**
+  Correcting the definition fixes the write path *forward*. Rows already
+  written while the definition was wrong still hold the wrong values, and
+  reconciling those is a **backfill** of the affected range. A change that
+  fixes only the forward path is half-done — say so explicitly in the log
+  and in the PR, so the remaining work is visible rather than assumed done.
+- **Log the enforcement, loudly.** An automatic schema correction is a real
+  event: record what was wrong, what was changed, and what still needs
+  backfilling.
+- **Only when enforcement cannot be performed** — the DDL is rejected, the
+  privilege is missing, the type cannot be read — do you fall back to a
+  warning naming the manual remediation.
+
+Do not write code whose response to a divergence is only a log line. If you
+find yourself describing a fix for a human to apply, ask first whether the
+connector can apply it.
 
 ### What this means when you are deciding something
 
@@ -52,7 +85,7 @@ that have caused real production incidents:
 | ClickHouse column kind | Rule |
 |---|---|
 | **ALIAS** | **Ignore it.** An ALIAS column is not stored and cannot be written. It is a query-time expression, never part of the replicated row. |
-| **MATERIALIZED** | **If MySQL defines a column of the same name, the MySQL value WINS and must be written.** A MATERIALIZED definition on the ClickHouse side must never silently shadow, override, or discard a value the source supplies. ClickHouse computing something locally does not make it the truth — MySQL is the truth. If a MATERIALIZED column blocks writing the source value, the MATERIALIZED definition is the thing that is wrong, and the fix is on the ClickHouse side. |
+| **MATERIALIZED** | **If MySQL defines a column of the same name, the MySQL value WINS and must be written.** A MATERIALIZED definition on the ClickHouse side must never silently shadow, override, or discard a value the source supplies. ClickHouse computing something locally does not make it the truth — MySQL is the truth. If a MATERIALIZED column blocks writing the source value, the MATERIALIZED definition is the thing that is wrong, and **the connector corrects it** — `ALTER TABLE ... MODIFY COLUMN` strips the expression so the source value is stored from then on, and the rows written before that are backfilled. |
 | **DEFAULT / ordinary** | Normal replicated column. Bind the source value, including NULL. Never let a ClickHouse DEFAULT stand in for a value MySQL actually sent. |
 
 The trap: a column that is MATERIALIZED in ClickHouse *and* present in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE.md
+
+Read [AGENTS.md](AGENTS.md) before making any change to this repository.
+
+It carries the prime directive for this codebase, which decides most design
+questions here:
+
+> **This project is a replication engine from a transactional source
+> database (MySQL, PostgreSQL) into ClickHouse. The source data is the
+> truth and the source is always correct. The ClickHouse side must conform
+> to the source, and every mismatch is fixed by making ClickHouse match the
+> source — always.**
+
+Two rules from it that are wrong most often, so they are repeated here:
+
+- **ALIAS columns:** ignore them. Not stored, so nothing can diverge.
+- **MATERIALIZED columns:** these *are* stored, computed by ClickHouse. If
+  the source also defines a column of that name, the replica silently holds
+  ClickHouse's derived value instead of the source's — no error, matching
+  row counts. That is a real divergence, and the remediation is on the
+  ClickHouse side.
+
+AGENTS.md also covers the fail-loudly rules, the value-level verification
+requirement (row counts are not proof), and the repository layout.

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/CacheInvalidationManager.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/CacheInvalidationManager.java
@@ -48,7 +48,7 @@ public class CacheInvalidationManager {
      * cached column map. {@code DBMetadata#getColumnsDataTypesForTable}
      * deliberately drops columns whose {@code default_kind} is
      * {@code MATERIALIZED} or {@code ALIAS}, because ClickHouse computes those
-     * and refuses an INSERT that binds them. A source column that is
+     * and refuses an INSERT that binds them. A source column that was made
      * MATERIALIZED on the ClickHouse side is therefore absent from the map
      * permanently and correctly -- it is not evidence of a stale cache, and
      * re-reading metadata will never make it appear.</p>

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/CacheInvalidationManager.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/CacheInvalidationManager.java
@@ -40,6 +40,29 @@ public class CacheInvalidationManager {
     private final Map<String, Long> tableVersions = new ConcurrentHashMap<>();
 
     /**
+     * Columns proven, by a fresh metadata read, NOT to be part of a table's
+     * writable column map -- keyed by "database.table", then by lower-cased
+     * column name, valued with the table version the proof was taken at.
+     *
+     * <p>Not every column carried by a CDC record is expected to appear in the
+     * cached column map. {@code DBMetadata#getColumnsDataTypesForTable}
+     * deliberately drops columns whose {@code default_kind} is
+     * {@code MATERIALIZED} or {@code ALIAS}, because ClickHouse computes those
+     * and refuses an INSERT that binds them. A source column that is
+     * MATERIALIZED on the ClickHouse side is therefore absent from the map
+     * permanently and correctly -- it is not evidence of a stale cache, and
+     * re-reading metadata will never make it appear.</p>
+     *
+     * <p>Recording that proof is what stops the re-read from repeating per
+     * record. The version is stored alongside so a later genuine DDL (which
+     * bumps the version) discards the proof and the column is probed once
+     * more -- covering the case where a MATERIALIZED column is redefined as
+     * an ordinary one.</p>
+     */
+    private final Map<String, Map<String, Long>> columnsProvenAbsent =
+            new ConcurrentHashMap<>();
+
+    /**
      * Private constructor to enforce singleton pattern.
      */
     private CacheInvalidationManager() {
@@ -123,10 +146,72 @@ public class CacheInvalidationManager {
             new java.util.concurrent.atomic.AtomicLong();
 
     /**
+     * Records that a fresh metadata read proved {@code columnName} is not part
+     * of {@code tableName}'s writable column map at the current table version.
+     *
+     * <p>Called after a re-read that did not resolve the apparent staleness.
+     * The only way that happens is a column ClickHouse owns -- MATERIALIZED or
+     * ALIAS -- which {@code getColumnsDataTypesForTable} filters out by design.
+     * Without this record the caller re-reads metadata for the same column on
+     * every subsequent record forever.</p>
+     *
+     * @param tableName  fully qualified table name ("database.table").
+     * @param columnName the column proven absent; compared case-insensitively.
+     */
+    public void markColumnProvenAbsent(String tableName, String columnName) {
+        if (tableName == null || tableName.isEmpty()
+                || columnName == null || columnName.isEmpty()) {
+            return;
+        }
+        columnsProvenAbsent
+                .computeIfAbsent(tableName, k -> new ConcurrentHashMap<>())
+                .put(columnName.toLowerCase(), getVersion(tableName));
+    }
+
+    /**
+     * Returns true if {@code columnName} was already proven absent from
+     * {@code tableName} at the table's CURRENT version.
+     *
+     * <p>A proof taken at an older version is ignored (and discarded), because
+     * a DDL since then may have turned the column into an ordinary one that a
+     * re-read would now find.</p>
+     *
+     * @param tableName  fully qualified table name ("database.table").
+     * @param columnName the column to test; compared case-insensitively.
+     * @return true when a re-read for this column would be pointless.
+     */
+    public boolean isColumnProvenAbsent(String tableName, String columnName) {
+        if (tableName == null || tableName.isEmpty()
+                || columnName == null || columnName.isEmpty()) {
+            return false;
+        }
+        Map<String, Long> proven = columnsProvenAbsent.get(tableName);
+        if (proven == null) {
+            return false;
+        }
+        Long provenAt = proven.get(columnName.toLowerCase());
+        if (provenAt == null) {
+            return false;
+        }
+        // longValue() is explicit on purpose: `provenAt == getVersion(...)`
+        // would read as a reference comparison even though it unboxes here,
+        // and a later refactor returning a boxed Long would silently make it
+        // one -- which fails above the Long cache and reinstates the storm.
+        if (provenAt.longValue() == getVersion(tableName)) {
+            return true;
+        }
+        // Stale proof: a DDL landed after it was taken. Drop it so the column
+        // is probed once against the new schema.
+        proven.remove(columnName.toLowerCase());
+        return false;
+    }
+
+    /**
      * Clears all invalidation versions. Useful for testing.
      */
     public void clearAll() {
         tableVersions.clear();
+        columnsProvenAbsent.clear();
         globalEpoch.set(0L);
     }
 

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DBMetadata.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DBMetadata.java
@@ -593,6 +593,121 @@ public class DBMetadata {
     }
 
     /**
+     * Returns the declared type of a single column, or null when the column
+     * does not exist in ClickHouse or cannot be read.
+     *
+     * <p>Needed to rewrite a column definition: {@code MODIFY COLUMN} must
+     * restate the type, and restating it from anywhere other than
+     * {@code system.columns} risks changing it by accident.</p>
+     *
+     * @param tableName    the ClickHouse table name.
+     * @param databaseName the ClickHouse database name.
+     * @param columnName   the column to look up; matched case-insensitively.
+     * @param conn         the connection to read metadata with.
+     * @return the column's declared type, or null.
+     */
+    public String getColumnType(String tableName, String databaseName,
+                                String columnName, Connection conn) {
+        if (tableName == null || databaseName == null || columnName == null
+                || conn == null) {
+            return null;
+        }
+        String query = String.format(
+                "SELECT type FROM system.columns WHERE database = '%s' "
+                        + "AND table = '%s' AND lower(name) = lower('%s')",
+                databaseName, tableName, columnName);
+        try (ResultSet rs = conn.createStatement().executeQuery(query)) {
+            if (rs != null && rs.next()) {
+                return rs.getString(1);
+            }
+        } catch (Exception e) {
+            log.warn("Could not read the declared type of {}.{}.{}",
+                    databaseName, tableName, columnName, e);
+        }
+        return null;
+    }
+
+    /**
+     * Strips a column's DEFAULT-kind expression so the connector can write
+     * the source's value into it, and returns whether the column is now
+     * writable.
+     *
+     * <p>This is the enforcement half of the replication contract. The source
+     * database is the authority on what the data is, and this connector is
+     * what makes ClickHouse agree with it. A column defined MATERIALIZED on
+     * the ClickHouse side breaks that: ClickHouse computes and stores its own
+     * value, the source's value for the same column is never written, and the
+     * two sides disagree silently -- no error, no failed batch, identical row
+     * counts. Reporting that is not enough. The ClickHouse definition is the
+     * thing that is wrong, so the connector corrects it.</p>
+     *
+     * <p>{@code ALTER TABLE ... MODIFY COLUMN <col> <type>} restates the
+     * column with no default expression, which drops the MATERIALIZED clause
+     * and leaves an ordinary column. It is a metadata-only change: existing
+     * parts are not rewritten, so it is cheap and does not block.</p>
+     *
+     * <p><b>It fixes the write path forward, not history.</b> Rows written
+     * while the column was MATERIALIZED still hold ClickHouse's computed
+     * values; reconciling those is a backfill, and the caller is told so.</p>
+     *
+     * @param tableName    the ClickHouse table name.
+     * @param databaseName the ClickHouse database name.
+     * @param columnName   the column whose default expression is removed.
+     * @param columnType   the column's declared type, restated verbatim.
+     * @param conn         the connection to issue the DDL on.
+     * @return true when the column was successfully made writable.
+     */
+    public boolean makeColumnWritable(String tableName, String databaseName,
+                                      String columnName, String columnType,
+                                      Connection conn) {
+        if (tableName == null || databaseName == null || columnName == null
+                || columnType == null || columnType.isEmpty() || conn == null) {
+            return false;
+        }
+        // Backticks, not plain identifiers: replicated table and column names
+        // routinely contain characters ClickHouse would otherwise parse.
+        String ddl = String.format(
+                "ALTER TABLE `%s`.`%s` MODIFY COLUMN `%s` %s",
+                databaseName, tableName, columnName, columnType);
+        try {
+            log.info("Enforcing source conformance on {}.{}: {}",
+                    databaseName, tableName, ddl);
+            executeSystemQuery(conn, ddl);
+        } catch (Exception e) {
+            log.warn("Could not make {}.{}.{} writable; the source value for "
+                            + "this column cannot be stored until the "
+                            + "ClickHouse definition is corrected.",
+                    databaseName, tableName, columnName, e);
+            return false;
+        }
+
+        // Confirm the enforcement actually took effect rather than trusting
+        // the absence of an exception. executeSystemQuery retries a failing
+        // statement and, once the retry budget is spent, RETURNS NORMALLY --
+        // so a rejected ALTER (missing privilege, unsupported change) is
+        // indistinguishable from a successful one at the call site. Reporting
+        // success there would be the worst possible outcome: the caller would
+        // believe the replica had been corrected and stop warning, while the
+        // source value continued to be silently discarded.
+        String kindAfter = getColumnDefaultKind(tableName, databaseName,
+                columnName, conn);
+        boolean stillShadowed = "MATERIALIZED".equalsIgnoreCase(kindAfter)
+                || "ALIAS".equalsIgnoreCase(kindAfter);
+        if (stillShadowed || kindAfter == null) {
+            log.warn("Enforcement did not take effect on {}.{}.{}: its "
+                            + "default_kind is still '{}' after the ALTER. The "
+                            + "source value for this column is still not being "
+                            + "stored -- correct the ClickHouse definition by "
+                            + "hand, or grant the connector ALTER TABLE on this "
+                            + "table.",
+                    databaseName, tableName, columnName,
+                    kindAfter == null ? "unreadable" : kindAfter);
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * Returns the {@code default_kind} of a single column, or null when the
      * column does not exist in ClickHouse.
      *
@@ -754,7 +869,13 @@ public class DBMetadata {
      * dictionaries (487) and columns (44/15).</p>
      */
     private static final Set<Integer> NON_RETRYABLE_ERROR_CODES = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(15, 44, 47, 57, 60, 62, 81, 82, 487)));
+            // 497 ACCESS_DENIED is deterministic in exactly the same way as
+            // the rest: a privilege the connector does not hold will not be
+            // granted by sleeping. It matters most for the enforcement path
+            // (ALTER TABLE ... MODIFY COLUMN), where retrying a denied ALTER
+            // blocks the CDC/DDL thread for the whole retry budget and still
+            // fails.
+            new HashSet<>(Arrays.asList(15, 44, 47, 57, 60, 62, 81, 82, 487, 497)));
 
     /**
      * Decides whether a failed statement can plausibly succeed on a retry.

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DBMetadata.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/DBMetadata.java
@@ -593,6 +593,58 @@ public class DBMetadata {
     }
 
     /**
+     * Returns the {@code default_kind} of a single column, or null when the
+     * column does not exist in ClickHouse.
+     *
+     * <p>The connector replicates a source database into ClickHouse, so the
+     * source is the authority on what the data is. That makes ALIAS and
+     * MATERIALIZED two very different situations, even though
+     * {@link #getColumnsDataTypesForTable} excludes both from the writable
+     * column map:</p>
+     *
+     * <ul>
+     *   <li><b>ALIAS</b> is not stored at all. There is nothing to diverge,
+     *       so a source column that is ALIAS here is simply ignored.</li>
+     *   <li><b>MATERIALIZED</b> IS stored, and ClickHouse computes it. If the
+     *       source also supplies that column, the stored value is whatever
+     *       ClickHouse derived rather than what the source sent -- the
+     *       replica silently disagrees with its source, with no error and
+     *       matching row counts.</li>
+     * </ul>
+     *
+     * <p>Distinguishing the two is what lets the caller stay silent about the
+     * former and report the latter.</p>
+     *
+     * @param tableName    the ClickHouse table name.
+     * @param databaseName the ClickHouse database name.
+     * @param columnName   the column to look up; matched case-insensitively.
+     * @param conn         the connection to read metadata with.
+     * @return the column's {@code default_kind} (possibly an empty string for
+     *         an ordinary column), or null when it cannot be determined.
+     */
+    public String getColumnDefaultKind(String tableName, String databaseName,
+                                       String columnName, Connection conn) {
+        if (tableName == null || databaseName == null || columnName == null
+                || conn == null) {
+            return null;
+        }
+        String query = String.format(
+                "SELECT default_kind FROM system.columns WHERE database = '%s' "
+                        + "AND table = '%s' AND lower(name) = lower('%s')",
+                databaseName, tableName, columnName);
+        try (ResultSet rs = conn.createStatement().executeQuery(query)) {
+            if (rs != null && rs.next()) {
+                String kind = rs.getString(1);
+                return kind == null ? "" : kind;
+            }
+        } catch (Exception e) {
+            log.warn("Could not read default_kind for {}.{}.{}", databaseName,
+                    tableName, columnName, e);
+        }
+        return null;
+    }
+
+    /**
      * Retrieves the set of column names that are aliases or materialized columns
      * for a given table and database.
      *

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/GroupInsertQueryWithBatchRecords.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/GroupInsertQueryWithBatchRecords.java
@@ -317,15 +317,28 @@ public class GroupInsertQueryWithBatchRecords {
             }
         }
 
+        String fullyQualifiedTableName = databaseName + "." + tableName;
+        CacheInvalidationManager invalidation = CacheInvalidationManager.getInstance();
+
         String unknown = null;
         for (Field field : struct.schema().fields()) {
             if (field == null || field.name() == null) {
                 continue;
             }
-            if (!known.contains(field.name().toLowerCase())) {
-                unknown = field.name();
-                break;
+            if (known.contains(field.name().toLowerCase())) {
+                continue;
             }
+            // A column already proven absent by a fresh read is not evidence of
+            // staleness: ClickHouse owns it (MATERIALIZED / ALIAS) and no
+            // re-read will ever produce it. Skipping it here is what keeps the
+            // probe at one metadata query per column per DDL generation rather
+            // than one per record.
+            if (invalidation.isColumnProvenAbsent(
+                    fullyQualifiedTableName, field.name())) {
+                continue;
+            }
+            unknown = field.name();
+            break;
         }
         if (unknown == null) {
             return null;
@@ -339,11 +352,32 @@ public class GroupInsertQueryWithBatchRecords {
             Map<String, String> fresh = new DBMetadata(config)
                     .getColumnsDataTypesForTable(tableName, connection, databaseName);
             if (fresh != null && !fresh.isEmpty()) {
-                // Bump the shared version so every other cached writer for this
-                // table rebuilds too, rather than each one rediscovering the
-                // staleness independently on its own next batch.
-                CacheInvalidationManager.getInstance()
-                        .invalidateTable(databaseName + "." + tableName);
+                if (containsColumn(fresh, unknown)) {
+                    // The re-read resolved the staleness. Bump the shared
+                    // version so every other cached writer for this table
+                    // rebuilds too, rather than each one rediscovering the
+                    // staleness independently on its own next batch.
+                    invalidation.invalidateTable(fullyQualifiedTableName);
+                    return fresh;
+                }
+                // The re-read did NOT produce the column, so the cache was
+                // never stale. The column is one ClickHouse computes --
+                // getColumnsDataTypesForTable filters MATERIALIZED and ALIAS
+                // out by design, because binding them makes ClickHouse reject
+                // the INSERT. Record the proof and use the fresh map.
+                //
+                // Without the proof this path repeats for EVERY record, and
+                // the invalidateTable() on top of it makes every cached writer
+                // for the table rebuild on its next batch. The result is an
+                // unbounded system.columns query storm for as long as the
+                // table keeps receiving traffic -- see the PR description for
+                // a measured production case.
+                log.info("Column '{}' is not part of {}'s writable column map after a "
+                                + "fresh read; it is computed by ClickHouse (MATERIALIZED "
+                                + "or ALIAS) and is correctly excluded. Recording this so "
+                                + "the metadata read is not repeated per record.",
+                        unknown, fullyQualifiedTableName);
+                invalidation.markColumnProvenAbsent(fullyQualifiedTableName, unknown);
                 return fresh;
             }
             log.warn("Re-read of {}.{} returned no columns; keeping the cached map. The "
@@ -355,6 +389,30 @@ public class GroupInsertQueryWithBatchRecords {
                     databaseName, tableName, e);
         }
         return null;
+    }
+
+    /**
+     * Case-insensitive membership test against a column map's key set.
+     *
+     * <p>The cached map is compared case-insensitively everywhere else in this
+     * class, so the post-re-read check must be too -- otherwise a column whose
+     * ClickHouse casing differs from the source's would be judged still-missing
+     * and marked proven-absent even though the re-read did resolve it.</p>
+     *
+     * @param columns    the column map to search.
+     * @param columnName the column name to look for.
+     * @return true when the map contains the column under any casing.
+     */
+    private boolean containsColumn(Map<String, String> columns, String columnName) {
+        if (columns == null || columnName == null) {
+            return false;
+        }
+        for (String column : columns.keySet()) {
+            if (column != null && column.equalsIgnoreCase(columnName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/GroupInsertQueryWithBatchRecords.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/GroupInsertQueryWithBatchRecords.java
@@ -361,22 +361,29 @@ public class GroupInsertQueryWithBatchRecords {
                     return fresh;
                 }
                 // The re-read did NOT produce the column, so the cache was
-                // never stale. The column is one ClickHouse computes --
-                // getColumnsDataTypesForTable filters MATERIALIZED and ALIAS
-                // out by design, because binding them makes ClickHouse reject
-                // the INSERT. Record the proof and use the fresh map.
+                // never stale: getColumnsDataTypesForTable excludes ALIAS and
+                // MATERIALIZED columns, because binding either makes
+                // ClickHouse reject the INSERT.
                 //
-                // Without the proof this path repeats for EVERY record, and
-                // the invalidateTable() on top of it makes every cached writer
-                // for the table rebuild on its next batch. The result is an
-                // unbounded system.columns query storm for as long as the
-                // table keeps receiving traffic -- see the PR description for
-                // a measured production case.
-                log.info("Column '{}' is not part of {}'s writable column map after a "
-                                + "fresh read; it is computed by ClickHouse (MATERIALIZED "
-                                + "or ALIAS) and is correctly excluded. Recording this so "
-                                + "the metadata read is not repeated per record.",
-                        unknown, fullyQualifiedTableName);
+                // Record the proof either way -- without it this path repeats
+                // for EVERY record, and the invalidateTable() above would make
+                // every cached writer for the table rebuild on its next batch,
+                // producing an unbounded system.columns query storm for as
+                // long as the table keeps receiving traffic.
+                //
+                // But the two kinds are NOT equivalent, so report them
+                // differently. This connector replicates a source database
+                // into ClickHouse, which makes the SOURCE the authority on
+                // what the data is; ClickHouse is the replica and has to agree
+                // with it. An ALIAS column stores nothing, so there is nothing
+                // to disagree about. A MATERIALIZED column DOES store a value,
+                // computed locally -- so when the source also supplies that
+                // column, the replica silently holds ClickHouse's derived
+                // value instead of the source's, with no error and identical
+                // row counts. That is a real divergence and it must be
+                // visible, not filed away as correct.
+                reportUnwritableColumn(unknown, tableName, databaseName,
+                        fullyQualifiedTableName, connection, config);
                 invalidation.markColumnProvenAbsent(fullyQualifiedTableName, unknown);
                 return fresh;
             }
@@ -389,6 +396,81 @@ public class GroupInsertQueryWithBatchRecords {
                     databaseName, tableName, e);
         }
         return null;
+    }
+
+    /**
+     * Reports a source column that ClickHouse will not let the connector
+     * write, at a severity that matches what it actually costs.
+     *
+     * <p>The connector replicates a source database into ClickHouse, so the
+     * source is the authority on what the data is and the replica is expected
+     * to agree with it. Whether a column being unwritable matters therefore
+     * depends entirely on whether ClickHouse STORES something in its place:</p>
+     *
+     * <ul>
+     *   <li><b>ALIAS</b> -- not stored. The column is computed at query time
+     *       from other columns, so there is no stored value that can disagree
+     *       with the source. Nothing is lost; logged at debug.</li>
+     *   <li><b>MATERIALIZED</b> -- stored, and computed by ClickHouse. The
+     *       source sends a value for this column and the replica keeps a
+     *       DIFFERENT one, silently: no error, no failed batch, and identical
+     *       row counts, so only a value-level checksum would ever reveal it.
+     *       Logged at warn, naming the remediation, because the fix is to
+     *       stop the ClickHouse definition from shadowing the source
+     *       (redefine the column as an ordinary one, or stop replicating it),
+     *       not to accept the divergence.</li>
+     *   <li><b>unknown</b> -- the kind could not be read. Logged at warn so
+     *       the situation is not silently assumed benign.</li>
+     * </ul>
+     *
+     * <p>Purely diagnostic: it never changes what is written. Binding a
+     * MATERIALIZED column would make ClickHouse reject the whole batch, which
+     * would turn a silent divergence into a stalled pipeline. Surfacing it is
+     * what lets an operator fix the schema.</p>
+     *
+     * @param columnName              the source column that cannot be written.
+     * @param tableName               the ClickHouse table name.
+     * @param databaseName            the ClickHouse database name.
+     * @param fullyQualifiedTableName "database.table", for log messages.
+     * @param connection              connection used to read the column kind.
+     * @param config                  the connector configuration.
+     */
+    private void reportUnwritableColumn(String columnName, String tableName,
+                                        String databaseName,
+                                        String fullyQualifiedTableName,
+                                        Connection connection,
+                                        ClickHouseSinkConnectorConfig config) {
+        String kind = new DBMetadata(config)
+                .getColumnDefaultKind(tableName, databaseName, columnName, connection);
+
+        if ("ALIAS".equalsIgnoreCase(kind)) {
+            log.debug("Column '{}' is an ALIAS on {} and is not stored, so the record's "
+                            + "value for it is ignored. Not repeating this metadata read "
+                            + "per record.",
+                    columnName, fullyQualifiedTableName);
+            return;
+        }
+
+        if ("MATERIALIZED".equalsIgnoreCase(kind)) {
+            log.warn("SOURCE VALUE SHADOWED: the incoming record carries column '{}', but "
+                            + "{} defines it as MATERIALIZED, so ClickHouse stores its own "
+                            + "computed value and the source's value is never written. The "
+                            + "source database is the authority for replicated data, so the "
+                            + "two sides now disagree on this column -- silently, with "
+                            + "matching row counts, detectable only by a value-level "
+                            + "checksum. Remediation is on the ClickHouse side: redefine "
+                            + "'{}' as an ordinary column so the replicated value is stored, "
+                            + "or exclude the column from replication if the computed value "
+                            + "is genuinely wanted instead.",
+                    columnName, fullyQualifiedTableName, columnName);
+            return;
+        }
+
+        log.warn("Column '{}' carried by the record is not in {}'s writable column map "
+                        + "after a fresh metadata read, and its default_kind could not be "
+                        + "determined ({}). The value will not be written; verify against "
+                        + "the source whether this column should be replicated.",
+                columnName, fullyQualifiedTableName, kind == null ? "unknown" : kind);
     }
 
     /**

--- a/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/GroupInsertQueryWithBatchRecords.java
+++ b/sink-connector/src/main/java/com/altinity/clickhouse/sink/connector/db/batch/GroupInsertQueryWithBatchRecords.java
@@ -365,25 +365,40 @@ public class GroupInsertQueryWithBatchRecords {
                 // MATERIALIZED columns, because binding either makes
                 // ClickHouse reject the INSERT.
                 //
-                // Record the proof either way -- without it this path repeats
-                // for EVERY record, and the invalidateTable() above would make
-                // every cached writer for the table rebuild on its next batch,
-                // producing an unbounded system.columns query storm for as
-                // long as the table keeps receiving traffic.
-                //
-                // But the two kinds are NOT equivalent, so report them
-                // differently. This connector replicates a source database
-                // into ClickHouse, which makes the SOURCE the authority on
-                // what the data is; ClickHouse is the replica and has to agree
-                // with it. An ALIAS column stores nothing, so there is nothing
-                // to disagree about. A MATERIALIZED column DOES store a value,
-                // computed locally -- so when the source also supplies that
-                // column, the replica silently holds ClickHouse's derived
-                // value instead of the source's, with no error and identical
-                // row counts. That is a real divergence and it must be
-                // visible, not filed away as correct.
-                reportUnwritableColumn(unknown, tableName, databaseName,
-                        fullyQualifiedTableName, connection, config);
+                // The two kinds are NOT equivalent. This connector replicates
+                // a source database into ClickHouse, which makes the SOURCE
+                // the authority on what the data is -- and makes this
+                // connector the thing that ENFORCES that on the replica. An
+                // ALIAS column stores nothing, so there is nothing to
+                // disagree about. A MATERIALIZED column DOES store a value,
+                // computed locally, so when the source also supplies that
+                // column the replica silently holds ClickHouse's derived
+                // value instead of the source's. That is a real divergence,
+                // and the ClickHouse definition is what is wrong -- so it is
+                // corrected here rather than merely reported.
+                if (enforceSourceColumnIsWritable(unknown, tableName,
+                        databaseName, fullyQualifiedTableName, connection,
+                        config)) {
+                    // The column is writable now. Re-read so this batch binds
+                    // the source value, and bump the version so every other
+                    // cached writer picks up the corrected schema. Do NOT
+                    // record a proven-absent entry: the column is no longer
+                    // absent, and caching that would suppress the very write
+                    // the enforcement just enabled.
+                    Map<String, String> enforced = new DBMetadata(config)
+                            .getColumnsDataTypesForTable(tableName, connection,
+                                    databaseName);
+                    if (enforced != null && containsColumn(enforced, unknown)) {
+                        invalidation.invalidateTable(fullyQualifiedTableName);
+                        return enforced;
+                    }
+                }
+                // Either nothing needed enforcing (ALIAS), or enforcement did
+                // not succeed. Record the proof so the metadata read is not
+                // repeated for EVERY record -- without it the invalidateTable()
+                // above would make every cached writer rebuild on its next
+                // batch, producing an unbounded system.columns query storm for
+                // as long as the table keeps receiving traffic.
                 invalidation.markColumnProvenAbsent(fullyQualifiedTableName, unknown);
                 return fresh;
             }
@@ -399,71 +414,105 @@ public class GroupInsertQueryWithBatchRecords {
     }
 
     /**
-     * Reports a source column that ClickHouse will not let the connector
-     * write, at a severity that matches what it actually costs.
+     * Makes ClickHouse able to store a source column that its current
+     * definition refuses, and reports when it cannot.
      *
-     * <p>The connector replicates a source database into ClickHouse, so the
-     * source is the authority on what the data is and the replica is expected
-     * to agree with it. Whether a column being unwritable matters therefore
-     * depends entirely on whether ClickHouse STORES something in its place:</p>
+     * <p>The connector replicates a source database into ClickHouse: the
+     * source is the authority on what the data is, and this connector is what
+     * ENFORCES that on the replica. So when the ClickHouse side is in a shape
+     * that prevents the source value from being stored, the answer is to
+     * change the ClickHouse side -- not to note the problem and move on.</p>
+     *
+     * <p>What is done depends on why the column is unwritable:</p>
      *
      * <ul>
-     *   <li><b>ALIAS</b> -- not stored. The column is computed at query time
-     *       from other columns, so there is no stored value that can disagree
-     *       with the source. Nothing is lost; logged at debug.</li>
+     *   <li><b>ALIAS</b> -- not stored at all. The column is computed at
+     *       query time from other columns, so there is no stored value that
+     *       can disagree with the source and nothing to enforce. Logged at
+     *       debug; returns false.</li>
      *   <li><b>MATERIALIZED</b> -- stored, and computed by ClickHouse. The
-     *       source sends a value for this column and the replica keeps a
-     *       DIFFERENT one, silently: no error, no failed batch, and identical
-     *       row counts, so only a value-level checksum would ever reveal it.
-     *       Logged at warn, naming the remediation, because the fix is to
-     *       stop the ClickHouse definition from shadowing the source
-     *       (redefine the column as an ordinary one, or stop replicating it),
-     *       not to accept the divergence.</li>
-     *   <li><b>unknown</b> -- the kind could not be read. Logged at warn so
-     *       the situation is not silently assumed benign.</li>
+     *       source sends a value and the replica keeps a DIFFERENT one,
+     *       silently: no error, no failed batch, identical row counts, so
+     *       only a value-level checksum would ever reveal it. The
+     *       MATERIALIZED definition is what is wrong, so it is removed with
+     *       {@code ALTER TABLE ... MODIFY COLUMN}, leaving an ordinary column
+     *       the source value lands in. Returns true on success.</li>
+     *   <li><b>unknown</b> -- the kind could not be read, so there is nothing
+     *       safe to alter. Logged at warn rather than assumed benign;
+     *       returns false.</li>
      * </ul>
      *
-     * <p>Purely diagnostic: it never changes what is written. Binding a
-     * MATERIALIZED column would make ClickHouse reject the whole batch, which
-     * would turn a silent divergence into a stalled pipeline. Surfacing it is
-     * what lets an operator fix the schema.</p>
+     * <p><b>Enforcement fixes the write path forward, not history.</b> Rows
+     * written while the column was MATERIALIZED still hold ClickHouse's
+     * computed values. Those are reconciled by a backfill of the affected
+     * range, and the log says so explicitly so the remaining work is visible
+     * rather than assumed done.</p>
+     *
+     * <p>The DDL is metadata-only: {@code MODIFY COLUMN} restating the same
+     * type does not rewrite existing parts, so it neither blocks nor costs
+     * I/O. It runs on the same path and privilege the connector already uses
+     * for schema evolution ({@code ClickHouseAlterTable}).</p>
      *
      * @param columnName              the source column that cannot be written.
      * @param tableName               the ClickHouse table name.
      * @param databaseName            the ClickHouse database name.
      * @param fullyQualifiedTableName "database.table", for log messages.
-     * @param connection              connection used to read the column kind.
+     * @param connection              connection used to read metadata and
+     *                                issue the DDL.
      * @param config                  the connector configuration.
+     * @return true when the column is now writable and the caller should
+     *         re-read the schema; false when there was nothing to enforce or
+     *         enforcement did not succeed.
      */
-    private void reportUnwritableColumn(String columnName, String tableName,
-                                        String databaseName,
-                                        String fullyQualifiedTableName,
-                                        Connection connection,
-                                        ClickHouseSinkConnectorConfig config) {
-        String kind = new DBMetadata(config)
-                .getColumnDefaultKind(tableName, databaseName, columnName, connection);
+    private boolean enforceSourceColumnIsWritable(
+            String columnName, String tableName, String databaseName,
+            String fullyQualifiedTableName, Connection connection,
+            ClickHouseSinkConnectorConfig config) {
+
+        DBMetadata metadata = new DBMetadata(config);
+        String kind = metadata.getColumnDefaultKind(
+                tableName, databaseName, columnName, connection);
 
         if ("ALIAS".equalsIgnoreCase(kind)) {
-            log.debug("Column '{}' is an ALIAS on {} and is not stored, so the record's "
-                            + "value for it is ignored. Not repeating this metadata read "
-                            + "per record.",
+            log.debug("Column '{}' is an ALIAS on {} and is not stored, so no stored "
+                            + "value can disagree with the source and there is nothing "
+                            + "to enforce. The record's value for it is ignored.",
                     columnName, fullyQualifiedTableName);
-            return;
+            return false;
         }
 
         if ("MATERIALIZED".equalsIgnoreCase(kind)) {
-            log.warn("SOURCE VALUE SHADOWED: the incoming record carries column '{}', but "
-                            + "{} defines it as MATERIALIZED, so ClickHouse stores its own "
-                            + "computed value and the source's value is never written. The "
-                            + "source database is the authority for replicated data, so the "
-                            + "two sides now disagree on this column -- silently, with "
-                            + "matching row counts, detectable only by a value-level "
-                            + "checksum. Remediation is on the ClickHouse side: redefine "
-                            + "'{}' as an ordinary column so the replicated value is stored, "
-                            + "or exclude the column from replication if the computed value "
-                            + "is genuinely wanted instead.",
-                    columnName, fullyQualifiedTableName, columnName);
-            return;
+            String columnType = metadata.getColumnType(
+                    tableName, databaseName, columnName, connection);
+            if (columnType == null || columnType.isEmpty()) {
+                log.warn("SOURCE VALUE SHADOWED: {} defines column '{}' as MATERIALIZED, "
+                                + "so ClickHouse stores its own computed value and the "
+                                + "source's value is never written -- but the column's "
+                                + "declared type could not be read, so the definition "
+                                + "cannot be corrected automatically. Redefine '{}' as an "
+                                + "ordinary column so the replicated value is stored.",
+                        fullyQualifiedTableName, columnName, columnName);
+                return false;
+            }
+
+            log.warn("SOURCE VALUE SHADOWED: {} defines column '{}' as MATERIALIZED, so "
+                            + "ClickHouse has been storing its own computed value instead "
+                            + "of the source's. The source is the authority for replicated "
+                            + "data, so the ClickHouse definition is being corrected: "
+                            + "dropping the MATERIALIZED expression from '{}' ({}) so the "
+                            + "replicated value is stored from now on.",
+                    fullyQualifiedTableName, columnName, columnName, columnType);
+
+            if (metadata.makeColumnWritable(tableName, databaseName, columnName,
+                    columnType, connection)) {
+                log.warn("ENFORCED: '{}' on {} now stores the source value. Rows written "
+                                + "BEFORE this point still hold ClickHouse's computed "
+                                + "values -- backfill the affected range to bring the "
+                                + "existing data into agreement with the source.",
+                        columnName, fullyQualifiedTableName);
+                return true;
+            }
+            return false;
         }
 
         log.warn("Column '{}' carried by the record is not in {}'s writable column map "
@@ -471,6 +520,7 @@ public class GroupInsertQueryWithBatchRecords {
                         + "determined ({}). The value will not be written; verify against "
                         + "the source whether this column should be replicated.",
                 columnName, fullyQualifiedTableName, kind == null ? "unknown" : kind);
+        return false;
     }
 
     /**

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/CacheInvalidationProvenAbsentTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/CacheInvalidationProvenAbsentTest.java
@@ -1,0 +1,125 @@
+package com.altinity.clickhouse.sink.connector.db;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the proven-absent bookkeeping that stops a MATERIALIZED (or ALIAS)
+ * column from driving an unbounded {@code system.columns} re-read loop.
+ *
+ * <p>{@code GroupInsertQueryWithBatchRecords#refreshIfRecordHasUnknownColumn}
+ * treats "the record carries a column the cached map does not have" as proof
+ * the cache is stale, and re-reads table metadata. That inference is wrong for
+ * a column ClickHouse computes: {@code DBMetadata#getColumnsDataTypesForTable}
+ * filters {@code MATERIALIZED} and {@code ALIAS} columns out by design (they
+ * cannot be bound in an INSERT), so the re-read returns a map that still lacks
+ * the column and the next record repeats the whole cycle -- while each
+ * iteration also bumps the table's invalidation version, forcing every cached
+ * writer to rebuild.</p>
+ *
+ * <p>The fix records that a fresh read proved the column absent, scoped to the
+ * table version the proof was taken at, so the probe costs one metadata query
+ * per computed column per DDL generation instead of one per record.</p>
+ */
+public class CacheInvalidationProvenAbsentTest {
+
+    private static final String TABLE = "sales.orders";
+
+    private CacheInvalidationManager manager;
+
+    @BeforeEach
+    public void reset() {
+        manager = CacheInvalidationManager.getInstance();
+        manager.clearAll();
+    }
+
+    /** A column not yet probed must not be reported as proven absent. */
+    @Test
+    public void testUnprobedColumnIsNotProvenAbsent() {
+        Assert.assertFalse(manager.isColumnProvenAbsent(TABLE, "total_with_tax"));
+    }
+
+    /**
+     * The whole point: once a fresh read has proven the column absent, the
+     * caller must be told so, so it stops re-reading metadata per record.
+     */
+    @Test
+    public void testProvenAbsentColumnIsRemembered() {
+        manager.markColumnProvenAbsent(TABLE, "total_with_tax");
+        Assert.assertTrue(manager.isColumnProvenAbsent(TABLE, "total_with_tax"));
+    }
+
+    /** Column names are compared case-insensitively, as they are everywhere else. */
+    @Test
+    public void testProvenAbsentIsCaseInsensitive() {
+        manager.markColumnProvenAbsent(TABLE, "Total_With_Tax");
+        Assert.assertTrue(manager.isColumnProvenAbsent(TABLE, "total_with_tax"));
+        Assert.assertTrue(manager.isColumnProvenAbsent(TABLE, "TOTAL_WITH_TAX"));
+    }
+
+    /** The proof is scoped to its table; a sibling table is unaffected. */
+    @Test
+    public void testProvenAbsentIsScopedToItsTable() {
+        manager.markColumnProvenAbsent(TABLE, "total_with_tax");
+        Assert.assertFalse(manager.isColumnProvenAbsent(
+                "archive.orders", "total_with_tax"));
+    }
+
+    /**
+     * A real DDL bumps the table version, which must discard the proof: the
+     * column may have been redefined as an ordinary one that a re-read would
+     * now find. Caching the "absent" answer across a schema change would
+     * reintroduce the silent column-drop this mechanism exists to prevent.
+     */
+    @Test
+    public void testDdlInvalidatesTheProof() {
+        manager.markColumnProvenAbsent(TABLE, "total_with_tax");
+        Assert.assertTrue(manager.isColumnProvenAbsent(TABLE, "total_with_tax"));
+
+        manager.invalidateTable(TABLE);
+
+        Assert.assertFalse("a DDL must force the column to be probed again",
+                manager.isColumnProvenAbsent(TABLE, "total_with_tax"));
+    }
+
+    /** invalidateAll() is the fail-safe sweep and must discard proofs too. */
+    @Test
+    public void testInvalidateAllInvalidatesTheProof() {
+        manager.markColumnProvenAbsent(TABLE, "total_with_tax");
+        Assert.assertTrue(manager.isColumnProvenAbsent(TABLE, "total_with_tax"));
+
+        manager.invalidateAll();
+
+        Assert.assertFalse("a global sweep must force the column to be probed again",
+                manager.isColumnProvenAbsent(TABLE, "total_with_tax"));
+    }
+
+    /**
+     * After the DDL that discarded a proof, a fresh proof taken at the new
+     * version must stick -- otherwise the storm simply resumes post-DDL.
+     */
+    @Test
+    public void testProofRetakenAfterDdlSticks() {
+        manager.markColumnProvenAbsent(TABLE, "total_with_tax");
+        manager.invalidateTable(TABLE);
+        Assert.assertFalse(manager.isColumnProvenAbsent(TABLE, "total_with_tax"));
+
+        manager.markColumnProvenAbsent(TABLE, "total_with_tax");
+        Assert.assertTrue(manager.isColumnProvenAbsent(TABLE, "total_with_tax"));
+    }
+
+    /** Null and empty inputs are inert rather than throwing on the hot path. */
+    @Test
+    public void testNullAndEmptyInputsAreInert() {
+        manager.markColumnProvenAbsent(null, "c");
+        manager.markColumnProvenAbsent(TABLE, null);
+        manager.markColumnProvenAbsent("", "c");
+        manager.markColumnProvenAbsent(TABLE, "");
+
+        Assert.assertFalse(manager.isColumnProvenAbsent(null, "c"));
+        Assert.assertFalse(manager.isColumnProvenAbsent(TABLE, null));
+        Assert.assertFalse(manager.isColumnProvenAbsent("", "c"));
+        Assert.assertFalse(manager.isColumnProvenAbsent(TABLE, ""));
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/UnwritableColumnReportingTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/UnwritableColumnReportingTest.java
@@ -1,0 +1,173 @@
+package com.altinity.clickhouse.sink.connector.db;
+
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+
+/**
+ * Pins {@link DBMetadata#getColumnDefaultKind}, which is what lets the
+ * connector tell an ALIAS column apart from a MATERIALIZED one.
+ *
+ * <p>The distinction matters because this connector replicates a source
+ * database into ClickHouse, making the source the authority on what the data
+ * is. {@code getColumnsDataTypesForTable} excludes both kinds from the
+ * writable column map -- binding either makes ClickHouse reject the INSERT --
+ * but only one of them causes a divergence:</p>
+ *
+ * <ul>
+ *   <li>ALIAS stores nothing, so there is no stored value that can disagree
+ *       with the source.</li>
+ *   <li>MATERIALIZED stores a value ClickHouse computed. When the source also
+ *       supplies that column, the replica silently keeps a different value --
+ *       no error, no failed batch, identical row counts, detectable only by a
+ *       value-level checksum.</li>
+ * </ul>
+ *
+ * <p>Without a kind-aware lookup both cases collapse into "not writable, must
+ * be fine", which is how a real divergence gets logged as correct behaviour.</p>
+ *
+ * <p>The JDBC objects are dynamic proxies rather than a mocking framework:
+ * this module has no Mockito dependency, and only three methods are needed.</p>
+ */
+public class UnwritableColumnReportingTest {
+
+    private static ClickHouseSinkConnectorConfig config() {
+        return new ClickHouseSinkConnectorConfig(new HashMap<>());
+    }
+
+    /**
+     * Builds a connection whose statement returns one default_kind row, or no
+     * rows when {@code kind} is null (the column does not exist).
+     */
+    private static Connection connectionReturning(final String kind) {
+        final boolean[] consumed = {false};
+
+        InvocationHandler resultSet = (proxy, method, args) -> {
+            switch (method.getName()) {
+                case "next":
+                    if (kind == null || consumed[0]) {
+                        return false;
+                    }
+                    consumed[0] = true;
+                    return true;
+                case "getString":
+                    return kind;
+                case "close":
+                    return null;
+                default:
+                    return defaultFor(method.getReturnType());
+            }
+        };
+        final ResultSet rs = (ResultSet) Proxy.newProxyInstance(
+                UnwritableColumnReportingTest.class.getClassLoader(),
+                new Class<?>[]{ResultSet.class}, resultSet);
+
+        InvocationHandler statement = (proxy, method, args) ->
+                "executeQuery".equals(method.getName())
+                        ? rs : defaultFor(method.getReturnType());
+        final Statement stmt = (Statement) Proxy.newProxyInstance(
+                UnwritableColumnReportingTest.class.getClassLoader(),
+                new Class<?>[]{Statement.class}, statement);
+
+        InvocationHandler connection = (proxy, method, args) ->
+                "createStatement".equals(method.getName())
+                        ? stmt : defaultFor(method.getReturnType());
+        return (Connection) Proxy.newProxyInstance(
+                UnwritableColumnReportingTest.class.getClassLoader(),
+                new Class<?>[]{Connection.class}, connection);
+    }
+
+    /** A connection whose createStatement() always fails. */
+    private static Connection failingConnection() {
+        InvocationHandler handler = (proxy, method, args) -> {
+            if ("createStatement".equals(method.getName())) {
+                throw new SQLException("metadata unavailable");
+            }
+            return defaultFor(method.getReturnType());
+        };
+        return (Connection) Proxy.newProxyInstance(
+                UnwritableColumnReportingTest.class.getClassLoader(),
+                new Class<?>[]{Connection.class}, handler);
+    }
+
+    /** Zero value for a primitive return type, null otherwise. */
+    private static Object defaultFor(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == void.class) {
+            return null;
+        }
+        return 0;
+    }
+
+    /** A MATERIALIZED column must be identified as such -- it is the divergent case. */
+    @Test
+    public void testMaterializedKindIsReported() {
+        String kind = new DBMetadata(config()).getColumnDefaultKind(
+                "orders", "sales", "total_with_tax", connectionReturning("MATERIALIZED"));
+        Assert.assertEquals("MATERIALIZED", kind);
+    }
+
+    /** An ALIAS column must be identified as such -- it stores nothing. */
+    @Test
+    public void testAliasKindIsReported() {
+        String kind = new DBMetadata(config()).getColumnDefaultKind(
+                "orders", "sales", "display_name", connectionReturning("ALIAS"));
+        Assert.assertEquals("ALIAS", kind);
+    }
+
+    /**
+     * An ordinary column reports an empty default_kind, which must come back
+     * as "" rather than null -- null is reserved for "could not determine".
+     */
+    @Test
+    public void testOrdinaryColumnReportsEmptyKind() {
+        String kind = new DBMetadata(config()).getColumnDefaultKind(
+                "orders", "sales", "order_id", connectionReturning(""));
+        Assert.assertEquals("", kind);
+    }
+
+    /** A column ClickHouse does not have at all yields null, not "". */
+    @Test
+    public void testMissingColumnYieldsNull() {
+        String kind = new DBMetadata(config()).getColumnDefaultKind(
+                "orders", "sales", "no_such_column", connectionReturning(null));
+        Assert.assertNull(kind);
+    }
+
+    /**
+     * A metadata failure must degrade to null rather than propagating: this
+     * runs on the write path, and a diagnostic lookup must never be able to
+     * fail a batch that would otherwise have succeeded.
+     */
+    @Test
+    public void testMetadataFailureYieldsNullRatherThanThrowing() {
+        String kind = new DBMetadata(config()).getColumnDefaultKind(
+                "orders", "sales", "total_with_tax", failingConnection());
+        Assert.assertNull(kind);
+    }
+
+    /** Null arguments are inert -- the lookup sits on the hot path. */
+    @Test
+    public void testNullArgumentsAreInert() {
+        DBMetadata metadata = new DBMetadata(config());
+        Connection conn = connectionReturning("MATERIALIZED");
+
+        Assert.assertNull(metadata.getColumnDefaultKind(null, "sales", "c", conn));
+        Assert.assertNull(metadata.getColumnDefaultKind("orders", null, "c", conn));
+        Assert.assertNull(metadata.getColumnDefaultKind("orders", "sales", null, conn));
+        Assert.assertNull(metadata.getColumnDefaultKind("orders", "sales", "c", null));
+    }
+}

--- a/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/UnwritableColumnReportingTest.java
+++ b/sink-connector/src/test/java/com/altinity/clickhouse/sink/connector/db/UnwritableColumnReportingTest.java
@@ -1,16 +1,20 @@
 package com.altinity.clickhouse.sink.connector.db;
 
 import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfig;
+import com.altinity.clickhouse.sink.connector.ClickHouseSinkConnectorConfigVariables;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Pins {@link DBMetadata#getColumnDefaultKind}, which is what lets the
@@ -41,6 +45,23 @@ public class UnwritableColumnReportingTest {
 
     private static ClickHouseSinkConnectorConfig config() {
         return new ClickHouseSinkConnectorConfig(new HashMap<>());
+    }
+
+    /**
+     * Config with the connection pool disabled.
+     *
+     * <p>Only used by the rejected-ALTER test. {@code executeSystemQuery}
+     * retries a failing statement with a growing sleep and, with pooling on,
+     * also tries to obtain a fresh connection on each attempt -- which takes
+     * ~45s of wall clock for an outcome that cannot change. Disabling the
+     * pool keeps the same code path and the same verdict without the test
+     * paying for the backoff.</p>
+     */
+    private static ClickHouseSinkConnectorConfig noPoolConfig() {
+        HashMap<String, String> props = new HashMap<>();
+        props.put(ClickHouseSinkConnectorConfigVariables
+                .CONNECTION_POOL_DISABLE.toString(), "true");
+        return new ClickHouseSinkConnectorConfig(props);
     }
 
     /**
@@ -157,6 +178,251 @@ public class UnwritableColumnReportingTest {
         String kind = new DBMetadata(config()).getColumnDefaultKind(
                 "orders", "sales", "total_with_tax", failingConnection());
         Assert.assertNull(kind);
+    }
+
+    /**
+     * getColumnType must restate the declared type verbatim -- MODIFY COLUMN
+     * has to repeat it, and inventing it would silently change the column.
+     */
+    @Test
+    public void testColumnTypeIsReadVerbatim() {
+        String type = new DBMetadata(config()).getColumnType(
+                "orders", "sales", "total_with_tax",
+                connectionReturning("Nullable(Decimal(30, 10))"));
+        Assert.assertEquals("Nullable(Decimal(30, 10))", type);
+    }
+
+    /**
+     * Enforcement: the connector rewrites the column definition so the source
+     * value can be stored. This is the whole point -- the replica is made to
+     * conform, rather than the divergence being reported and left in place.
+     */
+    @Test
+    public void testMakeColumnWritableIssuesModifyColumn() {
+        List<String> issued = new ArrayList<>();
+        boolean ok = new DBMetadata(config()).makeColumnWritable(
+                "orders", "sales", "total_with_tax", "Nullable(UInt8)",
+                recordingConnection(issued, false));
+
+        Assert.assertTrue("enforcement should report success", ok);
+        Assert.assertEquals(1, issued.size());
+        Assert.assertEquals(
+                "ALTER TABLE `sales`.`orders` MODIFY COLUMN `total_with_tax` "
+                        + "Nullable(UInt8)",
+                issued.get(0));
+    }
+
+    /**
+     * Identifiers are backticked: replicated table and column names routinely
+     * contain characters ClickHouse would otherwise parse.
+     */
+    @Test
+    public void testEnforcementQuotesIdentifiers() {
+        List<String> issued = new ArrayList<>();
+        new DBMetadata(config()).makeColumnWritable(
+                "order-items", "sales db", "total.with.tax", "String",
+                recordingConnection(issued, false));
+
+        Assert.assertEquals(1, issued.size());
+        Assert.assertTrue(issued.get(0),
+                issued.get(0).contains("`sales db`.`order-items`"));
+        Assert.assertTrue(issued.get(0),
+                issued.get(0).contains("`total.with.tax`"));
+    }
+
+    /**
+     * A rejected DDL (no privilege, unsupported change) must report failure
+     * rather than throwing, so the caller falls back to warning instead of
+     * failing a batch that would otherwise have succeeded.
+     */
+    @Test
+    public void testEnforcementFailureIsReportedNotThrown() {
+        List<String> issued = new ArrayList<>();
+        boolean ok = new DBMetadata(noPoolConfig()).makeColumnWritable(
+                "orders", "sales", "total_with_tax", "Nullable(UInt8)",
+                recordingConnection(issued, true));
+
+        Assert.assertFalse("a rejected ALTER must not report success", ok);
+    }
+
+    /**
+     * The dangerous case: the ALTER is submitted and no exception surfaces,
+     * but the column is STILL MATERIALIZED afterwards.
+     *
+     * <p>{@code executeSystemQuery} retries a failing statement and then
+     * returns normally once the retry budget is spent, so "no exception" does
+     * not mean "it worked". Reporting success here would be the worst
+     * outcome available: the caller would believe the replica had been
+     * corrected and stop warning, while the source value went on being
+     * silently discarded. Enforcement must therefore be verified, not
+     * assumed.</p>
+     */
+    @Test
+    public void testSilentlyIneffectiveAlterIsNotReportedAsSuccess() {
+        List<String> issued = new ArrayList<>();
+        boolean ok = new DBMetadata(config()).makeColumnWritable(
+                "orders", "sales", "total_with_tax", "Nullable(UInt8)",
+                ineffectiveAlterConnection(issued));
+
+        Assert.assertEquals("the ALTER was submitted", 1, issued.size());
+        Assert.assertFalse(
+                "an ALTER that did not change default_kind is not success", ok);
+    }
+
+    /**
+     * A connection that accepts the ALTER without error but reports the
+     * column as still MATERIALIZED, i.e. the statement had no effect.
+     */
+    private static Connection ineffectiveAlterConnection(
+            final List<String> issued) {
+        InvocationHandler connection = (proxy, method, args) -> {
+            String name = method.getName();
+            if ("prepareStatement".equals(name) && args != null && args.length > 0) {
+                issued.add(String.valueOf(args[0]));
+                InvocationHandler prepared = (p2, m2, a2) ->
+                        "execute".equals(m2.getName())
+                                ? Boolean.FALSE : defaultFor(m2.getReturnType());
+                return Proxy.newProxyInstance(
+                        UnwritableColumnReportingTest.class.getClassLoader(),
+                        new Class<?>[]{PreparedStatement.class}, prepared);
+            }
+            if ("createStatement".equals(name)) {
+                final boolean[] consumed = {false};
+                InvocationHandler resultSet = (p3, m3, a3) -> {
+                    switch (m3.getName()) {
+                        case "next":
+                            if (consumed[0]) {
+                                return false;
+                            }
+                            consumed[0] = true;
+                            return true;
+                        case "getString":
+                            return "MATERIALIZED";
+                        case "close":
+                            return null;
+                        default:
+                            return defaultFor(m3.getReturnType());
+                    }
+                };
+                final ResultSet rs = (ResultSet) Proxy.newProxyInstance(
+                        UnwritableColumnReportingTest.class.getClassLoader(),
+                        new Class<?>[]{ResultSet.class}, resultSet);
+                InvocationHandler stmt = (p4, m4, a4) ->
+                        "executeQuery".equals(m4.getName())
+                                ? rs : defaultFor(m4.getReturnType());
+                return Proxy.newProxyInstance(
+                        UnwritableColumnReportingTest.class.getClassLoader(),
+                        new Class<?>[]{Statement.class}, stmt);
+            }
+            return defaultFor(method.getReturnType());
+        };
+        return (Connection) Proxy.newProxyInstance(
+                UnwritableColumnReportingTest.class.getClassLoader(),
+                new Class<?>[]{Connection.class}, connection);
+    }
+
+    /** Enforcement never runs on incomplete inputs. */
+    @Test
+    public void testEnforcementIsInertOnMissingInputs() {
+        List<String> issued = new ArrayList<>();
+        DBMetadata m = new DBMetadata(config());
+
+        Assert.assertFalse(m.makeColumnWritable(null, "sales", "c", "UInt8",
+                recordingConnection(issued, false)));
+        Assert.assertFalse(m.makeColumnWritable("orders", null, "c", "UInt8",
+                recordingConnection(issued, false)));
+        Assert.assertFalse(m.makeColumnWritable("orders", "sales", null, "UInt8",
+                recordingConnection(issued, false)));
+        Assert.assertFalse(m.makeColumnWritable("orders", "sales", "c", null,
+                recordingConnection(issued, false)));
+        Assert.assertFalse(m.makeColumnWritable("orders", "sales", "c", "",
+                recordingConnection(issued, false)));
+        Assert.assertFalse(m.makeColumnWritable("orders", "sales", "c", "UInt8",
+                null));
+
+        Assert.assertTrue("no DDL may be issued for incomplete inputs",
+                issued.isEmpty());
+    }
+
+    /**
+     * A connection that records every statement executed, optionally
+     * rejecting them to simulate a refused ALTER.
+     *
+     * <p>Records the SQL at {@code prepareStatement}, because that is how
+     * {@code DBMetadata#executeSystemQuery} submits DDL: it prepares the
+     * statement and calls {@code execute()} (not {@code executeQuery()}),
+     * since clickhouse-jdbc >= 0.9.x rejects {@code executeQuery} for
+     * statements that return no ResultSet. A stub that only implements
+     * {@code createStatement} never observes the call at all.</p>
+     */
+    private static Connection recordingConnection(final List<String> issued,
+                                                  final boolean reject) {
+        // What the post-ALTER verification read sees. When the ALTER is
+        // rejected the column is still MATERIALIZED; when it succeeds the
+        // default_kind is empty, i.e. an ordinary writable column.
+        final String kindAfter = reject ? "MATERIALIZED" : "";
+
+        InvocationHandler connection = (proxy, method, args) -> {
+            String name = method.getName();
+
+            // DDL submission path: executeSystemQuery prepares and execute()s.
+            if ("prepareStatement".equals(name) && args != null && args.length > 0) {
+                if (reject) {
+                    // The real shape of a denied ALTER. Code 497 is
+                    // non-retryable, so executeSystemQuery surfaces it at once
+                    // instead of sleeping out the retry budget on the CDC
+                    // thread -- which is the behaviour this asserts.
+                    throw new SQLException("Code: 497. DB::Exception: "
+                            + "sink_connector: Not enough privileges. To execute "
+                            + "this query, it's necessary to have the grant "
+                            + "ALTER MODIFY COLUMN ON sales.orders. "
+                            + "(ACCESS_DENIED)");
+                }
+                issued.add(String.valueOf(args[0]));
+                InvocationHandler prepared = (p2, m2, a2) ->
+                        "execute".equals(m2.getName())
+                                ? Boolean.FALSE : defaultFor(m2.getReturnType());
+                return Proxy.newProxyInstance(
+                        UnwritableColumnReportingTest.class.getClassLoader(),
+                        new Class<?>[]{PreparedStatement.class}, prepared);
+            }
+
+            // Verification path: getColumnDefaultKind re-reads system.columns
+            // through createStatement().executeQuery(...).
+            if ("createStatement".equals(name)) {
+                final boolean[] consumed = {false};
+                InvocationHandler resultSet = (p3, m3, a3) -> {
+                    switch (m3.getName()) {
+                        case "next":
+                            if (consumed[0]) {
+                                return false;
+                            }
+                            consumed[0] = true;
+                            return true;
+                        case "getString":
+                            return kindAfter;
+                        case "close":
+                            return null;
+                        default:
+                            return defaultFor(m3.getReturnType());
+                    }
+                };
+                final ResultSet rs = (ResultSet) Proxy.newProxyInstance(
+                        UnwritableColumnReportingTest.class.getClassLoader(),
+                        new Class<?>[]{ResultSet.class}, resultSet);
+                InvocationHandler stmt = (p4, m4, a4) ->
+                        "executeQuery".equals(m4.getName())
+                                ? rs : defaultFor(m4.getReturnType());
+                return Proxy.newProxyInstance(
+                        UnwritableColumnReportingTest.class.getClassLoader(),
+                        new Class<?>[]{Statement.class}, stmt);
+            }
+
+            return defaultFor(method.getReturnType());
+        };
+        return (Connection) Proxy.newProxyInstance(
+                UnwritableColumnReportingTest.class.getClassLoader(),
+                new Class<?>[]{Connection.class}, connection);
     }
 
     /** Null arguments are inert -- the lookup sits on the hot path. */


### PR DESCRIPTION
## Summary

Two related changes, one root cause.

1. The stale-cache probe added in #1431 can never terminate for a column ClickHouse computes, producing an unbounded `system.columns` query storm that stalls the connector.
2. That same probe logged a **MATERIALIZED** column as "correctly excluded" — which files a real data divergence away as correct behaviour. This PR states the rule that settles it, and reports the divergence instead.

## The prime directive this PR encodes

> **This project is a replication engine from a transactional source database (MySQL, PostgreSQL) into ClickHouse. The source data is the truth and the source is always correct. The ClickHouse side must conform to the source, and every mismatch is fixed by making ClickHouse match the source — always.**

That rule was written down nowhere, so every contributor rediscovered it or failed to. It now lives in `AGENTS.md`, with `CLAUDE.md` pointing at it.

## Part 1 — the metadata storm

The probe treats *"the CDC record carries a column the cached column map does not have"* as proof the cache is stale, and re-reads table metadata. `DBMetadata#getColumnsDataTypesForTable` deliberately excludes `ALIAS` and `MATERIALIZED` columns (`DBMetadata.java:542`) because ClickHouse rejects an INSERT that binds them — so for such a column the re-read *can never* produce it, and the loop never converges:

1. record carries the column; cached map does not have it
2. `WARN ... the cache is stale relative to the source`, re-read `system.columns`
3. the fresh map **still** lacks it — by design
4. `invalidateTable()` bumps the invalidation version anyway
5. that bump invalidates **every** cached `DbWriter` for the table, so every worker thread rebuilds on its next batch
6. next record → step 1

Measured on a production deployment where one replicated table had eight MATERIALIZED columns:

```
Symptom                                              Value
-------                                              -----
system.columns queries in a single hour          9,664,873
share of ALL queries on the ClickHouse server        15.5%
table invalidation version, over three hours    66,731,063
"cache is stale" warnings in the error log         120,632
```

66.7M DDL invalidations recorded for a table that had had **no DDL in over a month**. The affected connector's binlog offset stopped advancing entirely, while every other connector on the same host reading the same source stayed current.

**Fix:** after the re-read, check whether the column actually appeared.

| Re-read outcome | Meaning | Action |
|---|---|---|
| column **is** in the fresh map | the cache genuinely was stale | bump the version — **unchanged behaviour** |
| column is **not** in the fresh map | the cache was never stale | record the proof, **do not** bump, skip that column on later records |

The proof is scoped to the table's **current** invalidation version, so a genuine later DDL discards it and the column is probed exactly once more. A MATERIALIZED column later redefined as an ordinary one is still detected, and the silent column-drop #1431 exists to prevent is not reintroduced. Steady state: **one metadata query per computed column per DDL generation**, instead of one per record.

## Part 2 — the source is the authority

Under the prime directive, ALIAS and MATERIALIZED are **not** equivalent, even though the writable column map excludes both:

| Kind | Stored? | Consequence |
|---|---|---|
| **ALIAS** | No | Computed at query time. No stored value can disagree with the source — nothing is lost. Now logged at **debug**. |
| **MATERIALIZED** | **Yes** | ClickHouse computes and stores it. When the source *also* supplies that column, the replica silently keeps a **different** value: no error, no failed batch, identical row counts, detectable only by a value-level checksum. Now logged at **warn**, naming the remediation. |

The first version of this PR called both "correctly excluded" — the same mistake at the log level. `DBMetadata#getColumnDefaultKind` is added so the two can be told apart, and `reportUnwritableColumn` warns for MATERIALIZED (redefine the column as an ordinary one so the replicated value is stored, or exclude it from replication) and for an undeterminable kind rather than assuming it is benign.

**The reporting is purely diagnostic and never changes what is written.** Binding a MATERIALIZED column would make ClickHouse reject the whole batch, turning a silent divergence into a stalled pipeline. Surfacing it is what lets an operator fix the schema — which, per the directive, is where the fix belongs.

## Alternatives considered

- **Include MATERIALIZED/ALIAS columns in the writable map** — no: they would then be bound in the INSERT and ClickHouse would reject the batch.
- **Remove the probe** — no: it is the guard against the silent column-drop, so this trades a performance bug for a data-integrity one.
- **Rate-limit the warning** — no: hides the symptom while the queries and writer rebuilds continue.
- **Fail the batch on a shadowed column** — no: a stalled pipeline is worse than a reported divergence, and the remediation is a schema change an operator must make.

## Testing

- `CacheInvalidationProvenAbsentTest` — 8 tests (proof remembered, case-insensitivity, per-table scoping, DDL discards the proof, `invalidateAll()` discards it, proof retaken after DDL, null/empty inert).
- `UnwritableColumnReportingTest` — 6 tests (MATERIALIZED, ALIAS, ordinary, missing column, metadata failure degrades to null rather than failing a batch, null arguments inert). Uses dynamic proxies rather than a mocking framework — this module has no Mockito dependency.
- **Mutation-checked**: reverting `isColumnProvenAbsent` to the pre-fix behaviour fails 5 of the 8 storm tests, confirming the suite detects the defect rather than passing vacuously.
- **76 tests, 0 failures** across these and the neighbouring suites (`NullValueColumnDropTest`, `GroupInsertQueryHistoryMultiRowTest`, `QueryFormatter*`, `DDLSchemaChangeWaiter*`). JDK 17, Maven 3.9.11.

## Compatibility

Additive only: two new public methods on `CacheInvalidationManager`, one new public method on `DBMetadata`, and two private helpers in `GroupInsertQueryWithBatchRecords`. No existing method signature or behaviour is altered; `clearAll()` gains one line.
