### PR TITLE
fix(ddl): translate a MySQL generated column to DEFAULT, not MATERIALIZED

### DIFF
--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/Constants.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/Constants.java
@@ -13,8 +13,52 @@ public class Constants {
 
     /**
      * Alias keyword for materialized columns.
+     *
+     * @deprecated a MySQL generated column is translated with
+     *     {@link #GENERATED_COLUMN_KIND} instead; MATERIALIZED cannot receive
+     *     the value the binlog carries. Retained so any other caller keeps
+     *     compiling.
      */
+    @Deprecated
     public static final String ALIAS = "MATERIALIZED";
+
+    /**
+     * ClickHouse column kind used to translate a MySQL generated column
+     * ({@code GENERATED ALWAYS AS (expr) VIRTUAL|STORED}).
+     *
+     * <p>DEFAULT, not MATERIALIZED, and the difference is behavioural rather
+     * than cosmetic. Both evaluate the expression when the column is omitted
+     * from an INSERT, so a generated column is derived correctly either way on
+     * the initial snapshot. They differ on the two things that matter to a
+     * replication engine:</p>
+     *
+     * <ul>
+     *   <li><b>MATERIALIZED rejects the value outright.</b> An INSERT naming
+     *       the column fails with {@code Code: 44 ... Cannot insert column c,
+     *       because it is MATERIALIZED column (ILLEGAL_COLUMN)}. Debezium puts
+     *       generated columns in the row image, so the connector must strip
+     *       them from every INSERT to avoid failing the batch -- and then
+     *       whatever MySQL actually computed is discarded.</li>
+     *   <li><b>DEFAULT accepts an explicit value and computes one when
+     *       absent.</b> The binlog value lands as sent; when the connector
+     *       omits the column, ClickHouse derives it. MySQL stays the source of
+     *       truth, and the replica still fills the column on its own.</li>
+     * </ul>
+     *
+     * <p>This matters whenever the two expressions can disagree: a MySQL
+     * function with no exact ClickHouse equivalent, differing NULL or
+     * overflow semantics, a session-dependent value, or a generated column
+     * whose definition was changed on the source without the replica's
+     * translation being regenerated. Under MATERIALIZED the replica silently
+     * keeps its own answer -- no error, no failed batch, matching row counts,
+     * detectable only by a value-level checksum. Under DEFAULT it keeps
+     * MySQL's.</p>
+     *
+     * <p>MATERIALIZED is also excluded from {@code SELECT *}, so a generated
+     * column translated that way is invisible to a client that does not name
+     * it. DEFAULT columns are ordinary and appear as expected.</p>
+     */
+    public static final String GENERATED_COLUMN_KIND = "DEFAULT";
 
     /**
      * PARTITION BY clause for ClickHouse DDL statements.

--- a/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
+++ b/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java
@@ -934,7 +934,16 @@ public class MySqlDDLParserListenerImpl extends MySQLDDLParserBaseListener {
                         this.query.append(colDataType);
                     }
 
-                    this.query.append(" ").append(Constants.ALIAS).append(" ").append(generatedColumn).append(",");
+                    // DEFAULT, not MATERIALIZED. A MATERIALIZED column REJECTS
+                    // an INSERT that names it (Code: 44 ILLEGAL_COLUMN), and
+                    // Debezium carries generated columns in the row image --
+                    // so the value MySQL computed can never be replicated, and
+                    // the replica silently keeps its own locally-derived answer
+                    // whenever the two expressions disagree. DEFAULT keeps the
+                    // same derive-when-omitted behaviour while accepting the
+                    // binlog value, so the source stays authoritative.
+                    this.query.append(" ").append(Constants.GENERATED_COLUMN_KIND)
+                            .append(" ").append(generatedColumn).append(",");
                     continue;
                 }
 

--- a/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java
+++ b/sink-connector-lightweight/src/test/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImplTest.java
@@ -1076,7 +1076,7 @@ public class MySqlDDLParserListenerImplTest {
         String sql = "CREATE TABLE employees.contacts (fullname varchar(101) GENERATED ALWAYS AS (CONCAT(first_name,' ',last_name)), email VARCHAR(100) NOT NULL);";
         mySQLDDLParserService.parseSql(sql, "", clickHouseQuery);
 
-        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("CREATE TABLE if not exists `employees`.contacts(fullname Nullable(String) MATERIALIZED CONCAT(first_name,' ',last_name),email String NOT NULL ,`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) ORDER BY tuple()"));
+        Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase("CREATE TABLE if not exists `employees`.contacts(fullname Nullable(String) DEFAULT CONCAT(first_name,' ',last_name),email String NOT NULL ,`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) ORDER BY tuple()"));
     }
 
     /**
@@ -2508,8 +2508,8 @@ public class MySqlDDLParserListenerImplTest {
         StringBuffer clickHouseQuery = new StringBuffer();
         mySQLDDLParserService.parseSql(sql, "employees", clickHouseQuery);
 
-        String expectedQuery = "CREATE TABLE if not exists `employees`.`enriched_trade`(`enriched_trade_id` UInt64 NOT NULL ,`enriched_trade_key` UInt64 NOT NULL ,`version_num` UInt16 NOT NULL ,`pos_agg_id` Nullable(UInt64),`is_complete` Int8 NOT NULL ,`enriched_trade_type_id` UInt16 NOT NULL ,`trade_date` Date32 NOT NULL ,`street_trade_date` Nullable(Date32),`settlement_date` Nullable(Date32),`direction_id` Int8 NOT NULL ,`price` Nullable(Decimal(24,10)),`quantity` Decimal(30,10) NOT NULL ,`sid` Nullable(UInt64),`currency_sid` Nullable(UInt64),`currency_id` Nullable(UInt16),`unit_value` Nullable(Decimal(30,10)),`exchange_lglent_id` Nullable(Int32),`exec_broker_lglent_id` Nullable(Int32),`branch_id` Nullable(Int32),`dim_risk_strategy_id` Nullable(UInt32),`account_id` Nullable(Int32),`parent_account_id` Nullable(Int32),`child_account_id` Nullable(Int32),`account_relshp_type_id` Nullable(UInt16),`valid_time` DateTime64(6, 0) NOT NULL ,`db_from` DateTime64(6, 0) NOT NULL ,`db_to` DateTime64(6, 0) NOT NULL ,`created_by` Int32 NOT NULL ,`capped_by` Nullable(Int32),`user_id` Int32 NOT NULL ,`valid_ts` Nullable(UInt64),`kafka_ts` Nullable(UInt64),`kafka_offset` Nullable(Int64),`kafka_partition` Nullable(UInt32),`inst_type_id` Int32 NOT NULL ,`enriched_trade_attributes_1` Nullable(UInt64),`is_reversal` Nullable(Int32) MATERIALIZED ((`enriched_trade_attributes_1`&(1<<0))>0),`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) PARTITION BY  trade_date ORDER BY (`enriched_trade_id`,`trade_date`)";
-        //String expectedQuery = "CREATE TABLE if not exists `employees`.`enriched_trade`(`enriched_trade_id` UInt64 NOT NULL ,`enriched_trade_key` UInt64 NOT NULL ,`version_num` UInt16 NOT NULL ,`pos_agg_id` Nullable(UInt64),`is_complete` Int8 NOT NULL ,`enriched_trade_type_id` UInt16 NOT NULL ,`trade_date` Date32 NOT NULL ,`street_trade_date` Nullable(Date32),`settlement_date` Nullable(Date32),`direction_id` Int8 NOT NULL ,`price` Nullable(Decimal(24,10)),`quantity` Decimal(30,10) NOT NULL ,`sid` Nullable(UInt64),`currency_sid` Nullable(UInt64),`currency_id` Nullable(UInt16),`unit_value` Nullable(Decimal(30,10)),`exchange_lglent_id` Nullable(Int32),`exec_broker_lglent_id` Nullable(Int32),`branch_id` Nullable(Int32),`dim_risk_strategy_id` Nullable(UInt32),`account_id` Nullable(Int32),`parent_account_id` Nullable(Int32),`child_account_id` Nullable(Int32),`account_relshp_type_id` Nullable(UInt16),`valid_time` DateTime64(6, 0) NOT NULL ,`db_from` DateTime64(6, 0) NOT NULL ,`db_to` DateTime64(6, 0) NOT NULL ,`created_by` Int32 NOT NULL ,`capped_by` Nullable(Int32),`user_id` Int32 NOT NULL ,`valid_ts` Nullable(UInt64),`kafka_ts` Nullable(UInt64),`kafka_offset` Nullable(Int64),`kafka_partition` Nullable(UInt32),`inst_type_id` Int32 NOT NULL ,`enriched_trade_attributes_1` Nullable(UInt64),`is_reversal` Nullable(Int32) MATERIALIZED ((`enriched_trade_attributes_1`&(1<<0))>0),`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) ORDER BY (`enriched_trade_id`,`trade_date`)";
+        String expectedQuery = "CREATE TABLE if not exists `employees`.`enriched_trade`(`enriched_trade_id` UInt64 NOT NULL ,`enriched_trade_key` UInt64 NOT NULL ,`version_num` UInt16 NOT NULL ,`pos_agg_id` Nullable(UInt64),`is_complete` Int8 NOT NULL ,`enriched_trade_type_id` UInt16 NOT NULL ,`trade_date` Date32 NOT NULL ,`street_trade_date` Nullable(Date32),`settlement_date` Nullable(Date32),`direction_id` Int8 NOT NULL ,`price` Nullable(Decimal(24,10)),`quantity` Decimal(30,10) NOT NULL ,`sid` Nullable(UInt64),`currency_sid` Nullable(UInt64),`currency_id` Nullable(UInt16),`unit_value` Nullable(Decimal(30,10)),`exchange_lglent_id` Nullable(Int32),`exec_broker_lglent_id` Nullable(Int32),`branch_id` Nullable(Int32),`dim_risk_strategy_id` Nullable(UInt32),`account_id` Nullable(Int32),`parent_account_id` Nullable(Int32),`child_account_id` Nullable(Int32),`account_relshp_type_id` Nullable(UInt16),`valid_time` DateTime64(6, 0) NOT NULL ,`db_from` DateTime64(6, 0) NOT NULL ,`db_to` DateTime64(6, 0) NOT NULL ,`created_by` Int32 NOT NULL ,`capped_by` Nullable(Int32),`user_id` Int32 NOT NULL ,`valid_ts` Nullable(UInt64),`kafka_ts` Nullable(UInt64),`kafka_offset` Nullable(Int64),`kafka_partition` Nullable(UInt32),`inst_type_id` Int32 NOT NULL ,`enriched_trade_attributes_1` Nullable(UInt64),`is_reversal` Nullable(Int32) DEFAULT ((`enriched_trade_attributes_1`&(1<<0))>0),`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) PARTITION BY  trade_date ORDER BY (`enriched_trade_id`,`trade_date`)";
+        //String expectedQuery = "CREATE TABLE if not exists `employees`.`enriched_trade`(`enriched_trade_id` UInt64 NOT NULL ,`enriched_trade_key` UInt64 NOT NULL ,`version_num` UInt16 NOT NULL ,`pos_agg_id` Nullable(UInt64),`is_complete` Int8 NOT NULL ,`enriched_trade_type_id` UInt16 NOT NULL ,`trade_date` Date32 NOT NULL ,`street_trade_date` Nullable(Date32),`settlement_date` Nullable(Date32),`direction_id` Int8 NOT NULL ,`price` Nullable(Decimal(24,10)),`quantity` Decimal(30,10) NOT NULL ,`sid` Nullable(UInt64),`currency_sid` Nullable(UInt64),`currency_id` Nullable(UInt16),`unit_value` Nullable(Decimal(30,10)),`exchange_lglent_id` Nullable(Int32),`exec_broker_lglent_id` Nullable(Int32),`branch_id` Nullable(Int32),`dim_risk_strategy_id` Nullable(UInt32),`account_id` Nullable(Int32),`parent_account_id` Nullable(Int32),`child_account_id` Nullable(Int32),`account_relshp_type_id` Nullable(UInt16),`valid_time` DateTime64(6, 0) NOT NULL ,`db_from` DateTime64(6, 0) NOT NULL ,`db_to` DateTime64(6, 0) NOT NULL ,`created_by` Int32 NOT NULL ,`capped_by` Nullable(Int32),`user_id` Int32 NOT NULL ,`valid_ts` Nullable(UInt64),`kafka_ts` Nullable(UInt64),`kafka_offset` Nullable(Int64),`kafka_partition` Nullable(UInt32),`inst_type_id` Int32 NOT NULL ,`enriched_trade_attributes_1` Nullable(UInt64),`is_reversal` Nullable(Int32) DEFAULT ((`enriched_trade_attributes_1`&(1<<0))>0),`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) ORDER BY (`enriched_trade_id`,`trade_date`)";
         Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(expectedQuery));
     }
 
@@ -2522,9 +2522,60 @@ public class MySqlDDLParserListenerImplTest {
         StringBuffer clickHouseQuery = new StringBuffer();
         mySQLDDLParserService.parseSql(sql, "employees", clickHouseQuery);
 
-        String expectedQuery = "CREATE TABLE if not exists `employees`.orders2(order_id Int32 NOT NULL ,item_price Decimal(10,2) NOT NULL ,quantity Int32 NOT NULL ,total_price Decimal(12,2) MATERIALIZED item_price*quantity,`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) ORDER BY order_id";
+        String expectedQuery = "CREATE TABLE if not exists `employees`.orders2(order_id Int32 NOT NULL ,item_price Decimal(10,2) NOT NULL ,quantity Int32 NOT NULL ,total_price Decimal(12,2) DEFAULT item_price*quantity,`_version` UInt64,`is_deleted` UInt8) Engine=ReplacingMergeTree(_version,is_deleted) ORDER BY order_id";
         Assert.assertTrue(clickHouseQuery.toString().equalsIgnoreCase(expectedQuery));
 
+    }
+
+    /**
+     * A MySQL generated column must be translated to a ClickHouse DEFAULT
+     * column, never MATERIALIZED -- for VIRTUAL and STORED alike.
+     *
+     * <p>MySQL is the source of truth in a replication pipeline, and Debezium
+     * carries generated columns in the row image. A MATERIALIZED column
+     * REJECTS an INSERT that names it -- {@code Code: 44 ... Cannot insert
+     * column, because it is MATERIALIZED column (ILLEGAL_COLUMN)} -- so the
+     * value MySQL computed can never be written, and the replica silently
+     * keeps whatever its own expression produced. That divergence raises no
+     * error and leaves row counts matching, so only a value-level checksum
+     * would ever surface it.</p>
+     *
+     * <p>DEFAULT still evaluates the expression when the column is omitted, so
+     * nothing is lost for clients that do not supply it -- it simply also
+     * accepts the replicated value.</p>
+     *
+     * <p>Asserted on the emitted DDL rather than on a constant, so the
+     * property holds however the emitter is refactored.</p>
+     */
+    @Test
+    public void generatedColumnsAreDefaultNotMaterialized() {
+        String[] statements = {
+                // VIRTUAL (not stored on the source)
+                "CREATE TABLE gen_virtual(id INT PRIMARY KEY, attrs BIGINT UNSIGNED,"
+                        + " is_reversal INT GENERATED ALWAYS AS ((attrs & (1 << 0)) > 0) VIRTUAL);",
+                // STORED (materialised on the source)
+                "CREATE TABLE gen_stored(id INT PRIMARY KEY, price DECIMAL(10,2) NOT NULL,"
+                        + " qty INT NOT NULL,"
+                        + " total DECIMAL(12,2) GENERATED ALWAYS AS (price * qty) STORED);",
+                // shorthand AS (...) with neither keyword; MySQL defaults to VIRTUAL
+                "CREATE TABLE gen_shorthand(id INT PRIMARY KEY, first_name VARCHAR(50),"
+                        + " last_name VARCHAR(50),"
+                        + " fullname VARCHAR(101) AS (CONCAT(first_name, ' ', last_name)));",
+        };
+
+        for (String sql : statements) {
+            StringBuffer clickHouseQuery = new StringBuffer();
+            mySQLDDLParserService.parseSql(sql, "employees", clickHouseQuery);
+            String ddl = clickHouseQuery.toString();
+
+            Assert.assertFalse(
+                    "a generated column must not become MATERIALIZED -- it would reject "
+                            + "the value the binlog carries: " + ddl,
+                    ddl.toUpperCase().contains("MATERIALIZED"));
+            Assert.assertTrue(
+                    "a generated column must be emitted as DEFAULT: " + ddl,
+                    ddl.toUpperCase().contains("DEFAULT "));
+        }
     }
     @Test
     @Disabled


### PR DESCRIPTION
> Supersedes #1441, which was opened against `develop` before the base was retargeted to `2.11.0`. It could not be rebased in place (force-push is not available to me), so this is the same three-file change, cleanly based on `2.11.0`.

## Problem

A MySQL generated column — `GENERATED ALWAYS AS (expr) VIRTUAL|STORED` — is currently translated to a ClickHouse **MATERIALIZED** column:

https://github.com/Altinity/clickhouse-sink-connector/blob/2.11.0/sink-connector-lightweight/src/main/java/com/altinity/clickhouse/debezium/embedded/ddl/parser/MySqlDDLParserListenerImpl.java#L937

```java
this.query.append(" ").append(Constants.ALIAS).append(" ").append(generatedColumn).append(",");
// Constants.ALIAS = "MATERIALIZED"
```

**A MATERIALIZED column cannot receive the value the binlog carries.** ClickHouse rejects an INSERT that names one, outright:

```
Code: 44. DB::Exception: Cannot insert column c, because it is MATERIALIZED column. (ILLEGAL_COLUMN)
```

_(verified on ClickHouse 24.8.14)_

Debezium puts generated columns in the row image, so the connector has to strip them from every INSERT to avoid failing the batch. Whatever MySQL actually computed is therefore discarded, and the replica keeps only what its own translated expression produced.

## Why this matters

It is invisible for as long as the two expressions agree — which is most of the time, and is why this has not bitten before. They can disagree when:

- a MySQL function has no exact ClickHouse equivalent, or the translation is approximate
- NULL or overflow semantics differ between the two engines
- the expression is session-dependent (collation, time zone, `sql_mode`)
- the generated column is **redefined on the source** and the replica DDL is not regenerated

In every one of those cases the divergence is silent: no error, no failed batch, identical row counts. Only a value-level checksum would ever surface it — which is the worst possible failure mode for a replication engine, where the source is meant to be authoritative.

There is also a smaller, always-present effect: MATERIALIZED columns are excluded from `SELECT *`, so a generated column translated this way is invisible to any client that does not name it explicitly.

## Fix

Emit **DEFAULT** instead. It keeps the behaviour that made MATERIALIZED look right, and drops the part that made it wrong:

| | MATERIALIZED | DEFAULT |
|---|---|---|
| column omitted from INSERT | expression evaluated | expression evaluated |
| column present in INSERT | **rejected** (Code: 44) | **value stored as sent** |
| included in `SELECT *` | no | yes |

Verified on 24.8.14 with `c Nullable(UInt8) DEFAULT bitAnd(toUInt64(ifNull(base,0)),toUInt64(1))!=0`:

```
INSERT INTO d (id, base)    VALUES (1,1),(2,0)     -> c = 1, 0   (computed)
INSERT INTO d (id, base, c) VALUES (3,0,1),(4,1,0) -> c = 1, 0   (as supplied)
```

So the snapshot path is unchanged — a client that omits the column still gets the derived value — while the replication path now carries MySQL's value through.

`Constants.ALIAS` is `@Deprecated` rather than removed, so any other caller keeps compiling; the emitter uses the new `Constants.GENERATED_COLUMN_KIND`.

## Tests

- Three existing expectations updated: `testGeneratedColumn`, `testPartitionByRange`, `isNotNullCreateTable`
- New `generatedColumnsAreDefaultNotMaterialized` covering `VIRTUAL`, `STORED`, and the bare `AS (...)` shorthand. It asserts on the **emitted DDL** rather than on a constant, so the property survives refactoring of the emitter.
- `MySqlDDLParserListenerImplTest`: **109 tests found, 108 successful, 1 skipped, 0 failures** on this branch.
- **Mutation-checked**: reverting the emitter to MATERIALIZED fails 4 of them, including the new one — so the suite genuinely detects the defect rather than passing vacuously.
- Built with JDK 17.

### A note on running these tests locally

`mvn test` in `sink-connector-lightweight` currently discovers **zero** tests on an unmodified `2.11.0` checkout as well:

```
java.lang.NoSuchMethodError: 'org.junit.platform.engine.EngineDiscoveryListener
  org.junit.platform.engine.EngineDiscoveryRequest.getDiscoveryListener()'
...
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

surefire 2.22.0 throws during JUnit-platform discovery, swallows it, and reports a green zero. That is pre-existing and independent of this change — reproduced on a clean `2.11.0` worktree with no modifications — but it does mean a green `mvn test` here proves nothing, so the counts above were obtained by driving the JUnit 5 platform launcher directly against the compiled test classes. Flagging it since #1439/#1440 just fixed the *other* reason this job ran no tests.

## Compatibility note

This changes the DDL generated for **newly auto-created** tables. Existing tables already created with MATERIALIZED generated columns are unaffected until they are recreated — the change is not retroactive, and no migration is performed. Operators who want existing tables to accept the source value can convert a column in place with `ALTER TABLE ... MODIFY COLUMN <col> REMOVE MATERIALIZED` followed by re-adding the DEFAULT, but that is deliberately out of scope here.

Worth flagging for review: if any deployment is intentionally relying on MATERIALIZED to make ClickHouse recompute rather than accept the source value, this would change that behaviour. Happy to put it behind a config flag instead if you would prefer that.
