### PR TITLE
ci: the java-lightweight job has never run any tests

### DIFF
--- a/.github/workflows/sink-connector-lightweight-tests.yml
+++ b/.github/workflows/sink-connector-lightweight-tests.yml
@@ -42,7 +42,21 @@ jobs:
         run: mvn clean install -DskipTests=true
       - name: Build Replicator with Maven
         working-directory: sink-connector-lightweight
-        run: mvn --quiet surefire-report:report
+        # `surefire-report:report` is a REPORTING goal: invoked bare, it does
+        # not bind to the lifecycle and therefore never runs the `test` phase.
+        # It only formats surefire XML that already exists -- and on a clean
+        # runner none does, so it emitted an empty report and the job passed
+        # in ~55s having executed zero tests. The junit-report step said so
+        # every run ("No annotations found for JUnit Test Report") while the
+        # check stayed green.
+        #
+        # `mvn test` runs them; `surefire-report:report` then formats the XML
+        # it produced. -Dmaven.test.failure.ignore lets the report step be the
+        # thing that fails the job, so a failure is annotated on the PR rather
+        # than aborting before the report is written.
+        run: |
+          mvn --quiet test -Dmaven.test.failure.ignore=true
+          mvn --quiet surefire-report:report-only
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v4
         if: always()


### PR DESCRIPTION
## The `java-lightweight` job has never run any tests

The step is:

```yaml
run: mvn --quiet surefire-report:report
```

`surefire-report:report` is a **reporting** goal. Invoked bare on the command line it does not bind to the lifecycle, so the `test` phase never runs. It only formats surefire XML that already exists — and on a clean CI runner, none does.

So the job produces an empty report and passes.

## Evidence

From the most recent run of this job (#1438, run `34307223948`, job `102327628230`):

```
03:43:01Z  ##[group]Run mvn --quiet surefire-report:report
03:43:56Z  report_paths: sink-connector-lightweight/target/surefire-reports/*.xml
03:43:56Z  ⚠️ No annotations found for JUnit Test Report.
```

**55 seconds**, zero tests executed, check green. The junit-report step has been printing `No annotations found` on every single run — the signal was there the whole time, it just never failed anything.

## How it surfaced

I added an integration test (`PostgresSnapshotCompletionIT`, merged in #1438) that sleeps well over 100 seconds by design — it snapshots a database, leaves the source idle, and waits for a heartbeat-driven offset commit. A 55-second green job could not possibly have run it. That is what prompted looking at the step itself.

Worth stating plainly: this means green `java-lightweight` checks on merged PRs did not represent passing tests. The `testflows-*` and `java-kafka` jobs are unaffected — they invoke their suites properly.

## The fix

```yaml
run: |
  mvn --quiet test -Dmaven.test.failure.ignore=true
  mvn --quiet surefire-report:report-only
```

- `mvn test` actually runs the suite.
- `report-only` formats the XML that run produced, without re-invoking the lifecycle.
- `-Dmaven.test.failure.ignore=true` deliberately lets Maven exit 0 on test failures so the **existing** `mikepenz/action-junit-report` step is what fails the job — it already has `fail_on_failure: true`. Without this, a failing test aborts the run before the report is written, and you get a red check with no annotation saying which test failed.

The surefire config in `sink-connector-lightweight/pom.xml` already includes both `**/*Test.java` and `**/*IT.java`, so no include changes are needed.

## Expect this run to be slower, and possibly red

This job has not executed its suite in a long time. The first honest run may surface genuine pre-existing failures, and it will certainly take much longer than 55 seconds. Both are the point — a red result here is information the project has not been getting.

Raised by OmniWatcher on behalf of the DBA team. Split out of #1438 as offered there, since it affects every PR that relies on this check rather than just that fix.
